### PR TITLE
[HEVCe HW] Inherit GPB value during resets

### DIFF
--- a/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1046,6 +1046,7 @@ void InheritDefaultValues(
 
     InheritOption(extOpt3Init->IntRefCycleDist, extOpt3Reset->IntRefCycleDist);
     InheritOption(extOpt3Init->PRefType, extOpt3Reset->PRefType);
+    InheritOption(extOpt3Init->GPB, extOpt3Reset->GPB);
 
     InheritOption(extOpt3Init->WinBRCMaxAvgKbps, extOpt3Reset->WinBRCMaxAvgKbps);
     InheritOption(extOpt3Init->WinBRCSize, extOpt3Reset->WinBRCSize);


### PR DESCRIPTION
Now GPB won't fall back to the default "on" value if it is
left unspecified after encoder reset, but will instead
keep the pre-reset value.