### PR TITLE
fix HEVC FEI repack quality mode

### DIFF
--- a/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
+++ b/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2017, Intel Corporation
+Copyright (c) 2017-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -69,6 +69,7 @@ struct sInputParams
     bool bEncodedOrder;        // use EncodeOrderControl for external reordering
     bool bFormattedMVout;      // use internal format for dumping MVP
     bool bFormattedMVPin;      // use internal format for reading MVP
+    bool bQualityRepack;       // use quality mode in MV repack
     mfxU8  QP;
     mfxU16 dstWidth;           // destination picture width
     mfxU16 dstHeight;          // destination picture height
@@ -98,6 +99,7 @@ struct sInputParams
         , bEncodedOrder(false)
         , bFormattedMVout(false)
         , bFormattedMVPin(false)
+        , bQualityRepack(false)
         , QP(26)
         , dstWidth(0)
         , dstHeight(0)

--- a/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
+++ b/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2017, Intel Corporation
+Copyright (c) 2017-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -353,7 +353,7 @@ mfxStatus PredictorsRepaking::RepackPredictorsQuality(const HevcTask& eTask, mfx
                 }
             }
 
-            // sort predcitors by ascending distortion
+            // sort predictors by ascending distortion
             if (numPredPairs < 2) // nothing to sort
             {
                 mvp.Data[permutEncIdx].MV[0][0] = mv[0][0];
@@ -363,12 +363,12 @@ mfxStatus PredictorsRepaking::RepackPredictorsQuality(const HevcTask& eTask, mfx
                 continue;
             }
 
-            // smaller idx to be first argument to be preffered if equal
+            // smaller idx to be first argument to be preferred if equal
             #define CMP_DIST(k,l) {                               \
                 mfxU8 res0 = distortion[k][0] > distortion[l][0]; \
                 mfxU8 res1 = distortion[k][1] > distortion[l][1]; \
-                worse[k][0] += res0; worse[k][0] += res0 ^ 1;     \
-                worse[k][1] += res1; worse[k][1] += res1 ^ 1;     \
+                worse[k][0] += res0; worse[l][0] += res0 ^ 1;     \
+                worse[k][1] += res1; worse[l][1] += res1 ^ 1;     \
             }
 
             // fill unused
@@ -395,11 +395,8 @@ mfxStatus PredictorsRepaking::RepackPredictorsQuality(const HevcTask& eTask, mfx
         }
     }
 
-    if (nMvPredictors[0] == 0 || nMvPredictors[1] == 0)
-    {
-        MSDK_TRACE_ERROR("Not implemented! The repacker didn't set number of MPVs");
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
-    }
+    nMvPredictors[0] = numFinalL0Predictors;
+    nMvPredictors[1] = numFinalL1Predictors;
 
     return MFX_ERR_NONE;
 }

--- a/samples/sample_hevc_fei/src/hevc_fei_preenc.cpp
+++ b/samples/sample_hevc_fei/src/hevc_fei_preenc.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2017, Intel Corporation
+Copyright (c) 2017-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -112,6 +112,7 @@ FEI_Preenc::FEI_Preenc(MFXVideoSession* session, MfxVideoParamsWrapper& preenc_p
     if (0 != msdk_strlen(mbstatoutFile))
     {
         m_pFile_MBstat_out.reset(new FileHandler(mbstatoutFile, MSDK_STRING("wb")));
+        m_defFrameCtrl.DisableStatisticsOutput = 0;
     }
 
     /* Default value for I-frames */
@@ -353,8 +354,7 @@ mfxStatus FEI_Preenc::PreEncOneFrame(HevcTask & task, const RefIdxPair& dpbRefId
 
     // disable MV output for I frames / if no reference frames provided
     ctrl->DisableMVOutput = (task.m_frameType & MFX_FRAMETYPE_I) || (IDX_INVALID == dpbRefIdxPair.RefL0 && IDX_INVALID == dpbRefIdxPair.RefL1);
-    // enable only if mbstat dump is required
-    ctrl->DisableStatisticsOutput = m_pFile_MBstat_out.get() ? 0 : 1;
+    // Note: ctrl->DisableStatisticsOutput is set on init and shouldn't change
 
     mfxENCOutputWrap & out = m_syncp.second.second;
 

--- a/samples/sample_hevc_fei/src/pipeline_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/pipeline_hevc_fei.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2017, Intel Corporation
+Copyright (c) 2017-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -565,7 +565,7 @@ FEI_Encode* CEncodingPipeline::CreateEncode(mfxFrameInfo& in_fi)
         sts = pRepacker->Init(pars, m_inParams.preencDSfactor, m_inParams.encodeCtrl.NumMvPredictors);
         CHECK_STS_AND_RETURN(sts, "CreateEncode::pRepacker->Init failed", NULL);
 
-        pRepacker->SetPerfomanceRepackingMode();
+        m_inParams.bQualityRepack ? pRepacker->SetQualityRepackingMode() : pRepacker->SetPerfomanceRepackingMode();
     }
 
     mfxHDL hdl = NULL;

--- a/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2017, Intel Corporation
+Copyright (c) 2017-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -103,6 +103,7 @@ void PrintHelp(const msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-mvpin::format <file-name>] - use this to input MVs for ENCODE before repacking in internal format\n"));
     msdk_printf(MSDK_STRING("                                   (Encoded Order will be enabled automatically).\n"));
 
+    msdk_printf(MSDK_STRING("   [-qrep] - quality predictor MV repacking before encode\n"));
     msdk_printf(MSDK_STRING("   [-SearchWindow value] - specifies one of the predefined search path and window size. In range [1,8] (5 is default).\n"));
     msdk_printf(MSDK_STRING("                           If zero value specified: -RefWidth / RefHeight, -LenSP are required\n"));
     msdk_printf(MSDK_STRING("   [-RefWidth width] - width of search region (should be multiple of 4), maximum allowed search window is 64x32 for\n"));
@@ -274,6 +275,11 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU32 nArgNum, sInputParams& 
         {
             CHECK_NEXT_VAL(i + 1 >= nArgNum, strInput[i], strInput[0]);
             PARSE_CHECK(msdk_opt_read(strInput[++i], params.mbstatoutFile), "MB stat out File", isParseInvalid);
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-qrep")))
+        {
+            params.bQualityRepack = true;                  // to enable quality mode in repack
+            params.preencCtrl.DisableStatisticsOutput = 0; // to gather statistics in preenc, needed for quality repack
         }
         else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-ppyr:on")))
         {


### PR DESCRIPTION
Add CL parameter to enable quality mode in repack.
Fixed repacking method.
DisableStatisticsOutput is set only once on init.

Issue: MDP-38601