### PR TITLE
[sample_hevc_fei] Properly initialize repack filenames

### DIFF
--- a/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
+++ b/samples/sample_hevc_fei/include/sample_hevc_fei_defs.h
@@ -139,6 +139,8 @@ struct sInputParams
         MSDK_ZERO_MEMORY(mvoutFile);
         MSDK_ZERO_MEMORY(mvpInFile);
         MSDK_ZERO_MEMORY(refctrlInFile);
+        MSDK_ZERO_MEMORY(repackctrlFile);
+        MSDK_ZERO_MEMORY(repackstatFile);
 
         MSDK_ZERO_MEMORY(preencCtrl);
         preencCtrl.Header.BufferId = MFX_EXTBUFF_FEI_PREENC_CTRL;


### PR DESCRIPTION
The repack filenames are stored in char arrays and so should be zero-
initialized.