### PR TITLE
[HEVC FEI SAMPLE] fix PictStruct for extern RefList control

### DIFF
--- a/samples/sample_hevc_fei/src/ref_list_manager.cpp
+++ b/samples/sample_hevc_fei/src/ref_list_manager.cpp
@@ -928,6 +928,12 @@ HevcTask* EncodeOrderExtControl::ReorderFrame(mfxFrameSurface1 * surface)
         free_task->m_idxRec = m_frameOrder & 0x7f; // Workaround to get unique idx and != IDX_INVALID (0xff)
         free_task->m_bottomField = ((*fi).picStruct == MFX_PICSTRUCT_FIELD_BOTTOM);
 
+        if (surface)
+        {
+            surface->Info.PicStruct = (*fi).picStruct;
+            surface->Data.FrameOrder = m_frameOrder;
+        }
+
         m_frameOrder ++;
     }
 


### PR DESCRIPTION
Set external picture structure value to mfxSurface structure,
otherwise input fields are named in tff order.