### PR TITLE
[AVC FEI][sample] add one option "-noPtoBref".

### DIFF
--- a/samples/sample_fei/include/encoding_task.h
+++ b/samples/sample_fei/include/encoding_task.h
@@ -712,6 +712,7 @@ struct iTaskParams
     mfxU16 NumMVPredictorsBL0;
     mfxU16 NumMVPredictorsBL1;
     bool   SingleFieldMode;
+    bool   NoPRefB;
 
     mfxFrameSurface1 *InputSurf;
     mfxFrameSurface1 *ReconSurf;
@@ -732,6 +733,7 @@ struct iTaskParams
         , NumMVPredictorsBL0(0)
         , NumMVPredictorsBL1(0)
         , SingleFieldMode(false)
+        , NoPRefB(false)
         , InputSurf(NULL)
         , ReconSurf(NULL)
         , DSsurface(NULL)
@@ -772,6 +774,7 @@ struct iTask
         , m_tid(0)
         , m_tidx(0)
         , m_longTermPicNum(PairU8(0, 0))
+        , m_bNoPRefB(task_params.NoPRefB)
         , prevTask(NULL)
     {
         NumMVPredictorsP[0]   = task_params.NumMVPredictorsP;
@@ -883,6 +886,7 @@ struct iTask
         m_type            = task.m_type;
         m_dpbPostEncoding = task.m_dpbPostEncoding;
         m_poc             = task.m_poc;
+        m_bNoPRefB        = task.m_bNoPRefB;
         PicStruct         = task.PicStruct;
 
         return *this;
@@ -1073,6 +1077,7 @@ struct iTask
 
     PairU8  m_longTermPicNum;
     PairU8  m_reference;        // is reference (short or long term) or not
+    bool    m_bNoPRefB;         // disable P frames to refer to B frames
     //.........................................................................................
 
     iTask* prevTask;
@@ -1167,6 +1172,7 @@ inline void InitNewDpbFrame(
     ref.m_frameNum       = task.m_frameNum;
     ref.m_frameNumWrap   = task.m_frameNumWrap;
     ref.m_longTermPicNum = task.m_longTermPicNum;
+    ref.m_type           = task.m_type;
     ref.m_longterm       = 0;
     ref.m_refBase        = 0;
 

--- a/samples/sample_fei/include/sample_fei_defs.h
+++ b/samples/sample_fei/include/sample_fei_defs.h
@@ -299,6 +299,7 @@ struct AppConfig
         , NumRefActiveBL0(0)
         , NumRefActiveBL1(0)
         , bRefType(MFX_B_REF_UNKNOWN) // Let MSDK library to decide wheather to use B-pyramid or not
+        , bNoPtoBref(false)
         , nIdrInterval(0xffff)        // Infinite IDR interval
         , preencDSstrength(0)         // No Downsampling
         , bDynamicRC(false)
@@ -407,6 +408,7 @@ struct AppConfig
     mfxU16 NumRefActiveBL0;  // maximal number of backward references for B frames
     mfxU16 NumRefActiveBL1;  // maximal number of forward references for B frames
     mfxU16 bRefType;         // B-pyramid ON/OFF/UNKNOWN (default, let MSDK lib to decide)
+    bool   bNoPtoBref;       // disable prediction of P frames from reference B
     mfxU16 nIdrInterval;     // distance between IDR frames in GOPs
     mfxU8  preencDSstrength; // downsample input before passing to preenc (2/4/8x are supported)
     bool   bDynamicRC;
@@ -762,6 +764,7 @@ struct DpbFrame
     PairU8  m_refPicFlag;
     mfxU8   m_longterm; // at least one field is a long term reference
     mfxU8   m_refBase;
+    PairU8  m_type;     // type of first and second field
 };
 
 struct ArrayDpbFrame : public FixedArray<DpbFrame, 16>

--- a/samples/sample_fei/src/pipeline_fei.cpp
+++ b/samples/sample_fei/src/pipeline_fei.cpp
@@ -844,6 +844,7 @@ mfxStatus CEncodingPipeline::SetSequenceParameters()
         m_appCfg.NumMVPredictors_Bl1 : (std::min)(mfxU16(m_numRefFrame*m_numOfFields), MaxFeiEncMVPNum);
 
     m_taskInitializationParams.BRefType           = m_bRefType;
+    m_taskInitializationParams.NoPRefB            = m_appCfg.bNoPtoBref;
 
     /* Section below calculates number of macroblocks for extension buffers allocation */
 

--- a/samples/sample_fei/src/refListsManagement_fei.cpp
+++ b/samples/sample_fei/src/refListsManagement_fei.cpp
@@ -131,16 +131,26 @@ void InitRefPicList(
         // 8.2.4.2.1-2 "Initialisation process for
         // the reference picture list for P and SP slices in frames/fields"
         for (mfxU32 i = 0; i < dpb.Size(); i++)
+        {
+            if (task.m_bNoPRefB && ((dpb[i].m_type[0] & MFX_FRAMETYPE_B) || (dpb[i].m_type[1] & MFX_FRAMETYPE_B)))
+                continue;
+
             if (!dpb[i].m_longterm)
                 list0Frm.PushBack(mfxU8(i));
+        }
 
         std::sort(list0Frm.Begin(), list0Frm.End(), RefPicNumIsGreater(dpb));
 
         mfxU8 * firstLongTerm = list0Frm.End();
 
         for (mfxU32 i = 0; i < dpb.Size(); i++)
+        {
+            if (task.m_bNoPRefB && ((dpb[i].m_type[0] & MFX_FRAMETYPE_B) || (dpb[i].m_type[1] & MFX_FRAMETYPE_B)))
+                continue;
+
             if (dpb[i].m_longterm)
                 list0Frm.PushBack(mfxU8(i));
+        }
 
         std::sort(
             firstLongTerm,

--- a/samples/sample_fei/src/sample_fei.cpp
+++ b/samples/sample_fei/src/sample_fei.cpp
@@ -49,6 +49,7 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-single_field_processing] - single-field coding mode, one call for each field, tff/bff option required\n"));
     msdk_printf(MSDK_STRING("   [-bref] - arrange B frames in B pyramid reference structure\n"));
     msdk_printf(MSDK_STRING("   [-nobref] - do not use B-pyramid (by default the decision is made by library)\n"));
+    msdk_printf(MSDK_STRING("   [-noPtoBref] - in B pyramid case, disable prediction of P frames from reference B; not for ENCODE pipeline\n"));
     msdk_printf(MSDK_STRING("   [-idr_interval size] - idr interval, default 0 means every I is an IDR, 1 means every other I frame is an IDR etc (default is infinite)\n"));
     msdk_printf(MSDK_STRING("   [-f frameRate] - video frame rate (frames per second)\n"));
     msdk_printf(MSDK_STRING("   [-n number] - number of frames to process\n"));
@@ -368,6 +369,10 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, AppConfig* pCon
         else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-nobref")))
         {
             pConfig->bRefType = MFX_B_REF_OFF;
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-noPtoBref")))
+        {
+            pConfig->bNoPtoBref = true;
         }
         else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-idr_interval")))
         {
@@ -1184,6 +1189,18 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, AppConfig* pCon
         msdk_printf(MSDK_STRING("           Current number of references extended.\n"));
 
         pConfig->numRef = 2;
+    }
+
+    if (pConfig->bRefType != MFX_B_REF_PYRAMID && pConfig->bNoPtoBref)
+    {
+        msdk_printf(MSDK_STRING("\nWARNING: option -noPtoBref can only be set together with -bref\n"));
+        pConfig->bNoPtoBref = false;
+    }
+
+    if (pConfig->bENCODE && pConfig->bNoPtoBref)
+    {
+        msdk_printf(MSDK_STRING("\nWARNING: option -noPtoBref doesn't work with ENCODE pipeline\n"));
+        pConfig->bNoPtoBref = false;
     }
 
     return MFX_ERR_NONE;


### PR DESCRIPTION
Change the default ref list for P frames when B-Pyramid is enabled,
disable prediction of P frames from reference B.