### PR TITLE
[VPP] Fix MCTF regression WW23.6 on Open Source

### DIFF
--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -201,7 +201,8 @@
 
 #if MFX_VERSION >= 1026
     #define MFX_ENABLE_MCTF
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1027)
+    // behavior test need extended version on MCTF
     #define MFX_ENABLE_MCTF_EXT // extended MCTF interface
 #endif
 #endif

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -2094,7 +2094,7 @@ typedef struct {
 #endif
 
 #if (MFX_VERSION >= 1026)
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1027)
 /* MCTFTemporalMode */
 enum {
     MFX_MCTF_TEMPORAL_MODE_UNKNOWN  = 0,
@@ -2109,7 +2109,7 @@ enum {
 typedef struct {
     mfxExtBuffer Header;
     mfxU16       FilterStrength;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1027)
     mfxU16       Overlap;               /* tri-state option */
     mfxU32       BitsPerPixelx100k;
     mfxU16       Deblocking;            /* tri-state option */


### PR DESCRIPTION
Update version number to fix MCTF regression on Open Source
MCTF extended need to be enabled to pass behavior test.
Enable MCTF extended for API 1.27

Issue: MDP-43046
Test: beh_vpp_mctf_frame_async