### PR TITLE
[HEVCe FEI] Use mfxExtHEVCParam to pass width/height to encoder

### DIFF
--- a/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
+++ b/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
@@ -228,6 +228,9 @@ template<>struct mfx_ext_buffer_id<mfxExtFeiHevcRepackCtrl>{
 template<>struct mfx_ext_buffer_id<mfxExtFeiHevcRepackStat>{
     enum {id = MFX_EXTBUFF_HEVCFEI_REPACK_STAT};
 };
+template<>struct mfx_ext_buffer_id<mfxExtHEVCParam> {
+    enum {id = MFX_EXTBUFF_HEVC_PARAM};
+};
 
 struct CmpExtBufById
 {
@@ -409,6 +412,7 @@ private:
             MFX_EXTBUFF_CODING_OPTION2,
             MFX_EXTBUFF_CODING_OPTION3,
             MFX_EXTBUFF_FEI_PARAM,
+            MFX_EXTBUFF_HEVC_PARAM,
         };
 
         for (mfxU32 i = 0; i < sizeof(allowed)/sizeof(allowed[0]); i++)

--- a/samples/sample_hevc_fei/src/pipeline_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/pipeline_hevc_fei.cpp
@@ -498,6 +498,17 @@ MfxVideoParamsWrapper GetEncodeParams(const sInputParams& user_pars, const mfxFr
     // qp offset per pyramid layer, default is library behavior
     pCO3->EnableQPOffset = user_pars.bDisableQPOffset ? MFX_CODINGOPTION_OFF : MFX_CODINGOPTION_UNKNOWN;
 
+    // When height and/or width divided with 8 but not divided with 16
+    // add extended parameter to increase performance
+    if ((pars.mfx.FrameInfo.CropW & 15) == 8 || (pars.mfx.FrameInfo.CropH & 15) == 8) {
+
+        mfxExtHEVCParam* pHP = pars.AddExtBuffer<mfxExtHEVCParam>();
+        if (!pHP) throw mfxError(MFX_ERR_NOT_INITIALIZED, "Failed to attach mfxExtHEVCParam");
+
+        pHP->PicWidthInLumaSamples  = pars.mfx.FrameInfo.CropW;
+        pHP->PicHeightInLumaSamples = pars.mfx.FrameInfo.CropH;
+    }
+
     return pars;
 }
 


### PR DESCRIPTION
When height and/or width divided with 8 but not divided with 16,
it's recommended to add extended buffer to increase performance.