### PR TITLE
h264enc: support expose QP value

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -3094,8 +3094,7 @@ mfxStatus VAAPIEncoder::QueryStatus(
 
     task.m_bsDataLength[fieldId] = codedBufferSegment->size;
 
-    // Disable QP report on Linux until driver fix.
-    //task.m_qpY[fieldId] = (codedBufferSegment->status & VA_CODED_BUF_STATUS_PICTURE_AVE_QP_MASK);
+    task.m_qpY[fieldId] = (codedBufferSegment->status & VA_CODED_BUF_STATUS_PICTURE_AVE_QP_MASK);
 
     if (codedBufferSegment->status & VA_CODED_BUF_STATUS_BAD_BITSTREAM)
         sts = MFX_ERR_GPU_HANG;


### PR DESCRIPTION
Looks like iHD driver has fixed it and support expose QP now.

Signed-off-by: Zhong Li <zhong.li@intel.com>