### PR TITLE
[VPP][Linux]Fix performance drop

### DIFF
--- a/_studio/mfx_lib/vpp/include/mfx_vpp_hw.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_hw.h
@@ -307,7 +307,7 @@ namespace MfxHwVideoProcessing
     {
         bool   m_bMode30i60pEnable;
         bool   m_bWeave;
-        bool   m_bPassThroughEnable;
+        bool   m_bPassThroughEnable;// if this flag is true input surface will be copied to output via DoFastCopyWrapper() without VPP
         bool   m_bRefFrameEnable;
         bool   m_multiBlt;// this flag defines mode of composition for D3D11: 1 - run few hw calls per frame (Blt), 0 - run one hw call (Blt)
 

--- a/_studio/mfx_lib/vpp/include/mfx_vpp_hw.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_hw.h
@@ -307,7 +307,7 @@ namespace MfxHwVideoProcessing
     {
         bool   m_bMode30i60pEnable;
         bool   m_bWeave;
-        bool   m_bPassThroughEnable;// if this flag is true input surface will be copied to output via DoFastCopyWrapper() without VPP
+        bool   m_bCopyPassThroughEnable;// if this flag is true input surface will be copied to output via DoFastCopyWrapper() without VPP
         bool   m_bRefFrameEnable;
         bool   m_multiBlt;// this flag defines mode of composition for D3D11: 1 - run few hw calls per frame (Blt), 0 - run one hw call (Blt)
 

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -1867,7 +1867,7 @@ VideoVPPHW::VideoVPPHW(IOMode mode, VideoCORE *core)
     m_config.m_bMode30i60pEnable = false;
     m_config.m_bWeave = false;
     m_config.m_extConfig.mode  = FRC_DISABLED;
-    m_config.m_bPassThroughEnable = false;
+    m_config.m_bCopyPassThroughEnable = false;
     m_config.m_surfCount[VPP_IN]   = 1;
     m_config.m_surfCount[VPP_OUT]  = 1;
     m_config.m_IOPattern = 0;
@@ -2856,7 +2856,7 @@ mfxStatus VideoVPPHW::Close()
     m_config.m_extConfig.mode  = FRC_DISABLED;
     m_config.m_bMode30i60pEnable  = false;
     m_config.m_bRefFrameEnable = false;
-    m_config.m_bPassThroughEnable = false;
+    m_config.m_bCopyPassThroughEnable = false;
     m_config.m_surfCount[VPP_IN]  = 1;
     m_config.m_surfCount[VPP_OUT] = 1;
 
@@ -3094,8 +3094,8 @@ mfxStatus VideoVPPHW::VppFrameCheck(
         // submit task
         SyncTaskSubmission(pTask);
 
-        if (false == m_config.m_bPassThroughEnable ||
-            (true == m_config.m_bPassThroughEnable && true == IsRoiDifferent(pTask->input.pSurf, pTask->output.pSurf)))
+        if (false == m_config.m_bCopyPassThroughEnable ||
+            (true == m_config.m_bCopyPassThroughEnable && true == IsRoiDifferent(pTask->input.pSurf, pTask->output.pSurf)))
         {
             // configure entry point
             pEntryPoint[0].pRoutine = VideoVPPHW::QueryTaskRoutine;
@@ -3109,8 +3109,8 @@ mfxStatus VideoVPPHW::VppFrameCheck(
     }
     else
     {
-        if (false == m_config.m_bPassThroughEnable ||
-            (true == m_config.m_bPassThroughEnable && true == IsRoiDifferent(pTask->input.pSurf, pTask->output.pSurf)))
+        if (false == m_config.m_bCopyPassThroughEnable ||
+            (true == m_config.m_bCopyPassThroughEnable && true == IsRoiDifferent(pTask->input.pSurf, pTask->output.pSurf)))
         {
             // configure entry point
             pEntryPoint[1].pRoutine = VideoVPPHW::QueryTaskRoutine;
@@ -3732,7 +3732,7 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
 #ifdef MFX_ENABLE_MCTF
     if (pTask->outputForApp.pSurf)
     {
-        if (true == m_config.m_bPassThroughEnable &&
+        if (true == m_config.m_bCopyPassThroughEnable &&
             false == IsRoiDifferent(pTask->input.pSurf, pTask->outputForApp.pSurf))
         {
             sts = CopyPassThrough(pTask->input.pSurf, pTask->outputForApp.pSurf);
@@ -3749,7 +3749,7 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
             return MFX_ERR_UNDEFINED_BEHAVIOR;
     }
 #else
-    if (true == m_config.m_bPassThroughEnable &&
+    if (true == m_config.m_bCopyPassThroughEnable &&
         false == IsRoiDifferent(pTask->input.pSurf, pTask->output.pSurf))
     {
         sts = CopyPassThrough(pTask->input.pSurf, pTask->output.pSurf);
@@ -6022,21 +6022,21 @@ mfxStatus ConfigureExecuteParams(
     if ( (0 == memcmp(&videoParam.vpp.In, &videoParam.vpp.Out, sizeof(mfxFrameInfo))) &&
          executeParams.IsDoNothing() )
     {
-        config.m_bPassThroughEnable = true;
+        config.m_bCopyPassThroughEnable = true;
     }
     else
     {
-        config.m_bPassThroughEnable = false;// after Reset() parameters may be changed,
+        config.m_bCopyPassThroughEnable = false;// after Reset() parameters may be changed,
                                             // flag should be disabled
     }
-#endif//m_bPassThroughEnable == false for another OS
+#endif//m_bCopyPassThroughEnable == false for another OS
 
     if (inDNRatio == outDNRatio && !executeParams.bVarianceEnable && !executeParams.bComposite &&
             !(config.m_extConfig.mode == IS_REFERENCES) )
     {
         // work around
         config.m_extConfig.mode  = FRC_DISABLED;
-        //config.m_bPassThroughEnable = false;
+        //config.m_bCopyPassThroughEnable = false;
     }
 
     if (true == executeParams.bComposite && 0 == executeParams.dstRects.size()) // composition was enabled via DO USE

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -6018,17 +6018,18 @@ mfxStatus ConfigureExecuteParams(
         executeParams.bSceneDetectionEnable = false;
     }
 
-    if (0 == memcmp(&videoParam.vpp.In, &videoParam.vpp.Out, sizeof(mfxFrameInfo)))
+#if defined(WIN64) || defined (WIN32)
+    if ( (0 == memcmp(&videoParam.vpp.In, &videoParam.vpp.Out, sizeof(mfxFrameInfo))) &&
+         executeParams.IsDoNothing() )
     {
-        if (executeParams.IsDoNothing())
-            config.m_bPassThroughEnable = true;
-        else
-            config.m_bPassThroughEnable = false;
+        config.m_bPassThroughEnable = true;
     }
     else
     {
-        config.m_bPassThroughEnable = false;
+        config.m_bPassThroughEnable = false;// after Reset() parameters may be changed,
+                                            // flag should be disabled
     }
+#endif//m_bPassThroughEnable == false for another OS
 
     if (inDNRatio == outDNRatio && !executeParams.bVarianceEnable && !executeParams.bComposite &&
             !(config.m_extConfig.mode == IS_REFERENCES) )


### PR DESCRIPTION
On Linux DoFastCopy copy works slowly then copy via driver, so make sense copy via
driver in case of VPP called without filters

Rename m_bPassThroughEnable to m_bCopyPassThroughEnable