### PR TITLE
[HEVC E] Field Bpyr Quality optimization

### DIFF
--- a/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -187,7 +187,7 @@ mfxU16 minRefForPyramid(mfxU16 GopRefDist, bool bField)
         refB -= x;
     }
 
-    return (bField ? 2:1)*(2 + refB);
+    return bField ? ((2 + refB)*2 +1) : (2 + refB);
 }
 
 mfxU32 GetMaxDpbSizeByLevel(MfxVideoParam const & par)


### PR DESCRIPTION
Issue: MDP-40457
Test: dev. test (quality test)

changes:
1) QP offsets were changed
2) first field is alway reference in B pyr
3) first field is always in RPL backward in B pyr

redesign:
1) native reordering (no last field class)
2) possibility to reorder fields in frame (switched off now).
3) possibility to avoid low high levels in b pyr.