### PR TITLE
dispatch: use MFX_MODULES_DIR preprocessor definition

### DIFF
--- a/api/opensource/mfx_dispatch/include/mfx_library_iterator.h
+++ b/api/opensource/mfx_dispatch/include/mfx_library_iterator.h
@@ -69,7 +69,7 @@ enum
 enum
 {
     MFX_UNKNOWN_KEY     = -1,
-    MFX_STORAGE_ID_OPT  = 0, // storage is: /opt/intel
+    MFX_STORAGE_ID_OPT  = 0, // storage is: MFX_MODULES_DIR
     MFX_APP_FOLDER      = 1,
 
     MFX_STORAGE_ID_FIRST   =  MFX_STORAGE_ID_OPT,

--- a/api/opensource/mfx_dispatch/src/mfx_library_iterator_linux.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_library_iterator_linux.cpp
@@ -37,26 +37,20 @@
 #define MFX_PCI_DIR "/sys/bus/pci/devices"
 #define MFX_PCI_DISPLAY_CONTROLLER_CLASS 0x03
 
-static const char mfx_storage_opt[] = "/opt/intel";
-
 #ifndef __APPLE__
 #if defined(LINUX64)
-    static const char mfx_folder[] = "mediasdk/lib64";
     static const char mfx_so_hw_base_name[] = "libmfxhw64-p.so";
     static const char mfx_so_sw_base_name[] = "libmfxsw64-p.so";
 #else
-    static const char mfx_folder[] = "mediasdk/lib32";
     static const char mfx_so_hw_base_name[] = "libmfxhw32-p.so";
     static const char mfx_so_sw_base_name[] = "libmfxsw32-p.so";
 #endif
 
 #else
 #if defined(X86_64)
-static const char mfx_folder[] = "mediasdk/lib64";
 static const char mfx_so_hw_base_name[] = "libmfxhw64.dylib";
 static const char mfx_so_sw_base_name[] = "libmfxsw64.dylib";
 #else
-static const char mfx_folder[] = "mediasdk/lib32";
 static const char mfx_so_hw_base_name[] = "libmfxhw32.dylib";
 static const char mfx_so_sw_base_name[] = "libmfxsw32.dylib";
 #endif
@@ -326,7 +320,7 @@ mfxStatus MFXLibraryIterator::Init(eMfxImplType implType, mfxIMPL impl, const mf
     m_implType = implType;
 
     snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),
-             "%s/%s", mfx_storage_opt, mfx_folder);
+             "%s", MFX_MODULES_DIR);
 
     m_libs_num = mfx_list_libraries(m_path, (MFX_LIB_HARDWARE == implType), &m_libs);
     

--- a/builder/FindGlobals.cmake
+++ b/builder/FindGlobals.cmake
@@ -146,6 +146,8 @@ endif()
 message( STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}" )
 set( MFX_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/plugins )
 
+add_definitions( -DMFX_MODULES_DIR=\"${MFX_MODULES_DIR}\" )
+
 # Some font definitions: colors, bold text, etc.
 if(NOT Windows)
   string(ASCII 27 Esc)


### PR DESCRIPTION
On Linux, use the MFX_MODULES_DIR preprocessor definition to
determine the dispatch library locations.

Change-Id: Id148d2851e739bad4a46a5e7d1f9bd74f114014b
Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>