### PR TITLE
[vpp] Fix random error out on VPP initialization due to non-configured attributes

### DIFF
--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -255,16 +255,11 @@ mfxStatus VAAPIVideoProcessing::Init(_mfxPlatformAccelerationService* pVADisplay
             return MFX_ERR_DEVICE_FAILED;
         }
 
-        // Configuration
-        VAConfigAttrib va_attributes;
-        vaSts = vaGetConfigAttributes(m_vaDisplay, VAProfileNone, VAEntrypointVideoProc, &va_attributes, 1);
-        MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-
         vaSts = vaCreateConfig( m_vaDisplay,
                                 VAProfileNone,
                                 VAEntrypointVideoProc,
-                                &va_attributes,
-                                1,
+                                NULL,
+                                0,
                                 &m_vaConfig);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 


### PR DESCRIPTION

Fixes: #236

This is misuse of vaGetConfigAttributes function. It _expects_ to get list of
attributes (i.e. types) to be queried. Instead mediasdk tried to do I don't know what.
It passed non-initialized attribute to the function and got random results. We could
hit unknown attribute and error out or we could hit known attribute and initialize to
some unpredictable behaviour.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>