### PR TITLE
[JPEGd/MJPEGd] Restore cases that can be executed by HW on BDW/SKL

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1,15 +1,15 @@
 // Copyright (c) 2018 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1086,24 +1086,26 @@ bool MFX_JPEG_Utility::IsNeedPartialAcceleration(VideoCORE * core, mfxVideoParam
         if (par->mfx.FrameInfo.Width > 8192 || par->mfx.FrameInfo.Height > 8192)
             return true;
 
-        if (par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV411)
-            return true;
-
-        if (par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444)
-            return true;
-
-        if (par->mfx.JPEGColorFormat  == MFX_JPEG_COLORFORMAT_YCbCr &&
+        if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
             par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_MONOCHROME)
             return true;
 
-        if (par->mfx.FrameInfo.FourCC == MFX_FOURCC_NV12 &&
-            par->mfx.JPEGColorFormat  == MFX_JPEG_COLORFORMAT_RGB &&
-            par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV420)
+        if (par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV411)
             return true;
 
-        if (par->mfx.FrameInfo.FourCC == MFX_FOURCC_RGB4 &&
-            par->mfx.JPEGColorFormat  == MFX_JPEG_COLORFORMAT_YCbCr &&
-            par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV420)
+        if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
+            par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444)
+            return true;
+
+        if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
+            par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV420 &&
+            par->mfx.FrameInfo.FourCC == MFX_FOURCC_RGB4 &&
+            (par->mfx.FrameInfo.Width > 4096 || par->mfx.FrameInfo.Height > 4096))
+            return true;
+
+        if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_RGB &&
+            par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444 &&
+            par->mfx.FrameInfo.FourCC != MFX_FOURCC_RGB4)
             return true;
     }
     if (core->GetHWType() == MFX_HW_VLV)


### PR DESCRIPTION
Library doesn't support SW implementation for M/JPEG decoder and
HW implementation supports only part of them. Commit restored cases
which can be executed by HW implementation.