### PR TITLE
[mpeg2d] Fix possible memory access out of boundary

### DIFF
--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_slice_hw.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_slice_hw.cpp
@@ -136,12 +136,18 @@ Status MPEG2VideoDecoderHW::DecodeSliceHeader(VideoContext *video, int task_num)
             uint8_t *ptr = start_ptr;
             uint32_t count = 0;
 
-            // calculate number of bytes of slice data
-            while (ptr < end_ptr && (ptr[0] || ptr[1] || ptr[2] || ptr[3]))
+            uint32_t zeroes = 0;
+            //calculating the size of slice data, if 4 consecutive 0s are found, it indicates the end of the slice no further check is needed
+            while (ptr < end_ptr)
             {
-                ptr++;
-                count++;
-            }
+                if (*ptr++) zeroes = 0;
+                else ++zeroes;
+                ++count;
+                if (zeroes == 4) break;
+             }
+            // Adjust the count by reducing the number of 0s found, either 4 consecutive 0s or 0-3 0s existing at the end of the data. 
+            // Based on the standard, they should be stuffing bytes.
+            count -= zeroes;
 
             // update slice info structures (+ extra 10 bytes, this is @to do@)
             if(pack_w.pSliceInfoBuffer < pack_w.pSliceInfo)


### PR DESCRIPTION
Valgrind check shows a possible illegal memory access out of boundary.
This change removed the illegal memory access and fixed a bug
for slice size calculation related to stuffing bytes.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>