### PR TITLE
samples: use WARNING_FLAGS definition

### DIFF
--- a/samples/sample_hevc_fei/CMakeLists.txt
+++ b/samples/sample_hevc_fei/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories (
 list( APPEND LIBS_VARIANT sample_common )
 
 set(DEPENDENCIES ${skipping} itt libmfx dl pthread)
-set( defs "-Werror" )
+set( defs "${WARNING_FLAGS}" )
 make_executable( shortname universal "nosafestring" )
 
 install( TARGETS ${target} RUNTIME DESTINATION ${MFX_SAMPLES_INSTALL_BIN_DIR} )


### PR DESCRIPTION
Don't hard-code -Werror into compiler flags.  Instead, use
the configured value from WARNING_FLAGS.  This allows
the user to disable -Werror if needed.
    
Currently, on some compiler versions there are still
some warnings being generated in samples/hevc_fei. So
remove hard-coded -Werror and use WARNING_FLAGS instead.
    
Fixes #48