### PR TITLE
Add CFL and CNL support.

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_cm.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_cm.cpp
@@ -816,6 +816,7 @@ void CmContext::Setup(
     case MFX_HW_SCL:
     case MFX_HW_APL:
     case MFX_HW_KBL:
+    case MFX_HW_CFL:
         m_program = ReadProgram(m_device, genx_skl_simple_me, SizeOf(genx_skl_simple_me));
         m_programHist = ReadProgram(m_device, genx_skl_histogram, SizeOf(genx_skl_histogram));
         break;

--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -251,6 +251,25 @@ typedef struct {
     { 0x593B, MFX_HW_KBL}, // HALO GT4
     { 0x593D, MFX_HW_KBL}, // WRK GT4
 
+    /* CFL */
+    { 0x3E90, MFX_HW_CFL},
+    { 0x3E91, MFX_HW_CFL},
+    { 0x3E92, MFX_HW_CFL},
+    { 0x3E93, MFX_HW_CFL},
+    { 0x3E94, MFX_HW_CFL},
+    { 0x3E96, MFX_HW_CFL},
+    { 0x3E9B, MFX_HW_CFL},
+
+    /* CNL */
+    { 0x5A51, MFX_HW_CNL }, 
+    { 0x5A52, MFX_HW_CNL }, 
+    { 0x5A5A, MFX_HW_CNL }, 
+    { 0x5A42, MFX_HW_CNL }, 
+    { 0x5A4A, MFX_HW_CNL }, 
+    { 0x5A59, MFX_HW_CNL }, 
+    { 0x5A41, MFX_HW_CNL }, 
+    { 0x5A49, MFX_HW_CNL },
+
 };
 
 /* END: IOCTLs definitions */


### PR DESCRIPTION
Adding CFL and CNL into MSDK whitelist as exposed by Media Driver.

Signed-off-by: Raynald Lim <raynald.lim@intel.com>