### PR TITLE
Fixes for compilation warnings on gcc 7.3

### DIFF
--- a/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
+++ b/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
@@ -287,7 +287,7 @@ mfxStatus MFXVideoDECODEVC1::Init(mfxVideoParam *par)
 
     ConvertMfxToCodecParams(&m_par);
     m_VideoParams->lpMemoryAllocator = &m_MemoryAllocator;
-    if (par->mfx.FrameInfo.Width*par->mfx.FrameInfo.Height)
+    if (par->mfx.FrameInfo.Width && par->mfx.FrameInfo.Height)
     {
         m_BufSize = par->mfx.FrameInfo.Width*par->mfx.FrameInfo.Height*2;
         // Set surface number for decoding. HW requires
@@ -757,7 +757,7 @@ mfxStatus MFXVideoDECODEVC1::SelfConstructFrame(mfxBitstream *bs)
     mfxStatus MFXSts = MFX_ERR_NONE;
     Status IntUMCStatus = UMC_OK;
 
-    if (!(m_par.mfx.FrameInfo.Width*m_par.mfx.FrameInfo.Height))
+    if (0 == (m_par.mfx.FrameInfo.Width*m_par.mfx.FrameInfo.Height))
     {
         MFXSts = MFXVC1DecCommon::ParseSeqHeader(bs, &m_par, 0, 0);
         MFX_CHECK_STS(MFXSts);
@@ -994,7 +994,7 @@ mfxStatus MFXVideoDECODEVC1::SelfDecodeFrame(mfxFrameSurface1 *surface_work, mfx
              (IntUMCStatus == UMC::UMC_ERR_NOT_ENOUGH_DATA))
     {
         // Updated parameters with weq header data
-        if (! (m_par.mfx.FrameInfo.FrameRateExtD * m_par.mfx.FrameInfo.FrameRateExtN))
+        if (0 == (m_par.mfx.FrameInfo.FrameRateExtD * m_par.mfx.FrameInfo.FrameRateExtN))
         {
             // new frame rate parameters
             mfxU32 frCode;

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -2302,7 +2302,7 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
             task->m_vmeData = FindUnusedVmeData(m_vmeDataStorage);
             if ((!task->m_cmRawLa && extOpt2->LookAheadDS > MFX_LOOKAHEAD_DS_OFF) || !task->m_cmMb || !task->m_cmCurbe || !task->m_vmeData)
                 return Error(MFX_ERR_UNDEFINED_BEHAVIOR);
-                task->m_cmRaw = CreateSurface(m_cmDevice, task->m_handleRaw, m_currentVaType);
+            task->m_cmRaw = CreateSurface(m_cmDevice, task->m_handleRaw, m_currentVaType);
         }
 
         if (IsOn(extOpt3.FadeDetection) && m_cmCtx.get() && m_cmCtx->isHistogramSupported())

--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
@@ -431,7 +431,6 @@ mfxStatus MFXVideoENCODEMJPEG_HW::Query(VideoCORE * core, mfxVideoParam *in, mfx
             isInvalid ++;
         } else
             out->mfx.FrameInfo.CropY = in->mfx.FrameInfo.CropY;
-            out->mfx.FrameInfo.CropY = in->mfx.FrameInfo.CropY;
 
         out->mfx.FrameInfo.AspectRatioW = in->mfx.FrameInfo.AspectRatioW;
         out->mfx.FrameInfo.AspectRatioH = in->mfx.FrameInfo.AspectRatioH;

--- a/_studio/mfx_lib/fei/h264_common/fei_common.cpp
+++ b/_studio/mfx_lib/fei/h264_common/fei_common.cpp
@@ -885,7 +885,7 @@ mfxStatus MfxH264FEIcommon::CheckRuntimeExtBuffers(T* input, U* output, const Mf
 
             if (!I_SLICE(extFeiSliceInRintime->Slice[i].SliceType))
             {
-                MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL0Active      <= is_progressive ? 16 : 32,
+                MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL0Active      <= (is_progressive ? 16 : 32),
                                                                                         MFX_ERR_INVALID_VIDEO_PARAM);
                 MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL0Active,             MFX_ERR_INVALID_VIDEO_PARAM);
 
@@ -895,7 +895,7 @@ mfxStatus MfxH264FEIcommon::CheckRuntimeExtBuffers(T* input, U* output, const Mf
 
             if (B_SLICE(extFeiSliceInRintime->Slice[i].SliceType))
             {
-                MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL1Active      <= is_progressive ? 16 : 32,
+                MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL1Active      <= (is_progressive ? 16 : 32),
                                                                                         MFX_ERR_INVALID_VIDEO_PARAM);
                 MFX_CHECK(extFeiSliceInRintime->Slice[i].NumRefIdxL1Active,             MFX_ERR_INVALID_VIDEO_PARAM);
 

--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -176,7 +176,7 @@ mfxStatus CheckFrameInfoCodecs(mfxFrameInfo  *info, mfxU32 codecId, bool isHW)
     case MFX_CODEC_VP8:
         if (info->FourCC != MFX_FOURCC_NV12 && info->FourCC != MFX_FOURCC_YV12)
             return MFX_ERR_INVALID_VIDEO_PARAM;
-            break;
+        break;
     case MFX_CODEC_VP9:
         if (info->FourCC != MFX_FOURCC_NV12 &&
             info->FourCC != MFX_FOURCC_AYUV &&

--- a/_studio/mfx_lib/shared/src/mfx_enc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_enc_common.cpp
@@ -57,7 +57,7 @@ uint16_t CalculateUMCGOPLength (mfxU16 GOPSize, mfxU8 targetUsage)
         case MFX_TARGETUSAGE_BEST_SPEED:
             return 1;
         }
-        return 1;
+    return 1;
 }
 bool SetUFParameters(mfxU8 TargetUsages, bool& mixed,uint32_t& twoRef )
 {

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -978,7 +978,7 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
             }
         }
 
-        if ( !(out->vpp.In.FrameRateExtN * out->vpp.In.FrameRateExtD) &&
+        if ((0 == (out->vpp.In.FrameRateExtN * out->vpp.In.FrameRateExtD)) &&
             (out->vpp.In.FrameRateExtN + out->vpp.In.FrameRateExtD) )
         {
             out->vpp.In.FrameRateExtN = 0;
@@ -1031,7 +1031,7 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
             }
         }
 
-        if ( !(out->vpp.Out.FrameRateExtN * out->vpp.Out.FrameRateExtD) &&
+        if ((0 == (out->vpp.Out.FrameRateExtN * out->vpp.Out.FrameRateExtD)) &&
             (out->vpp.Out.FrameRateExtN + out->vpp.Out.FrameRateExtD))
         {
             out->vpp.Out.FrameRateExtN = 0;

--- a/_studio/shared/src/cm_mem_copy.cpp
+++ b/_studio/shared/src/cm_mem_copy.cpp
@@ -2107,24 +2107,24 @@ mfxStatus CmCopyWrapper::InitializeSwapKernels(eMFXHWType hwtype)
     if (!m_pCmDevice)
         return MFX_ERR_DEVICE_FAILED;
 
-        switch (hwtype)
-        {
+    switch (hwtype)
+    {
 #if !(defined(AS_VPP_PLUGIN) || defined(UNIFIED_PLUGIN) || defined(AS_H264LA_PLUGIN))
-        case MFX_HW_BDW:
-        case MFX_HW_CHT:
-            cmSts = m_pCmDevice->LoadProgram((void*)cht_copy_kernel_genx,sizeof(cht_copy_kernel_genx),m_pCmProgram,"nojitter");
-            break;
+    case MFX_HW_BDW:
+    case MFX_HW_CHT:
+        cmSts = m_pCmDevice->LoadProgram((void*)cht_copy_kernel_genx,sizeof(cht_copy_kernel_genx),m_pCmProgram,"nojitter");
+        break;
 #endif
-        case MFX_HW_SCL:
-        case MFX_HW_APL:
-        case MFX_HW_KBL:
-            cmSts = m_pCmDevice->LoadProgram((void*)skl_copy_kernel_genx,sizeof(skl_copy_kernel_genx),m_pCmProgram,"nojitter");
-            break;
-        default:
-            cmSts = CM_FAILURE;
-            break;
-        }
-        CHECK_CM_STATUS(cmSts, MFX_ERR_DEVICE_FAILED);
+    case MFX_HW_SCL:
+    case MFX_HW_APL:
+    case MFX_HW_KBL:
+        cmSts = m_pCmDevice->LoadProgram((void*)skl_copy_kernel_genx,sizeof(skl_copy_kernel_genx),m_pCmProgram,"nojitter");
+        break;
+    default:
+        cmSts = CM_FAILURE;
+        break;
+    }
+    CHECK_CM_STATUS(cmSts, MFX_ERR_DEVICE_FAILED);
 
     return MFX_ERR_NONE;
 

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
@@ -2045,9 +2045,9 @@ Status H264HeadersBitstream::GetSliceHeaderPart3(
                 // Get reorder idc,pic_num pairs until idc==3
                 for (;;)
                 {
-                  reordering_of_pic_nums_idc = (uint8_t)GetVLCElement(false);
-                  if (reordering_of_pic_nums_idc > 5)
-                    return UMC_ERR_INVALID_STREAM;
+                    reordering_of_pic_nums_idc = (uint8_t)GetVLCElement(false);
+                    if (reordering_of_pic_nums_idc > 5)
+                      return UMC_ERR_INVALID_STREAM;
 
                     if (reordering_of_pic_nums_idc == 3)
                         break;
@@ -2082,9 +2082,9 @@ Status H264HeadersBitstream::GetSliceHeaderPart3(
                     reordering_of_pic_nums_idc = 0;
                     for (;;)
                     {
-                    reordering_of_pic_nums_idc = GetVLCElement(false);
-                      if (reordering_of_pic_nums_idc > 5)
-                        return UMC_ERR_INVALID_STREAM;
+                        reordering_of_pic_nums_idc = GetVLCElement(false);
+                        if (reordering_of_pic_nums_idc > 5)
+                            return UMC_ERR_INVALID_STREAM;
 
                         if (reordering_of_pic_nums_idc == 3)
                             break;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
@@ -1520,8 +1520,8 @@ void POCDecoder::DecodePictureOrderCount(const H264Slice *slice, int32_t frame_n
         m_PicOrderCnt = uAbsFrameNum*2;
         if (sliceHeader->nal_ref_idc == false)
             m_PicOrderCnt--;
-            m_TopFieldPOC = m_PicOrderCnt;
-            m_BottomFieldPOC = m_PicOrderCnt;
+        m_TopFieldPOC = m_PicOrderCnt;
+        m_BottomFieldPOC = m_PicOrderCnt;
 
     }    // pic_order_cnt type 2
 

--- a/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_huffman.cpp
+++ b/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_huffman.cpp
@@ -189,7 +189,7 @@ static int HuffmanInitAlloc(int32_t rl, const int32_t* pSrcTable, int32_t** ppDs
                         if (rl == 0) table[code + j + 1] = (value1 << 8) | (commLen - i);
                         else      table[code + j + 1] = ((int16_t)value2 << 16) | ((uint8_t)value1 << 8) | (commLen - i);
 
-                        break;
+                    break;
                 }
                 else
                 {


### PR DESCRIPTION
The change addresses the following types of warnings treated as errors:
* this ‘if’ clause does not guard this statement
* ‘*’ in boolean context
* dereferencing type-punned pointer will break strict-aliasing rules

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>