### PR TITLE
[vpp] Enable low power mode scaling

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -313,19 +313,19 @@ mfxStatus VideoDECODEH264::Init(mfxVideoParam *par)
         (m_vPar.IOPattern & MFX_IOPATTERN_OUT_VIDEO_MEMORY) : (m_vPar.IOPattern & MFX_IOPATTERN_OUT_SYSTEM_MEMORY);
 
     mfxExtDecVideoProcessing * videoProcessing = (mfxExtDecVideoProcessing *)GetExtendedBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_DEC_VIDEO_PROCESSING);
-    /* There are following conditions for SFC post processing:
+    /* There are following conditions for post processing via HW fixed function engine:
      * (1): AVC
      * (2): Progressive only
-     * (3): Tested on APL platform only
+     * (3): Supported on APL platform and above
      * (4): Only video memory supported (so, OPAQ memory does not supported!)
      * */
     if (videoProcessing)
     {
         if ((MFX_PICSTRUCT_PROGRESSIVE == m_vPar.mfx.FrameInfo.PicStruct) &&
-            (MFX_HW_APL == m_core->GetHWType()) &&
+            (MFX_HW_APL <= m_core->GetHWType()) &&
             (m_vPar.IOPattern & MFX_IOPATTERN_OUT_VIDEO_MEMORY))
             useInternal = 1;
-        else /* SFC can't be used */
+        else /* fixed function engine is not available */
             return MFX_ERR_UNSUPPORTED;
     }
 

--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -770,15 +770,15 @@ VAAPIVideoCORE::CreateVideoAccelerator(
 
     params.m_protectedVA = param->Protected;
 
-    /* There are following conditions for SFC post processing:
+    /* There are following conditions for post processing via HW fixed function engine:
      * (1): AVC
      * (2): Progressive only
-     * (3): Tested on APL platform only
+     * (3): Supported on APL platform and above
      * (4): Only video memory supported (so, OPAQ memory does not supported!)
      * */
     if ( (GetExtBuffer(param->ExtParam, param->NumExtParam, MFX_EXTBUFF_DEC_VIDEO_PROCESSING)) &&
          (MFX_PICSTRUCT_PROGRESSIVE == param->mfx.FrameInfo.PicStruct) &&
-         (MFX_HW_APL == GetHWType()) &&
+         (MFX_HW_APL <= GetHWType()) &&
          (param->IOPattern & MFX_IOPATTERN_OUT_VIDEO_MEMORY))
     {
         params.m_needVideoProcessingVA = true;

--- a/samples/sample_vpp/src/sample_vpp_parser.cpp
+++ b/samples/sample_vpp/src/sample_vpp_parser.cpp
@@ -159,7 +159,12 @@ msdk_printf(MSDK_STRING("   [-deinterlace (type)] - enable deinterlace algorithm
 msdk_printf(MSDK_STRING("                         type is tff (default) or bff \n"));
 
 msdk_printf(MSDK_STRING("   [-rotate (angle)]   - enable rotation. Supported angles: 0, 90, 180, 270.\n"));
-msdk_printf(MSDK_STRING("   [-scaling_mode (mode)] - specify type of scaling to be used for resize.\n"));
+
+msdk_printf(MSDK_STRING("   [-scaling_mode (mode)] - specify type of scaling to be used for resize\n"));
+msdk_printf(MSDK_STRING("                            0 - default\n"));
+msdk_printf(MSDK_STRING("                            1 - low power mode\n"));
+msdk_printf(MSDK_STRING("                            2 - quality mode\n\n"));
+
 msdk_printf(MSDK_STRING("   [-denoise (level)]  - enable denoise algorithm. Level is optional \n"));
 msdk_printf(MSDK_STRING("                         range of  noise level is [0, 100]\n"));
 msdk_printf(MSDK_STRING("   [-detail  (level)]  - enable detail enhancement algorithm. Level is optional \n"));


### PR DESCRIPTION
Added run-time check for APL to use low
power scaling mode by default due to power
consumption consideration.
Document scaling mode in sample vpp.