### PR TITLE
fixed mfx_dispatch compilation with gcc6/MinGW64

### DIFF
--- a/api/opensource/mfx_dispatch/include/mfx_dispatcher_defs.h
+++ b/api/opensource/mfx_dispatch/include/mfx_dispatcher_defs.h
@@ -63,7 +63,7 @@ inline std::wstring getWideString(const char * string)
 
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(_WIN32) && !defined(_WIN64)
 #define  sscanf_s  sscanf
 #define  swscanf_s swscanf
 #endif

--- a/api/opensource/mfx_dispatch/src/mfx_load_plugin.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_load_plugin.cpp
@@ -22,8 +22,8 @@
 #include "mfx_load_dll.h"
 #include "mfx_dispatcher_log.h"
 
-#define TRACE_PLUGIN_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[PLUGIN]: "str), __VA_ARGS__))
-#define TRACE_PLUGIN_INFO(str, ...) DISPATCHER_LOG_INFO((("[PLUGIN]: "str), __VA_ARGS__))
+#define TRACE_PLUGIN_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[PLUGIN]: " str), __VA_ARGS__))
+#define TRACE_PLUGIN_INFO(str, ...) DISPATCHER_LOG_INFO((("[PLUGIN]: " str), __VA_ARGS__))
 
 #define CREATE_PLUGIN_FNC "CreatePlugin"
 

--- a/api/opensource/mfx_dispatch/src/mfx_plugin_hive.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_plugin_hive.cpp
@@ -26,9 +26,9 @@
 #include "mfx_dispatcher_log.h"
 #include "mfx_load_dll.h"
 
-#define TRACE_HIVE_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[HIVE]: "str), __VA_ARGS__))
-#define TRACE_HIVE_INFO(str, ...) DISPATCHER_LOG_INFO((("[HIVE]: "str), __VA_ARGS__))
-#define TRACE_HIVE_WRN(str, ...) DISPATCHER_LOG_WRN((("[HIVE]: "str), __VA_ARGS__))
+#define TRACE_HIVE_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[HIVE]: " str), __VA_ARGS__))
+#define TRACE_HIVE_INFO(str, ...) DISPATCHER_LOG_INFO((("[HIVE]: " str), __VA_ARGS__))
+#define TRACE_HIVE_WRN(str, ...) DISPATCHER_LOG_WRN((("[HIVE]: " str), __VA_ARGS__))
 
 namespace 
 {

--- a/api/opensource/mfx_dispatch/src/mfx_win_reg_key.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_win_reg_key.cpp
@@ -23,7 +23,7 @@
 #include "mfx_win_reg_key.h"
 #include "mfx_dispatcher_log.h"
 
-#define TRACE_WINREG_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[WINREG]: "str), __VA_ARGS__))
+#define TRACE_WINREG_ERROR(str, ...) DISPATCHER_LOG_ERROR((("[WINREG]: " str), __VA_ARGS__))
 
 namespace MFX
 {


### PR DESCRIPTION
This small change allows compiling mfx.lib on Windows MINGW64 with gcc-6.3.