### PR TITLE
[h264e, h264e fei] Removed usage of VAEncPackedHeaderH264_SEI

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2017-2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2357,7 +2357,7 @@ mfxStatus VAAPIEncoder::Execute(
         // SEI
         if (sei.Size() > 0)
         {
-            packed_header_param_buffer.type = VAEncPackedHeaderH264_SEI;
+            packed_header_param_buffer.type = VAEncPackedHeaderRawData;
             packed_header_param_buffer.has_emulation_bytes = 1;
             packed_header_param_buffer.bit_length = sei.Size()*8;
 
@@ -2488,7 +2488,7 @@ mfxStatus VAAPIEncoder::Execute(
         // SEI
         if (sei.Size() > 0)
         {
-            packed_header_param_buffer.type = VAEncPackedHeaderH264_SEI;
+            packed_header_param_buffer.type = VAEncPackedHeaderRawData;
             packed_header_param_buffer.has_emulation_bytes = 1;
             packed_header_param_buffer.bit_length = sei.Size()*8;
 

--- a/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2017-2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2304,7 +2304,7 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
      //SEI
     if (sei.Size() > 0)
     {
-        packed_header_param_buffer.type                = VAEncPackedHeaderH264_SEI;
+        packed_header_param_buffer.type                = VAEncPackedHeaderRawData;
         packed_header_param_buffer.has_emulation_bytes = 1;
         packed_header_param_buffer.bit_length          = sei.Size() * 8;
 


### PR DESCRIPTION
VAEncPackedHeaderH264_SEI has been depricated so
we replace it with VAEncPackedHeaderRawData