### PR TITLE
mfx_plugin: make plugins path configurable on Linux

### DIFF
--- a/builder/FindGlobals.cmake
+++ b/builder/FindGlobals.cmake
@@ -146,6 +146,8 @@ endif()
 message( STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}" )
 set( MFX_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/plugins )
 
+add_definitions( -DMFX_PLUGINS_DIR=\"${MFX_PLUGINS_DIR}\" )
+
 # Some font definitions: colors, bold text, etc.
 if(NOT Windows)
   string(ASCII 27 Esc)


### PR DESCRIPTION
Allow plugins path can be configured by environment variable
"MFX_PLUGINS_PATH".
Default path is "/opt/intel/mediasdk/plugins/plugins.cfg"

Signed-off-by: Zhong Li <zhong.li@intel.com>