### PR TITLE
cmake: allow MFX_HOME to be optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ if( NOT DEFINED CMAKE_MFX_HOME )
   set( CMAKE_MFX_HOME "${CMAKE_HOME_DIRECTORY}/api" )
 endif()
 
+if( "$ENV{MFX_HOME}" STREQUAL "" )
+  set( ENV{MFX_HOME} ${CMAKE_HOME_DIRECTORY} )
+endif()
+
 option( ENABLE_OPENCL "Build targets dependent on OpenCL?" ON )
 if( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
   option( ENABLE_DRM "Build DRM versions of the targets?" ON )


### PR DESCRIPTION
Often, MFX_HOME will just point back to the source tree that
is being configured by cmake.

Thus, set MFX_HOME to CMAKE_HOME_DIRECTORY if user does not
set it.

Fixes #16

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>