### PR TITLE
[hevcd] Re-enable MAIN10 profile for linux

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -92,9 +92,7 @@ bool CheckGUID(VideoCORE * core, eMFXHWType type, mfxVideoParam const* param)
     {
         case MFX_PROFILE_HEVC_MAIN:
         case MFX_PROFILE_HEVC_MAINSP:
-#if defined(ANDROID)
         case MFX_PROFILE_HEVC_MAIN10:
-#endif
             return true;
     }
 


### PR DESCRIPTION
It was accidentally disabled in "Update API to 1.26" commit.