### PR TITLE
Remove mediasdk target names difference between Debug and Release

### DIFF
--- a/_studio/hevce_hw/CMakeLists.txt
+++ b/_studio/hevce_hw/CMakeLists.txt
@@ -40,10 +40,6 @@ else()
   set( plugin_name mfx_hevce_hw32 )
 endif()
 
-if( CMAKE_BUILD_TYPE MATCHES Debug )
-  set( plugin_name ${plugin_name}_d )
-endif()
-
 set_file_and_product_version( ${hevc_version} version_defs )
 
 set( sources "" )

--- a/_studio/mfx_lib/CMakeLists.txt
+++ b/_studio/mfx_lib/CMakeLists.txt
@@ -161,9 +161,6 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 else()
   set( mfxlibname mfxhw32 )
 endif()
-if( CMAKE_BUILD_TYPE MATCHES Debug )
-  set( mfxlibname ${mfxlibname}_d )
-endif()
 
 set( LIBS "" )
 list( APPEND LIBS

--- a/_studio/mfx_lib/plugin/CMakeLists.txt
+++ b/_studio/mfx_lib/plugin/CMakeLists.txt
@@ -148,10 +148,6 @@ if( DEFINED HEVC_DECODER_HW_GUID )
     set( plugin_name mfx_hevcd_hw32 )
   endif()
 
-  if( CMAKE_BUILD_TYPE MATCHES Debug )
-    set( plugin_name ${plugin_name}_d )
-  endif()
-
   set_file_and_product_version( ${hevc_version} version_defs )
 
   list( APPEND sources ${plugin_common_sources} )
@@ -209,10 +205,6 @@ if( DEFINED H264LA_ENCODER_GUID )
     set( plugin_name mfx_h264la_hw64 )
   else()
     set( plugin_name mfx_h264la_hw32 )
-  endif()
-
-  if( CMAKE_BUILD_TYPE MATCHES Debug )
-    set( plugin_name ${plugin_name}_d )
   endif()
 
   set_file_and_product_version( ${h264la_version} version_defs )
@@ -310,9 +302,6 @@ if( DEFINED VP8_DECODER_HW_GUID )
   else()
     set( plugin_name mfx_vp8d_hw32 )
   endif()
-  if( CMAKE_BUILD_TYPE MATCHES Debug )
-    set( plugin_name ${plugin_name}_d )
-  endif()
 
   set_file_and_product_version( ${vp8_version} version_defs )
 
@@ -388,9 +377,6 @@ if( DEFINED VP9_DECODER_HW_GUID )
     set( plugin_name mfx_vp9d_hw64 )
   else()
     set( plugin_name mfx_vp9d_hw32 )
-  endif()
-  if( CMAKE_BUILD_TYPE MATCHES Debug )
-    set( plugin_name ${plugin_name}_d )
   endif()
 
   set_file_and_product_version( ${vp9_version} version_defs )

--- a/api/opensource/mfx_dispatch/src/mfx_load_dll_linux.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_load_dll_linux.cpp
@@ -23,8 +23,6 @@
 #include <dlfcn.h>
 #include <string.h>
 
-#if !defined(_DEBUG)
-
 #if defined(LINUX64)
 const msdk_disp_char * defaultDLLName[2] = {"libmfxhw64.so",
                                             "libmfxsw64.so"};
@@ -43,29 +41,7 @@ const msdk_disp_char * defaultAudioDLLName[2] = {"libmfxaudiosw32.so",
 
 const msdk_disp_char * defaultPluginDLLName[2] = {"libmfxplugin32_hw.so",
                                                   "libmfxplugin32_sw.so"};
-#endif // (defined(WIN64))
-
-#else // defined(_DEBUG)
-
-#if defined(LINUX64)
-const msdk_disp_char * defaultDLLName[2] = {"libmfxhw64_d.so",
-                                            "libmfxsw64_d.so"};
-const msdk_disp_char * defaultAudioDLLName[2] = {"libmfxaudiosw64_d.so",
-                                            "libmfxaudiosw64_d.so"};
-
-const msdk_disp_char * defaultPluginDLLName[2] = {"libmfxplugin64_hw_d.so",
-                                                  "libmfxplugin64_sw_d.so"};
-#else // for Linux32 and Android
-const msdk_disp_char * defaultDLLName[2] = {"libmfxhw32_d.so",
-                                            "libmfxsw32_d.so"};
-const msdk_disp_char * defaultAudioDLLName[2] = {"libmfxaudiosw32_d.so",
-                                            "libmfxaudiosw32_d.so"};
-
-const msdk_disp_char * defaultPluginDLLName[2] = {"libmfxplugin32_hw_d.so",
-                                                  "libmfxplugin32_sw_d.so"};
-#endif // (defined(WIN64))
-
-#endif // !defined(_DEBUG)
+#endif
 
 namespace MFX
 {

--- a/builder/FindPackages.cmake
+++ b/builder/FindPackages.cmake
@@ -151,11 +151,7 @@ function(configure_libmfx_target target)
 
   set(SCOPE_CFLAGS ${SCOPE_CFLAGS} PARENT_SCOPE)
   set(SCOPE_LINKFLAGS "${SCOPE_LINKFLAGS} -Wl,--default-symver" PARENT_SCOPE)
-  if (CMAKE_BUILD_TYPE STREQUAL debug)
-    set(SCOPE_LIBS ${SCOPE_LIBS} mfx PARENT_SCOPE)
-  else()
-    set(SCOPE_LIBS ${SCOPE_LIBS} mfx PARENT_SCOPE)
-  endif()
+  set(SCOPE_LIBS ${SCOPE_LIBS} mfx PARENT_SCOPE)
 endfunction()
 
 function(configure_itt_target target)


### PR DESCRIPTION
Different names for targets in Release and Debug modes just complicate
the things. Usually end user will either rewrite release binaries with
the debug ones or use separate installation folders.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>