### PR TITLE
[gcc8.x] Fix a bunch of compilation issues from gcc8.x

### DIFF
--- a/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
+++ b/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
@@ -316,7 +316,7 @@ mfxStatus MFXVideoDECODEVC1::Init(mfxVideoParam *par)
         return MFX_ERR_MEMORY_ALLOC;
 
     m_pStCodes = (UMC::MediaDataEx::_MediaDataEx*)(m_MemoryAllocator.Lock(m_stCodesID));
-    memset(m_pStCodes, 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(UMC::MediaDataEx::_MediaDataEx)));
+    memset(reinterpret_cast<void*>(m_pStCodes), 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(UMC::MediaDataEx::_MediaDataEx)));
     m_pStCodes->count      = 0;
     m_pStCodes->index      = 0;
     m_pStCodes->bstrm_pos  = 0;

--- a/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
+++ b/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
@@ -381,7 +381,7 @@ mfxStatus MFXVideoDECODEVC1::Reset(mfxVideoParam *par)
     // buffers setting
     m_FrameConstrData.SetBufferPointer(m_pReadBuffer, m_BufSize);
     m_FrameConstrData.SetDataSize(0);
-    memset(m_pStCodes, 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(UMC::MediaDataEx::_MediaDataEx)));
+    memset(reinterpret_cast<void*>(m_pStCodes), 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(UMC::MediaDataEx::_MediaDataEx)));
     m_pStCodes->count      = 0;
     m_pStCodes->index      = 0;
     m_pStCodes->bstrm_pos  = 0;

--- a/_studio/mfx_lib/scheduler/include/mfx_dependency_item.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_dependency_item.h
@@ -252,7 +252,7 @@ protected:
     MFX_DEPENDENCY_LIST_ITEM m_beginListObjects;
     MFX_DEPENDENCY_LIST_ITEM m_endListObjects;
     // Pointer to the next item in the corresponding dependency list
-    MFX_DEPENDENCY_LIST_ITEM (m_dependency[dependency_level]);
+    MFX_DEPENDENCY_LIST_ITEM m_dependency[dependency_level];
 };
 
 #endif // __MFX_DEPENDENCY_ITEM_H

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -381,7 +381,7 @@ protected:
     // Guard for task queues
     vm_mutex m_guard;
     // array of task queues
