### PR TITLE
libmfxhw64: add -ldl to linker flags

### DIFF
--- a/builder/FindPackages.cmake
+++ b/builder/FindPackages.cmake
@@ -82,7 +82,7 @@ function( configure_build_variant_linux target variant )
   if( NOT Linux )
     return() # should not occur; just in case
   endif()
-  set( link_flags_list "-Wl,--no-undefined,-z,relro,-z,now,-z,noexecstack")
+  set( link_flags_list "-Wl,--no-undefined,-z,relro,-z,now,-z,noexecstack -Wl,--no-as-needed -ldl")
   append_property( ${ARGV0} LINK_FLAGS "${link_flags_list} ${MFX_LDFLAGS} -fstack-protector" )
 #  message( STATUS "Libva located at: ${PKG_LIBVA_LIBRARY_DIRS}" )
 


### PR DESCRIPTION
Add "-Wl,--no-as-needed -ldl" to linker flags.

On Ubuntu Trusty 14.04 LTS with GCC 4.8.4, fix linker
error in vm_shared_object_linux32.c.o for libmfxhw64.so:
```
  undefined reference to `dlopen'
  undefined reference to `dlsym'
  undefined reference to `dlclose'
```

Fixes #34
  