### PR TITLE
[HEVCe FEI] Add extern RefListCtrl from file

### DIFF
--- a/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -1580,9 +1580,10 @@ void MfxVideoParam::SyncMfxToHeadersParam(mfxU32 numSlicesForSTRPSOpt)
     }
 
     m_sps.vui.field_seq_flag = isField();
-    if (IsOn(m_ext.CO.PicTimingSEI))
+    if (IsOn(m_ext.CO.PicTimingSEI) || m_sps.vui.field_seq_flag
+        || (m_vps.general.progressive_source_flag && m_vps.general.interlaced_source_flag))
     {
-        m_sps.vui.frame_field_info_present_flag = 1;
+        m_sps.vui.frame_field_info_present_flag = 1; // spec requirement for interlace
     }
 
     if (IsOn(m_ext.CO.VuiNalHrdParameters))

--- a/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
+++ b/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
@@ -63,6 +63,7 @@ struct sInputParams
     msdk_char  mbstatoutFile[MSDK_MAX_FILENAME_LEN];
     msdk_char  mvoutFile[MSDK_MAX_FILENAME_LEN];
     msdk_char  mvpInFile[MSDK_MAX_FILENAME_LEN];
+    msdk_char  refctrlInFile[MSDK_MAX_FILENAME_LEN];
 
     bool bENCODE;
     bool bPREENC;
@@ -126,6 +127,7 @@ struct sInputParams
         MSDK_ZERO_MEMORY(mbstatoutFile);
         MSDK_ZERO_MEMORY(mvoutFile);
         MSDK_ZERO_MEMORY(mvpInFile);
+        MSDK_ZERO_MEMORY(refctrlInFile);
 
         MSDK_ZERO_MEMORY(preencCtrl);
         preencCtrl.Header.BufferId = MFX_EXTBUFF_FEI_PREENC_CTRL;
@@ -489,7 +491,7 @@ typedef HevcDpbFrame HevcDpbArray[MAX_DPB_SIZE];
 struct HevcTask : HevcDpbFrame
 {
     mfxU16       m_frameType;
-    mfxU8        m_refPicList[2][MAX_DPB_SIZE];
+    mfxU8        m_refPicList[2][MAX_DPB_SIZE]; // index in dpb
     mfxU8        m_numRefActive[2]; // L0 and L1 lists
     mfxU8        m_shNUT;           // NALU type
     mfxI32       m_lastIPoc;

--- a/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
@@ -103,6 +103,8 @@ void PrintHelp(const msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-mvpin <file-name>]         - use this to input MV predictors for ENCODE (Encoded Order will be enabled automatically).\n"));
     msdk_printf(MSDK_STRING("   [-mvpin::format <file-name>] - use this to input MVs for ENCODE before repacking in internal format\n"));
     msdk_printf(MSDK_STRING("                                   (Encoded Order will be enabled automatically).\n"));
+    msdk_printf(MSDK_STRING("   [-active_ref_lists_par <file-name>] - par - file for reference lists + reordering. Each line :\n"));
+    msdk_printf(MSDK_STRING("                                         <POC> <FrameType> <PicStruct> | 8 <reference POC> in L0 list | then L1 | 16 DPB\n"));
 
     msdk_printf(MSDK_STRING("   [-qrep] - quality predictor MV repacking before encode\n"));
     msdk_printf(MSDK_STRING("   [-SearchWindow value] - specifies one of the predefined search path and window size. In range [1,5] (5 is default).\n"));
@@ -278,6 +280,12 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU32 nArgNum, sInputParams& 
         {
             CHECK_NEXT_VAL(i + 1 >= nArgNum, strInput[i], strInput[0]);
             PARSE_CHECK(msdk_opt_read(strInput[++i], params.mbstatoutFile), "MB stat out File", isParseInvalid);
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-active_ref_lists_par")))
+        {
+            CHECK_NEXT_VAL(i + 1 >= nArgNum, strInput[i], strInput[0]);
+            PARSE_CHECK(msdk_opt_read(strInput[++i], params.refctrlInFile), "RefList ctrl File", isParseInvalid);
+            params.bEncodedOrder = true;
         }
         else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-qrep")))
         {


### PR DESCRIPTION
New CL parameter -active_ref_lists_par <file> which contains
frame and ref.list info for each frame in stream
(file is generated by ASG).
EncodeOrderExtControl inherits EncodeOrderControl.
Commit also fix frame_field_infor_present_flag and
limits max_num_reorder.