### PR TITLE
Disallow base class deletion for derivates

### DIFF
--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
@@ -1534,6 +1534,8 @@ namespace CmLinux
 
         CM_RT_API virtual int32_t GetVISAVersion(uint32_t& majorVersion, uint32_t& minorVersion) = 0;
         //adding new functions in the bottom is a must
+protected: // do not allow  base deletion for derivates
+        ~CmDevice() {};
     };
 }
 #endif
@@ -1590,6 +1592,8 @@ public:
     CM_RT_API virtual INT FlushPrintBuffer() = 0;
     CM_RT_API virtual INT CreateSurface2DSubresource(AbstractSurfaceHandle pD3D11Texture2D, UINT subresourceCount, CmSurface2D** ppSurfaces, UINT& createdSurfaceCount, UINT option = 0) = 0;
     CM_RT_API virtual INT CreateSurface2DbySubresourceIndex(AbstractSurfaceHandle pD3D11Texture2D, UINT FirstArraySlice, UINT FirstMipSlice, CmSurface2D* &pSurface) = 0;
+protected: // do not allow  base deletion for derivates
+    ~CmDevice() {};
 };
 
 INT CreateCmDevice(CmDevice* &pD, UINT& version, VADisplay va_dpy = NULL, UINT mode = CM_DEVICE_CREATE_OPTION_DEFAULT);

--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
@@ -49,14 +49,6 @@
 #endif
 #endif
 
-#if defined(__clang__)
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#elif defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
-
 class SurfaceIndex
 {
 public:

--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmvm.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmvm.h
@@ -26,14 +26,6 @@
 #include <limits>
 #include <limits.h>
 
-#if defined(__clang__)
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#elif defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
-
 typedef unsigned int   uint;
 typedef unsigned short ushort;
 typedef unsigned char  uchar;

--- a/_studio/mfx_lib/cmrt_cross_platform/src/cmrt_cross_platform.cpp
+++ b/_studio/mfx_lib/cmrt_cross_platform/src/cmrt_cross_platform.cpp
@@ -53,14 +53,6 @@ const vm_char * DLL_NAME_LINUX = VM_STRING("igfxcmrt32.so");
 
 #define CONVERT_FORMAT(FORMAT) (FORMAT)
 
-#if defined(__clang__)
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#elif defined(__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
-
 enum { DX9=1, DX11=2, VAAPI=3 };
 
 typedef INT (* CreateCmDeviceLinuxFuncTypeEx)(CmLinux::CmDevice *&, UINT &, VADisplay, UINT);


### PR DESCRIPTION
To avoid 'non-virtual-dtor' warning and possible mistakes, do not allow the deletion of  "CmDevice" derivate instances from its base class.
If this feature is required, remove the 'protected' keyword and set the destructor virtual.