### PR TITLE
[mpeg2d] Add check for headers corruption

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
+++ b/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
@@ -223,11 +223,13 @@ protected:
     int32_t display_order;
     unsigned long long last_timestamp;
     mfxF64 last_good_timestamp;
+    mfxU16 m_fieldsInCurrFrame; // first field or new frame if 3 or 0; 1 - only top etc
 
     int32_t m_Protected;
 
     void ResetFcState(FcState& state) { state.picStart = state.picHeader = 0; }
     mfxStatus UpdateCurrVideoParams(mfxFrameSurface1 *surface_work, int task_num);
+    bool VerifyPictureBits(mfxBitstream* currPicBs, const mfxU8* head, const mfxU8* tail);
 
     //get index to read input data:
     bool SetCurr_m_frame()

--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2419,13 +2419,8 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
 
             MoveBitstreamData(*in, (mfxU32)(curr - head));
 
-            if (m_fcState.picHeader == FcState::FRAME)
-                if (!VerifyPictureBits(out, curr, tail)) {
-                    out->DataLength = 0; // drop prepared picture, continue to find next
-                    m_fcState.picStart = 0;
-                    m_fcState.picHeader = FcState::NONE;
-                    continue;
-                }
+            if (m_fcState.picHeader == FcState::FRAME && !VerifyPictureBits(out, curr, tail))
+                return MFX_ERR_NOT_ENOUGH_BUFFER; // to start again with next picture
 
             if (FcState::FRAME == m_fcState.picHeader)
             {

--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2424,6 +2424,7 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
                     out->DataLength = 0; // drop prepared picture, continue to find next
                     m_fcState.picStart = 0;
                     m_fcState.picHeader = FcState::NONE;
+                    continue;
                 }
 
             if (FcState::FRAME == m_fcState.picHeader)

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
@@ -876,6 +876,8 @@ int32_t MPEG2VideoDecoderBase::GetDisplayIndex()
     if(frame_buffer.ret_array[frame_buffer.ret_array_curr] != -1)
     {
       frame_buffer.retrieve     = frame_buffer.ret_array[frame_buffer.ret_array_curr];
+      if (frame_buffer.retrieve >= DPB_SIZE)
+          frame_buffer.retrieve -= DPB_SIZE;
       frame_buffer.ret_array[frame_buffer.ret_array_curr] = -1;
       frame_buffer.ret_array_curr++;
       if(frame_buffer.ret_array_curr >= DPB_SIZE)

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_pic.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_pic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -895,11 +895,6 @@ Status MPEG2VideoDecoderBase::DecodePictureHeader(int task_num)
      // return (UMC_ERR_INVALID_STREAM);
         isCorrupted = true;
     }
-    // compute maximum slice vertical position
-    if(PictureHeader[task_num].picture_structure == FRAME_PICTURE)
-      PictureHeader[task_num].max_slice_vert_pos = sequenceHeader.mb_height[task_num];
-    else
-      PictureHeader[task_num].max_slice_vert_pos = sequenceHeader.mb_height[task_num] >> 1;
 
     if(code == EXTENSION_START_CODE)
     {
@@ -907,6 +902,12 @@ Status MPEG2VideoDecoderBase::DecodePictureHeader(int task_num)
 
         FIND_START_CODE(video->bs, code);
     }
+
+    // compute maximum slice vertical position
+    if(PictureHeader[task_num].picture_structure == FRAME_PICTURE)
+      PictureHeader[task_num].max_slice_vert_pos = sequenceHeader.mb_height[task_num];
+    else
+      PictureHeader[task_num].max_slice_vert_pos = sequenceHeader.mb_height[task_num] >> 1;
 
     while (code == EXTENSION_START_CODE || code == USER_DATA_START_CODE)
     {


### PR DESCRIPTION
When picture data is extracted from bs, verifies for proper picture
type, structure and temporal order using current and next picture headers.
If corrupted picture is detected it is dropped and the next picture
will be extracted.