### PR TITLE
[sample_hevc_fei] Fix MVP block size setting for PREENC use cases

### DIFF
--- a/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
+++ b/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
@@ -149,7 +149,7 @@ mfxStatus PredictorsRepaking::RepackPredictorsPerformance(const HevcTask& eTask,
             // 0 - MV predictor is disabled
             // 1 - enabled per 16x16 block
             // 2 - enabled per 32x32 block (used only first 16x16 block data)
-            mvp.Data[permutEncIdx].BlockSize = 2;
+            mvp.Data[permutEncIdx].BlockSize = 1; // Using finest granularity
 
             for (mfxU32 j = 0; j < numPredPairs; ++j)
             {
@@ -287,7 +287,7 @@ mfxStatus PredictorsRepaking::RepackPredictorsQuality(const HevcTask& eTask, mfx
             // 0 - MV predictor disabled
             // 1 - enabled per 16x16 block
             // 2 - enabled per 32x32 block (used only first 16x16 block data)
-            mvp.Data[permutEncIdx].BlockSize = 2;
+            mvp.Data[permutEncIdx].BlockSize = 1; // Using finest granularity
             for (mfxU32 j = 0; j < numPredPairs; ++j)
             {
                 ref[j][0] = refIdx_vec[j]->RefL0;

--- a/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
@@ -634,9 +634,9 @@ void AdjustOptions(sInputParams& params)
 
     if (params.encodeCtrl.MVPredictor == 0 && (params.bPREENC || 0 != msdk_strlen(params.mvpInFile)))
     {
-        msdk_printf(MSDK_STRING("WARNING: MV predictor block size is invalid. Adjust to 2 for PreENC (7 for -mvpin)\n"));
+        msdk_printf(MSDK_STRING("WARNING: MV predictor block size is invalid or unspecified. Adjust to 1 for PreENC (7 for -mvpin)\n"));
         if (params.bPREENC)
-            params.encodeCtrl.MVPredictor = 2;
+            params.encodeCtrl.MVPredictor = 1;
         if (0 != msdk_strlen(params.mvpInFile))
             params.encodeCtrl.MVPredictor = 7;
     }


### PR DESCRIPTION
Now if PREENC is being used without external MVP input file and
-MVPBlockSize is not specified, the MVPredictor FEI option will be set
to 1 (16x16 MVP block layout)