### PR TITLE
[h264e][mfe] fix skip frame issue

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -2892,7 +2892,7 @@ mfxStatus VAAPIEncoder::Execute(
                 timeout = 0;
             }
         }*/
-        mfxStatus sts = m_mfe->Submit(m_vaContextEncode, (task.m_flushMfe? 0 : timeout));
+        mfxStatus sts = m_mfe->Submit(m_vaContextEncode, (task.m_flushMfe? 0 : timeout), skipFlag == NORMAL_MODE);
         if (sts != MFX_ERR_NONE)
             return sts;
     }

--- a/_studio/shared/include/mfx_mfe_adapter.h
+++ b/_studio/shared/include/mfx_mfe_adapter.h
@@ -86,7 +86,7 @@ public:
     mfxStatus Join(VAContextID ctx, bool doubleField);
     mfxStatus Disjoin(VAContextID ctx);
     mfxStatus Destroy();
-    mfxStatus Submit(VAContextID context, vm_tick timeToWait);//time passed in vm_tick, so milliseconds to be multiplied by vm_frequency/1000
+    mfxStatus Submit(VAContextID context, vm_tick timeToWait, bool skipFrame);//time passed in vm_tick, so milliseconds to be multiplied by vm_frequency/1000
 
     virtual void AddRef();
     virtual void Release();


### PR DESCRIPTION
Fixed performance/functional issue with SkipFrame & mfe
When nothing is sent to driver during skip frame
need to count stream as submitted without real submission
to not make other streams wait for it.

Issue: MDP-40197
Test: manual

Signed-off-by: Artem Shaporenko <artem.shaporenko@intel.com>