### PR TITLE
[AVC FEI PreENC] remove QueryIOSurf for PreENC.

### DIFF
--- a/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.cpp
+++ b/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.cpp
@@ -702,13 +702,6 @@ mfxStatus VideoENC_PREENC::Query(VideoCORE* core, mfxVideoParam *in, mfxVideoPar
     return checkSts;
 } // mfxStatus VideoENC_PREENC::Query(VideoCORE*, mfxVideoParam *in, mfxVideoParam *out)
 
-mfxStatus VideoENC_PREENC::QueryIOSurf(VideoCORE* , mfxVideoParam *par, mfxFrameAllocRequest *request)
-{
-    MFX_CHECK_NULL_PTR2(par,request);
-    return MFX_ERR_NONE;
-} // mfxStatus VideoENC_PREENC::QueryIOSurf(VideoCORE* , mfxVideoParam *par, mfxFrameAllocRequest *request)
-
-
 VideoENC_PREENC::VideoENC_PREENC(VideoCORE *core,  mfxStatus * sts)
     : m_bInit( false )
     , m_core( core )

--- a/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.h
+++ b/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.h
@@ -54,7 +54,6 @@ public:
     mfxStatus QueryStatus(MfxHwH264Encode::DdiTask& task);
 
     static mfxStatus Query(VideoCORE*, mfxVideoParam *in, mfxVideoParam *out);
-    static mfxStatus QueryIOSurf(VideoCORE*, mfxVideoParam *par, mfxFrameAllocRequest *request);
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
 

--- a/samples/sample_fei/include/fei_preenc.h
+++ b/samples/sample_fei/include/fei_preenc.h
@@ -72,7 +72,7 @@ public:
     mfxStatus Init();
     mfxStatus Close();
     mfxStatus Reset(mfxU16 width = 0, mfxU16 height = 0, mfxU16 crop_w = 0, mfxU16 crop_h = 0);
-    mfxStatus QueryIOSurf(mfxFrameAllocRequest* preenc_request, mfxFrameAllocRequest ds_request[2] = NULL);
+    mfxStatus QueryIOSurf(mfxFrameAllocRequest ds_request[2]);
     mfxVideoParam* GetCommonVideoParams();
     mfxStatus UpdateVideoParam();
 

--- a/samples/sample_fei/src/fei_preenc.cpp
+++ b/samples/sample_fei/src/fei_preenc.cpp
@@ -155,27 +155,12 @@ mfxStatus FEI_PreencInterface::Reset(mfxU16 width, mfxU16 height, mfxU16 crop_w,
     return m_pmfxPREENC->Reset(&m_videoParams);
 }
 
-mfxStatus FEI_PreencInterface::QueryIOSurf(mfxFrameAllocRequest* preenc_request, mfxFrameAllocRequest ds_request[2])
+mfxStatus FEI_PreencInterface::QueryIOSurf(mfxFrameAllocRequest ds_request[2])
 {
-    mfxStatus sts = MFX_ERR_NULL_PTR;
+    MSDK_CHECK_POINTER(ds_request, MFX_ERR_NULL_PTR);
+    MSDK_CHECK_POINTER(m_pmfxDS,   MFX_ERR_NOT_INITIALIZED);
 
-    if (ds_request)
-    {
-        if (m_pmfxDS)
-        {
-            sts = m_pmfxDS->QueryIOSurf(&m_DSParams, ds_request);
-            MSDK_CHECK_STATUS(sts, "FEI PreENC DS: QueryIOSurf failed");
-        }
-        else
-            return MFX_ERR_NOT_INITIALIZED;
-    }
-
-    if (preenc_request)
-    {
-        m_pmfxPREENC->QueryIOSurf(&m_videoParams, preenc_request);
-    }
-
-    return sts;
+    return m_pmfxDS->QueryIOSurf(&m_DSParams, ds_request);
 }
 
 /* This function return video params that applicable to the subsequent interfaces.

--- a/samples/sample_fei/src/pipeline_fei.cpp
+++ b/samples/sample_fei/src/pipeline_fei.cpp
@@ -450,7 +450,7 @@ mfxStatus CEncodingPipeline::AllocFrames()
         MSDK_ZERO_MEMORY(DSRequest[0]);
         MSDK_ZERO_MEMORY(DSRequest[1]);
 
-        sts = m_pFEI_PreENC->QueryIOSurf(NULL, DSRequest);
+        sts = m_pFEI_PreENC->QueryIOSurf(DSRequest);
         MSDK_CHECK_STATUS(sts, "m_pmfxDS->QueryIOSurf failed");
 
         // these surfaces are input surfaces for PREENC


### PR DESCRIPTION
There is no sense of QueryIOSurf() for PreENC for current PreENC implementation, so 1) remove the declaration and implementation of this API from PreENC. 2) remove the call in sample_fei.