-    MFX_SCHEDULER_TASK *(m_pTasks[MFX_PRIORITY_NUMBER][MFX_TYPE_NUMBER]);
+    MFX_SCHEDULER_TASK *m_pTasks[MFX_PRIORITY_NUMBER][MFX_TYPE_NUMBER];
     // Number of assigned tasks for each kind of tasks
     mfxU32 m_numAssignedTasks[MFX_PRIORITY_NUMBER];
     // Queue of failed tasks

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
@@ -462,7 +462,7 @@ void mfxSchedulerCore::ScrubCompletedTasks(bool bComprehensive)
 void mfxSchedulerCore::RegisterTaskDependencies(MFX_SCHEDULER_TASK  *pTask)
 {
     mfxU32 i, tableIdx, remainInputs;
-    const void *(pSrcCopy[MFX_TASK_NUM_DEPENDENCIES]);
+    const void *pSrcCopy[MFX_TASK_NUM_DEPENDENCIES];
     mfxStatus taskRes = MFX_WRN_IN_EXECUTION;
 
     //

--- a/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
@@ -126,7 +126,7 @@ namespace MfxHwH264Encode
 
     template<class T> inline T* SecondHalfOf(std::vector<T>& v) { return &v[v.size() / 2]; }
 
-    template<class T> inline void Zero(T & obj)                { memset(&obj, 0, sizeof(obj)); }
+    template<class T> inline void Zero(T & obj)                { memset(reinterpret_cast<void*>(&obj), 0, sizeof(obj)); }
     template<class T> inline void Zero(std::vector<T> & vec)   { if (vec.size() > 0) memset(&vec[0], 0, sizeof(T) * vec.size()); }
     template<class T> inline void Zero(T * first, size_t cnt)  { memset(first, 0, sizeof(T) * cnt); }
 

--- a/_studio/mfx_lib/shared/include/mfx_task.h
+++ b/_studio/mfx_lib/shared/include/mfx_task.h
@@ -121,9 +121,9 @@ struct MFX_TASK
     // these are only in/out dependencies.
 
     // Array of source dependencies
-    const void *(pSrc[MFX_TASK_NUM_DEPENDENCIES]);
+    const void *pSrc[MFX_TASK_NUM_DEPENDENCIES];
     // Array of destination dependencies
-    void *(pDst[MFX_TASK_NUM_DEPENDENCIES]);
+    void *pDst[MFX_TASK_NUM_DEPENDENCIES];
 
     // Task's priority
     mfxPriority priority;

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -2145,7 +2145,7 @@ mfxStatus  VideoVPPHW::Init(
         {
             m_ddi = new VPPHWResMng();
         }
-        catch(std::bad_alloc)
+        catch(std::bad_alloc&)
         {
             return MFX_WRN_PARTIAL_ACCELERATION;
         }

--- a/_studio/shared/mfx_trace/src/mfx_trace_ftrace.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace_ftrace.cpp
@@ -79,7 +79,7 @@ namespace
     // not thread-safe
     const char *get_tracing_file(const char *file_name)
     {
-        snprintf(trace_file_name, MAX_PATH, "%s/%s", get_debugfs_prefix(), file_name);
+        snprintf(trace_file_name, MAX_PATH, "%.160s/%.96s", get_debugfs_prefix(), file_name);
         return trace_file_name;
     }
 

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_debug.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_debug.cpp
@@ -30,7 +30,7 @@ namespace UMC
 
 void Trace(vm_char const* format, ...)
 {
-    va_list(arglist);
+    va_list arglist;
     va_start(arglist, format);
 
     vm_char cStr[256];

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_slice_decoder_decode_pic.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_slice_decoder_decode_pic.cpp
@@ -71,7 +71,7 @@ Status H264Slice::UpdateReferenceList(ViewList &views,
     ReferenceFlags *pFields1;
     uint32_t NumShortTermRefs, NumLongTermRefs;
     H264RefListInfo rli;
-    H264DecoderFrame *(pLastInList[2]) = {NULL, NULL};
+    H264DecoderFrame *pLastInList[2] = {NULL, NULL};
 
     VM_ASSERT(m_pCurrentFrame);
 

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -573,7 +573,7 @@ UMC::Status HeadersAnalyzer::ProcessNalUnit(UMC::MediaData * data)
                     return UMC::UMC_OK;
                 }
             }
-            catch(h265_exception ex)
+            catch(h265_exception& ex)
             {
                 if (ex.GetStatus() != UMC::UMC_ERR_UNSUPPORTED)
                 {

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
@@ -85,7 +85,7 @@ int32_t H265Slice::RetrievePicParamSetNumber()
     if (!m_source.GetDataSize())
         return -1;
 
-    memset(&m_SliceHeader, 0, sizeof(m_SliceHeader));
+    memset(reinterpret_cast<void*>(&m_SliceHeader), 0, sizeof(m_SliceHeader));
     m_BitStream.Reset((uint8_t *) m_source.GetPointer(), (uint32_t) m_source.GetDataSize());
 
     UMC::Status umcRes = UMC::UMC_OK;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
@@ -158,7 +158,7 @@ bool H265Slice::DecodeSliceHeader(PocDecoding * pocDecoding)
     // discarded when read again here.
     try
     {
-        memset(&m_SliceHeader, 0, sizeof(m_SliceHeader));
+        memset(reinterpret_cast<void*>(&m_SliceHeader), 0, sizeof(m_SliceHeader));
 
         umcRes = m_BitStream.GetNALUnitType(m_SliceHeader.nal_unit_type,
                                             m_SliceHeader.nuh_temporal_id);

--- a/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
+++ b/_studio/shared/umc/codec/jpeg_common/src/bitstreamin.cpp
@@ -109,7 +109,7 @@ JERRCODE CBitStreamInput::FillBuffer(int nMinBytes)
 
   if(remainder && !m_eod)
   {
-    memmove(m_pData, &m_pData[m_currPos], remainder);
+    memmove(m_pData, &m_pData[m_currPos], (unsigned int)remainder);
     m_currPos = 0;
   }
 

--- a/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder.cpp
+++ b/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder.cpp
@@ -346,7 +346,7 @@ Status VC1VideoDecoder::ContextAllocation(uint32_t mbWidth,uint32_t mbHeight)
             m_stCodes = (MediaDataEx::_MediaDataEx *)(ptr);
 
 
-            memset(m_stCodes, 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(MediaDataEx::_MediaDataEx)));
+            memset(reinterpret_cast<void*>(m_stCodes), 0, (START_CODE_NUMBER*2*sizeof(int32_t)+sizeof(MediaDataEx::_MediaDataEx)));
             m_stCodes->count      = 0;
             m_stCodes->index      = 0;
             m_stCodes->bstrm_pos  = 0;

--- a/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
+++ b/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
@@ -231,7 +231,7 @@ bool VC1VideoDecoderHW::InitAlloc(VC1Context* pContext, uint32_t )
         m_stCodes_VA = (MediaDataEx::_MediaDataEx *)malloc(START_CODE_NUMBER * 2 * sizeof(int32_t) + sizeof(MediaDataEx::_MediaDataEx));
         if (m_stCodes_VA == NULL)
             return false;
-        memset(m_stCodes_VA, 0, (START_CODE_NUMBER * 2 * sizeof(int32_t) + sizeof(MediaDataEx::_MediaDataEx)));
+        memset(reinterpret_cast<void*>(m_stCodes_VA), 0, (START_CODE_NUMBER * 2 * sizeof(int32_t) + sizeof(MediaDataEx::_MediaDataEx)));
         m_stCodes_VA->count = 0;
         m_stCodes_VA->index = 0;
         m_stCodes_VA->bstrm_pos = 0;

--- a/_studio/shared/umc/core/umc/include/umc_array.h
+++ b/_studio/shared/umc/core/umc/include/umc_array.h
@@ -198,7 +198,7 @@ protected:
         }
 
         // reset new items to zero
-        memset(pNewArray + i, 0, sizeof(item_t) * (sizeNew - i));
+        memset(reinterpret_cast<void*>(pNewArray + i), 0, sizeof(item_t) * (sizeNew - i));
 
         // set the pointer and size
         m_pArray = pNewArray;

--- a/_studio/shared/umc/core/umc/src/umc_video_decoder.cpp
+++ b/_studio/shared/umc/core/umc/src/umc_video_decoder.cpp
@@ -27,7 +27,7 @@ namespace UMC
 VideoDecoderParams::VideoDecoderParams(void)
 {
     m_pData = NULL;
-    memset(&info, 0, sizeof(sVideoStreamInfo));
+    memset(reinterpret_cast<void*>(&info), 0, sizeof(sVideoStreamInfo));
     lFlags = 0;
     pPostProcessing = NULL;
     lpMemoryAllocator = NULL;

--- a/api/opensource/mfx_dispatch/include/mfx_load_plugin.h
+++ b/api/opensource/mfx_dispatch/include/mfx_load_plugin.h
@@ -51,7 +51,7 @@ namespace MFX
             PluginModule module;
             mfxPlugin plugin;
             FactoryRecord ()
-                : plugin()
+                : plgParams(), plugin()
             {}
             FactoryRecord(const mfxPluginParam &plgParams,
                           PluginModule &module,

--- a/api/opensource/mfx_dispatch/src/mfx_plugin_hive_linux.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_plugin_hive_linux.cpp
@@ -267,7 +267,7 @@ MFXPluginsInFS::MFXPluginsInFS(mfxVersion currentAPIVersion)
             PluginDescriptionRecord descriptionRecord;
             descriptionRecord.onlyVersionRegistered = true;
             char cfgName[MAX_PLUGIN_PATH];
-            snprintf(cfgName, sizeof(cfgName), "%s/%s/%s", selfName, namelist[i]->d_name, pluginCfgFileName);
+            snprintf(cfgName, sizeof(cfgName), "%.512s/%.512s/%s", selfName, namelist[i]->d_name, pluginCfgFileName);
             if ( strlen(selfName) + strlen("/") + strlen(namelist[i]->d_name) >= MAX_PLUGIN_PATH)
             {
                 TRACE_HIVE_ERROR("buffer of MAX_PLUGIN_PATH characters which is %d, not enough to store plugin directory path: %s/%s\n",


### PR DESCRIPTION
#266 Fedora28 and latest ClearLinux introduce gcc8.x, which bring more strict
check during compilation. This PR fix a bunch of errors including -Werror=paraentheses/class-memaccess/maybe-uninitilized/..