### PR TITLE
Package config fixes

### DIFF
--- a/api/opensource/mfx_dispatch/CMakeLists.txt
+++ b/api/opensource/mfx_dispatch/CMakeLists.txt
@@ -160,9 +160,15 @@ set( defs "-DMFX_DISPATCHER_LOG -DDXVA2DEVICE_LOG ${WARNING_FLAGS}" )
 make_static_library( dispatch_trace )
 
 get_api_version(MFX_VERSION_MAJOR MFX_VERSION_MINOR)
-set( PKG_CONFIG_FNAME "${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.pc")
+set( PKG_CONFIG_FNAME "${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.pc")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake" ${PKG_CONFIG_FNAME} @ONLY)
 
 install( TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 install( FILES ${PKG_CONFIG_FNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 install( DIRECTORY ${MFX_API_FOLDER}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN *.h )
+
+# For backwards compatibility, create a relative symbolic link without the "lib"
+# prefix to the .pc file.
+set( PKG_CONFIG_LFNAME "${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.pc" )
+add_custom_target(pc_link_target ALL COMMAND ${CMAKE_COMMAND} -E create_symlink lib${PROJECT_NAME}.pc ${PKG_CONFIG_LFNAME})
+install( FILES ${PKG_CONFIG_LFNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )

--- a/api/opensource/mfx_dispatch/pkg-config.pc.cmake
+++ b/api/opensource/mfx_dispatch/pkg-config.pc.cmake
@@ -5,5 +5,5 @@ Version: @MFX_VERSION_MAJOR@.@MFX_VERSION_MINOR@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
-Libs: -L${libdir} -lmfx
+Libs: -L${libdir} -lmfx -lstdc++ -ldl
 Cflags: -I${includedir}


### PR DESCRIPTION
Add additional required libraries needed to link to libmfx and rename mfx.pc to libmfx.pc (with a backwards compatible symlink).