### PR TITLE
[HEVC FEI] Get different videoParams for PreENC and Encode

### DIFF
--- a/samples/sample_hevc_fei/include/pipeline_hevc_fei.h
+++ b/samples/sample_hevc_fei/include/pipeline_hevc_fei.h
@@ -83,6 +83,11 @@ private:
     DISALLOW_COPY_AND_ASSIGN(CEncodingPipeline);
 };
 
-MfxVideoParamsWrapper GetEncodeParams(const sInputParams& user_pars, const mfxFrameInfo& in_fi);
+enum PIPELINE_COMPONENT {
+    PREENC,
+    ENCODE
+};
+
+MfxVideoParamsWrapper GetEncodeParams(const sInputParams& user_pars, const mfxFrameInfo& in_fi, PIPELINE_COMPONENT component);
 
 #endif // __PIPELINE_FEI_H__


### PR DESCRIPTION
PreENC doesn't support all the ext buffers, as Encode does.
This commit fixes the problem of getting more buffers for PreENC, than it supports.