### PR TITLE
[HEVCe FEI]Avoid double init

### DIFF
--- a/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_hw.h
+++ b/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_hw.h
@@ -196,6 +196,8 @@ public:
     virtual mfxStatus Init(mfxVideoParam *par) override
     {
         mfxStatus sts;
+        if (m_pImpl.get() && (m_pImpl->IsInitialized()))
+            return MFX_ERR_UNDEFINED_BEHAVIOR;
         m_pImpl.reset(new H265FeiEncode_HW(&m_core, &sts));
         MFX_CHECK_STS(sts);
         return m_pImpl->Init(par);


### PR DESCRIPTION
H265FeiEncodePlugin::Init(...) - added check that implementation was not
initialized, if so - returns error