### PR TITLE
[vpp] Fix issues in horizontal mirroring

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -1968,6 +1968,10 @@ mfxStatus  VideoVPPHW::Init(
             sts = m_pCmCopy->Initialize(m_pCore->GetHWType());
             MFX_CHECK_STS(sts);
         }
+        else
+        {
+            return MFX_ERR_DEVICE_FAILED;
+        }
     }
 
 

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
@@ -2178,6 +2178,11 @@ void ConvertCaps2ListDoUse(MfxHwVideoProcessing::mfxVppCaps& caps, std::vector<m
         list.push_back(MFX_EXTBUFF_VPP_ROTATION);
     }
 
+    if(caps.uMirroring)
+    {
+        list.push_back(MFX_EXTBUFF_VPP_MIRRORING);
+    }
+
     if(caps.uScaling)
     {
         list.push_back(MFX_EXTBUFF_VPP_SCALING);


### PR DESCRIPTION
Fixed a couple of issues:
1. Init returns skipped_filter warning
even if this is supported according to caps.
This is incorrect behaviour.
2. For case of unloaded cmrt libraries
horizontal mirroring is crashed with seg fault
because CmCopy device is not created.