### PR TITLE
[AVC FEI, ENC, PAK, PreENC] Sync output data via vaMapBuffer call

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
@@ -682,18 +682,6 @@ mfxStatus VAAPIFEIPREENCEncoder::QueryStatus(
     VASurfaceStatus surfSts = VASurfaceSkipped;
 
     {
-        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaSyncSurface");
-        vaSts = vaSyncSurface(m_vaDisplay, waitSurface);
-    }
-    // following code is workaround:
-    // because of driver bug it could happen that decoding error will not be returned after decoder sync
-    // and will be returned at subsequent encoder sync instead
-    // just ignore VA_STATUS_ERROR_DECODING_ERROR in encoder
-    if (vaSts == VA_STATUS_ERROR_DECODING_ERROR)
-        vaSts = VA_STATUS_SUCCESS;
-    MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-
-    {
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaQuerySurfaceStatus");
         vaSts = vaQuerySurfaceStatus(m_vaDisplay, waitSurface, &surfSts);
     }
@@ -1631,16 +1619,6 @@ mfxStatus VAAPIFEIENCEncoder::QueryStatus(
 
     VASurfaceStatus surfSts = VASurfaceSkipped;
 
-    {
-        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaSyncSurface");
-        vaSts = vaSyncSurface(m_vaDisplay, waitSurface);
-    }
-
-    // ignore VA_STATUS_ERROR_DECODING_ERROR in encoder
-    if (vaSts == VA_STATUS_ERROR_DECODING_ERROR)
-        vaSts = VA_STATUS_SUCCESS;
-    MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-
     vaSts = vaQuerySurfaceStatus(m_vaDisplay, waitSurface, &surfSts);
     MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
@@ -2545,17 +2523,6 @@ mfxStatus VAAPIFEIPAKEncoder::QueryStatus(
         }
     }
     MFX_CHECK(indxSurf != m_statFeedbackCache.size(), MFX_ERR_UNKNOWN);
-
-
-    {
-        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaSyncSurface");
-        vaSts = vaSyncSurface(m_vaDisplay, waitSurface);
-    }
-
-    //  ignore VA_STATUS_ERROR_DECODING_ERROR in encoder
-    if (vaSts == VA_STATUS_ERROR_DECODING_ERROR)
-        vaSts = VA_STATUS_SUCCESS;
-    MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
     VASurfaceStatus surfSts = VASurfaceSkipped;
 


### PR DESCRIPTION
Call of vaSyncSurface looks to be excessive, according to change in AVC encoder, vaMapBuffer perform blocking synchronization and should be enough to get the output data.

Manual runs showed no difference in approaches