### PR TITLE
[SMT] Return back no_bref option to switch off the B-pyramid

### DIFF
--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -231,6 +231,7 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("  -dist         Distance between I- or P- key frames \n"));
     msdk_printf(MSDK_STRING("  -num_ref      Number of reference frames\n"));
     msdk_printf(MSDK_STRING("  -bref         Arrange B frames in B pyramid reference structure\n"));
+    msdk_printf(MSDK_STRING("  -nobref       Do not use B-pyramid (by default the decision is made by library)\n"));
     msdk_printf(MSDK_STRING("  -bpyr         Enable B pyramid\n"));
     msdk_printf(MSDK_STRING("  -CodecProfile          - Specifies codec profile\n"));
     msdk_printf(MSDK_STRING("  -CodecLevel            - Specifies codec level\n"));
@@ -1371,6 +1372,10 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-bref")))
         {
             InputParams.nBRefType = MFX_B_REF_PYRAMID;
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-nobref")))
+        {
+            InputParams.nBRefType = MFX_B_REF_OFF;
         }
         else if(0 == msdk_strcmp(argv[i], MSDK_STRING("-u")))
         {


### PR DESCRIPTION
This option was removed by mistake in one of the previous commits to SMT