### PR TITLE
[sample_common] Load libX11.so.6 instead of libX11.so

### DIFF
--- a/samples/sample_common/src/vaapi_utils.cpp
+++ b/samples/sample_common/src/vaapi_utils.cpp
@@ -224,7 +224,7 @@ VA_X11Proxy::~VA_X11Proxy()
 {}
 
 XLib_Proxy::XLib_Proxy()
-    : lib("libX11.so")
+    : lib("libX11.so.6")
     , SIMPLE_LOADER_FUNCTION(XOpenDisplay)
     , SIMPLE_LOADER_FUNCTION(XCloseDisplay)
     , SIMPLE_LOADER_FUNCTION(XCreateSimpleWindow)


### PR DESCRIPTION
libX11.so is a linker name so it is not available if the
  libX11-dev package is not installed.
As a result, attempting to render to screen with X server
  will fail (e.g. sample_decode -r ...)
This fix changes the code to dlopen the actual library name
  instead: libX11.so.6

Issue: #210
Tests: remove symlink for libX11.so and run sample_decode -r

test_results.json attached.
[test_results.json.txt](https://github.com/Intel-Media-SDK/MediaSDK/files/2074198/test_results.json.txt)
