### PR TITLE
[H264e HW] CFL Support, fix ASCVidSample init, MFX_VERSION >= 1026

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -1268,7 +1268,7 @@ namespace MfxHwH264Encode
         par.EncodedOrder = task->m_encOrder;
         par.PyramidLayer = (mfxU16)task->m_loc.level;
         par.NumRecode = (mfxU16)task->m_repack;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1026)
         par.FrameCmplx   = task->m_frcmplx;
         par.LongTerm     = (task->m_longTermFrameIdx != NO_INDEX_U8) ? 1 : 0;
         par.SceneChange  = (mfxU16) task->m_SceneChange;

--- a/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
@@ -896,7 +896,7 @@ mfxI32 ExtBRC::GetPicQP(mfxI32 pqp, mfxU32 type, mfxI32 layer, mfxU16 isRef)
 
 mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctrl, mfxBRCFrameStatus* status)
 {
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1026)
     mfxU16 ParSceneChange = frame_par->SceneChange;
     mfxU32 ParFrameCmplx = frame_par->FrameCmplx;
 #else
@@ -1369,7 +1369,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
 {
     MFX_CHECK_NULL_PTR2(par, ctrl);
     MFX_CHECK(m_bInit, MFX_ERR_NOT_INITIALIZED);
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1026)
     mfxU16 ParSceneChange = par->SceneChange;
     mfxU16 ParLongTerm = par->LongTerm;
     mfxU32 ParFrameCmplx = par->FrameCmplx;

--- a/_studio/shared/asc/src/asc.cpp
+++ b/_studio/shared/asc/src/asc.cpp
@@ -284,6 +284,8 @@ mfxStatus ASC::InitGPUsurf(CmDevice* pCmDevice) {
         break;
     case PLATFORM_INTEL_SKL:
     case PLATFORM_INTEL_KBL:
+    case PLATFORM_INTEL_CFL:
+    case PLATFORM_INTEL_GLK:
         res = m_device->LoadProgram((void *)genx_scd_skl, sizeof(genx_scd_skl), m_program, "nojitter");
         break;
     case PLATFORM_INTEL_BXT:
@@ -685,6 +687,8 @@ ASC_API mfxStatus ASC::Init(mfxI32 Width, mfxI32 Height, mfxI32 Pitch, mfxU32 Pi
     {
         m_dataIn->layer = new ASCImDetails;
         m_videoData = new ASCVidSample *[ASCVIDEOSTATSBUF];
+        for(mfxU8 i =0; i < ASCVIDEOSTATSBUF; i++)
+            m_videoData[i] = nullptr;
         m_support = new ASCVidRead;
     }
     catch (...)


### PR DESCRIPTION
Added support for CFL in ASC::InitGPUsurf(), it was causing
mfx_err_device_failed when ran on a CFL platform.
Correct initialization of ASCVidSample in ASC::Init, which in case
of failure during initialization of GPU surfaces in InitGPUsurf()
will make Init to exit without initializing m_videoData array,
which then cause the system to crash at ASC::Close() because it
will identify m_videoData array to hold info (not NULL) and then
try to deallocate unallocated memory.
BRC LTR code now Wrapped in MFX_VERSION >= 1026, replaces
(MFX_VERSION >= MFX_VERSION_NEXT)

Issue: MDP-41086, MDP-40692
Test: h264e_extbrc_adaptive_ltr