### PR TITLE
[h264e] fixed IntraRefresh behavior regression

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -4630,7 +4630,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         mfeParam.MaxNumFrames = numFrames;
         changed = true;
     }
-    if (extOpt2->IntRefType && mfeParam.MaxNumFrames != 1)
+    if (extOpt2->IntRefType && (mfeParam.MaxNumFrames > 1 || mfeParam.MFMode >= MFX_MF_AUTO))
     {
         mfeParam.MaxNumFrames = 1;
         changed = true;


### PR DESCRIPTION
fix regression in IntraRefresh parameters processing when MFE is not enabled.

Signed-off-by: Artem Shaporenko <artem.shaporenko@intel.com>