### PR TITLE
cmake: using GNUInstallDirs for mfx libraries and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required( VERSION 2.6.2 )
+cmake_minimum_required( VERSION 2.8.5 )
 project( mediasdk )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/api/opensource/mfx_dispatch/CMakeLists.txt
+++ b/api/opensource/mfx_dispatch/CMakeLists.txt
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required( VERSION 2.6.2 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8.5 FATAL_ERROR )
 project( mfx )
 
 set( MFX_API_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/../../include )
@@ -51,6 +51,8 @@ else( )
   endif( )
   message( STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}" )
 
+  include( GNUInstallDirs )
+
   if( NOT DEFINED MFX_PLUGINS_DIR )
     set( MFX_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/plugins )
   endif( )
@@ -58,11 +60,7 @@ else( )
   message( STATUS "MFX_PLUGINS_DIR=${MFX_PLUGINS_DIR}" )
 
   if( NOT DEFINED MFX_MODULES_DIR )
-    if(__ARCH MATCHES intel64)
-        set( MFX_MODULES_DIR ${CMAKE_INSTALL_PREFIX}/lib64 )
-    else( )
-        set( MFX_MODULES_DIR ${CMAKE_INSTALL_PREFIX}/lib )
-    endif( )
+    set( MFX_MODULES_DIR ${CMAKE_INSTALL_FULL_LIBDIR} )
   endif( )
   add_definitions( -DMFX_MODULES_DIR="${MFX_MODULES_DIR}" )
   message( STATUS "MFX_MODULES_DIR=${MFX_MODULES_DIR}" )
@@ -151,14 +149,6 @@ endfunction( )
 set( defs "${WARNING_FLAGS}" )
 make_static_library( mfx )
 
-if(__ARCH MATCHES intel64)
-  install( TARGETS mfx ARCHIVE DESTINATION lib64 )
-else( )
-  install( TARGETS mfx ARCHIVE DESTINATION lib )
-endif( )
-
-install( DIRECTORY ${MFX_API_FOLDER}/ DESTINATION include FILES_MATCHING PATTERN *.h )
-
 set( defs "-DMFX_DISPATCHER_EXPOSED_PREFIX ${WARNING_FLAGS}" )
 make_static_library( dispatch_shared )
 
@@ -173,11 +163,6 @@ get_api_version(MFX_VERSION_MAJOR MFX_VERSION_MINOR)
 set( PKG_CONFIG_FNAME "${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.pc")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake" ${PKG_CONFIG_FNAME} @ONLY)
 
-if(__ARCH MATCHES intel64)
-  install( TARGETS mfx ARCHIVE DESTINATION lib/lin_x64 )
-  install( FILES ${PKG_CONFIG_FNAME} DESTINATION lib/lin_x64/pkgconfig )
-else( )
-  install( TARGETS mfx ARCHIVE DESTINATION lib/lin_x86 )
-  install( FILES ${PKG_CONFIG_FNAME} DESTINATION lib/lin_x86/pkgconfig )
-endif( )
-install( DIRECTORY ${MFX_API_FOLDER}/ DESTINATION include FILES_MATCHING PATTERN *.h )
+install( TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+install( FILES ${PKG_CONFIG_FNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+install( DIRECTORY ${MFX_API_FOLDER}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN *.h )

--- a/api/opensource/mfx_dispatch/pkg-config.pc.cmake
+++ b/api/opensource/mfx_dispatch/pkg-config.pc.cmake
@@ -3,7 +3,7 @@ Description: Intel(R) Media SDK Dispatcher
 Version: @MFX_VERSION_MAJOR@.@MFX_VERSION_MINOR@
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib/lin_x64
-includedir=@CMAKE_INSTALL_PREFIX@/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Libs: -L${libdir} -lmfx
 Cflags: -I${includedir}

--- a/builder/FindGlobals.cmake
+++ b/builder/FindGlobals.cmake
@@ -36,6 +36,8 @@ if( Linux OR Darwin )
     set( CMAKE_INSTALL_PREFIX /opt/intel/mediasdk CACHE PATH "Install Path Prefix" FORCE )
   endif()
 
+  include( GNUInstallDirs )
+
   add_definitions(-DUNIX)
 
   if( Linux )
@@ -133,18 +135,18 @@ elseif( Windows )
   endif()
 endif( )
 
-if(__ARCH MATCHES ia32)
-  set( MFX_MODULES_DIR ${CMAKE_INSTALL_PREFIX}/lib )
-  set( MFX_SAMPLES_INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/samples )
-  set( MFX_SAMPLES_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/samples )
-else()
-  set( MFX_MODULES_DIR ${CMAKE_INSTALL_PREFIX}/lib64 )
-  set( MFX_SAMPLES_INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/samples )
-  set( MFX_SAMPLES_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/samples )
-endif()
+set( MFX_SAMPLES_INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/samples )
+set( MFX_SAMPLES_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/samples )
+
+if( NOT DEFINED MFX_PLUGINS_DIR )
+  set( MFX_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/plugins )
+endif( )
+
+if( NOT DEFINED MFX_MODULES_DIR )
+  set( MFX_MODULES_DIR ${CMAKE_INSTALL_FULL_LIBDIR} )
+endif( )
 
 message( STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}" )
-set( MFX_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/plugins )
 
 # Some font definitions: colors, bold text, etc.
 if(NOT Windows)


### PR DESCRIPTION
Use GNUInstallDirs to determine standard location to
install libraries and include headers.  This also
enables developers to override them, too.  For example,

-DCMAKE_INSTALL_LIBDIR=lib/lin_x64 will install into
$CMAKE_INSTALL_PREFIX/lib/lin_x64 and so on.

Fixes #17

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>