### PR TITLE
[mpeg2d] fix hang in mpeg2d_stream_corrupter

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2269,6 +2269,8 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
             if (eEXT == ptr[3])
             {
                 sts = AppendBitstream(*out, curr, (mfxU32)(ptr - curr));
+                if (sts == MFX_ERR_NOT_ENOUGH_BUFFER)
+                    MoveBitstreamData(*in, (mfxU32)(ptr - curr)); // huge frame - skip it
                 MFX_CHECK_STS(sts);
                 curr = ptr;
             }


### PR DESCRIPTION
Heavily corrupted stream.
There are so many noise bytes between sequence header and next start code,
so it exceeds frame buffer size, after reentering FrameConstructor does the
same. Added code drops noise bytes in such situation.