### PR TITLE
[h265] Fix decoder hang

### DIFF
--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2017-2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -903,13 +903,12 @@ mfxStatus VideoDECODEH265::DecodeFrameCheck(mfxBitstream *bs,
                 }
             }
 
-            if (!frame && m_pH265VideoDecoder->GetTaskBroker()->IsEnoughForStartDecoding(true) && !m_globalTask)
+            if (!frame)
             {
-                m_globalTask = true;
-            }
-            else
-            {
-                return MFX_WRN_DEVICE_BUSY;
+                if (m_pH265VideoDecoder->GetTaskBroker()->IsEnoughForStartDecoding(true) && !m_globalTask)
+                    m_globalTask = true;
+                else
+                    return MFX_WRN_DEVICE_BUSY;
             }
         }
 


### PR DESCRIPTION
Decoder stucks when DPB is exhausted and submitted slices have
[SliceHeader :: pic_output_flag == 0]

Flow which cause the issue:
1. Submit 1st slice (IDR)
2. There is available data in bitstream, but there is no free frames
in allocator. This is because [async == 1] and for sys. mem an internal
allocator is used. Note, increasing async depth doesn't help, we just
move a little bit further.
3. [DecodeFrame] returns ERR_MORE_SURFACE -> no scheduler task is
created
4. Repeat 2-3 for a couple of following slices, until capacity of
internal allocator (DPB) is exhausted
6. Error above is handled in the following way - if we have enough
data to start 'decoding' (this means we have at least on full AU in
queue) - we create special 'virtual task' (if it was not scheduled yet).
7. The thing is we don't create this 'virtual task' because we have
frames which are 'not outputted' (SliceHeader :: pic_output_flag == 0]

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>