### PR TITLE
[sw brc] Fixed rounding error accumulated on long stream.

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_brc_common.h
+++ b/_studio/mfx_lib/shared/include/mfx_brc_common.h
@@ -1,15 +1,15 @@
 // Copyright (c) 2018 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -149,7 +149,7 @@ protected:
         return m_maxWinBits - GetStep() * GetWindowSize();
     }
 };
- 
+
 #if defined (MFX_ENABLE_H264_VIDEO_ENCODE) || defined (MFX_ENABLE_H265_VIDEO_ENCODE)
 
 #define MIN_RACA 0.25
@@ -179,7 +179,7 @@ public:
     // RC params
     mfxU32 targetbps;
     mfxU32 maxbps;
-    mfxF64 frameRate;    
+    mfxF64 frameRate;
     mfxF64 inputBitsPerFrame;
     mfxF64 maxInputBitsPerFrame;
     mfxU32 maxFrameSizeInBits;
@@ -198,9 +198,9 @@ public:
     bool   bPyr;
 
     //BRC accurancy params
-    mfxF64 fAbPeriodLong;   // number on frames to calculate abberation from target frame 
-    mfxF64 fAbPeriodShort;  // number on frames to calculate abberation from target frame 
-    mfxF64 dqAbPeriod;      // number on frames to calculate abberation from dequant 
+    mfxF64 fAbPeriodLong;   // number on frames to calculate abberation from target frame
+    mfxF64 fAbPeriodShort;  // number on frames to calculate abberation from target frame
+    mfxF64 dqAbPeriod;      // number on frames to calculate abberation from dequant
     mfxF64 bAbPeriod;       // number of frames to calculate abberation from target bitrate
 
     //QP parameters
@@ -297,7 +297,7 @@ public:
     mfxF64    GetBufferDiviation(mfxU32 targetBitrate);
     mfxF64    GetBufferDiviation();
     mfxF64    GetBufferDiviationFactor();
- 
+
 
 
 private:
@@ -312,7 +312,7 @@ private:
 private:
     mfxI32 m_buffSizeInBits;
     mfxI32 m_delayInBits;
-    mfxF64 m_inputBitsPerFrame;    
+    mfxF64 m_inputBitsPerFrame;
     bool   m_bCBR;
 
 };
@@ -342,13 +342,13 @@ struct BRC_Ctx
     mfxU32 LastIQpSetOrder; // Qp of last intra frame
     mfxU32 LastIQpMin; // Qp of last intra frame
     mfxU32 LastIQpSet;      // Qp of last intra frame
-    
+
     mfxU32 LastNonBFrameSize; // encoded frame size of last non B frame (is used for sceneChange)
 
     mfxF64 fAbLong;         // frame abberation (long period)
     mfxF64 fAbShort;        // frame abberation (short period)
     mfxF64 dQuantAb;        // dequant abberation
-    mfxI32 totalDiviation;   // divation from  target bitrate (total)
+    mfxF64 totalDiviation;   // divation from  target bitrate (total)
 
     mfxF64 eRate;               // eRate of last encoded frame, this parameter is used for scene change calculation
     mfxF64 eRateSH;             // eRate of last encoded scene change frame, this parameter is used for scene change calculation
@@ -383,7 +383,7 @@ public:
     mfxStatus Close () {
         //printf("\nFrames skipped: %i \n", m_SkipCount);
         //printf("\nNumber of re-encodes: %i \n", m_ReEncodeCount);
-        m_bInit = false; 
+        m_bInit = false;
         return MFX_ERR_NONE;
     }
     mfxStatus GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl);
@@ -401,7 +401,7 @@ namespace HEVCExtBRC
     inline mfxStatus Init  (mfxHDL pthis, mfxVideoParam* par)
     {
         MFX_CHECK_NULL_PTR1(pthis);
-        return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->Init(par) ;    
+        return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->Init(par) ;
     }
     inline mfxStatus Reset (mfxHDL pthis, mfxVideoParam* par)
     {
@@ -411,12 +411,12 @@ namespace HEVCExtBRC
     inline mfxStatus Close (mfxHDL pthis)
     {
         MFX_CHECK_NULL_PTR1(pthis);
-        return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->Close() ;    
+        return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->Close() ;
     }
     inline mfxStatus GetFrameCtrl (mfxHDL pthis, mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
     {
        MFX_CHECK_NULL_PTR1(pthis);
-       return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->GetFrameCtrl(par,ctrl) ;    
+       return ((MfxHwH265EncodeBRC::ExtBRC*)pthis)->GetFrameCtrl(par,ctrl) ;
     }
     inline mfxStatus Update       (mfxHDL pthis, mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl, mfxBRCFrameStatus* status)
     {
@@ -431,7 +431,7 @@ namespace HEVCExtBRC
         m_BRC.Reset = Reset;
         m_BRC.Close = Close;
         m_BRC.GetFrameCtrl = GetFrameCtrl;
-        m_BRC.Update = Update; 
+        m_BRC.Update = Update;
         return MFX_ERR_NONE;
     }
     inline mfxStatus Destroy(mfxExtBRC & m_BRC)
@@ -445,7 +445,7 @@ namespace HEVCExtBRC
         m_BRC.Reset = 0;
         m_BRC.Close = 0;
         m_BRC.GetFrameCtrl = 0;
-        m_BRC.Update = 0;   
+        m_BRC.Update = 0;
         return MFX_ERR_NONE;
     }
 }

--- a/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
@@ -935,7 +935,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
     mfxF64 e2pe     =  0;
     bool bMaxFrameSizeMode = m_par.maxFrameSizeInBits != 0 &&
         m_par.maxFrameSizeInBits < m_par.inputBitsPerFrame * 2 &&
-        m_ctx.totalDiviation < (mfxI32)(-1)*m_par.inputBitsPerFrame*m_par.frameRate;
+        m_ctx.totalDiviation < (-1)*m_par.inputBitsPerFrame*m_par.frameRate;
 
     if (IS_IFRAME(picType)) {
         e2pe = (m_ctx.eRateSH == 0) ? (BRC_SCENE_CHANGE_RATIO2 + 1) : eRate / m_ctx.eRateSH;
@@ -1252,7 +1252,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             m_avg->UpdateSlidingWindow(bitsEncoded, m_ctx.encOrder, m_ctx.bPanic, bSHStart || IS_IFRAME(picType),frame_par->NumRecode, qpY);
         }
 
-        m_ctx.totalDiviation += (bitsEncoded - (mfxI32)m_par.inputBitsPerFrame);
+        m_ctx.totalDiviation += ((mfxF64)bitsEncoded -m_par.inputBitsPerFrame);
 
         //printf("------------------ %d (%d)) Total diviation %d, old scene %d, bNeedUpdateQP %d, m_ctx.Quant %d, type %d, m_ctx.fAbLong %f m_par.inputBitsPerFrame %f\n", frame_par->EncodedOrder, frame_par->DisplayOrder,m_ctx.totalDiviation, oldScene , bNeedUpdateQP, m_ctx.Quant,picType, m_ctx.fAbLong, m_par.inputBitsPerFrame);
 

--- a/samples/sample_common/include/brc_routines.h
+++ b/samples/sample_common/include/brc_routines.h
@@ -199,7 +199,7 @@ struct BRC_Ctx
     mfxF64 fAbLong;         // avarage frame size (long period)
     mfxF64 fAbShort;        // avarage frame size (short period)
     mfxF64 dQuantAb;        // avarage dequant
-    mfxI32 totalDiviation;   // divation from  target bitrate (total)
+    mfxF64 totalDiviation;   // divation from  target bitrate (total)
 
     mfxF64 eRate;               // eRate of last encoded frame, this parameter is used for scene change calculation
     mfxF64 eRateSH;             // eRate of last encoded scene change frame, this parameter is used for scene change calculation

--- a/samples/sample_common/src/brc_routines.cpp
+++ b/samples/sample_common/src/brc_routines.cpp
@@ -631,7 +631,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
     bool bMaxFrameSizeMode = m_par.maxFrameSizeInBits != 0 &&
         m_par.rateControlMethod == MFX_RATECONTROL_VBR &&
         m_par.maxFrameSizeInBits < m_par.inputBitsPerFrame * 2 &&
-        m_ctx.totalDiviation < (mfxI32)(-1)*m_par.inputBitsPerFrame*m_par.frameRate;
+        m_ctx.totalDiviation < (-1)*m_par.inputBitsPerFrame*m_par.frameRate;
 
     if (picType == MFX_FRAMETYPE_I)
         e2pe = (m_ctx.eRateSH == 0) ? (BRC_SCENE_CHANGE_RATIO2 + 1) : eRate / m_ctx.eRateSH;
@@ -879,7 +879,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             m_avg->UpdateSlidingWindow(bitsEncoded, m_ctx.encOrder, m_ctx.bPanic, bSHStart || picType == MFX_FRAMETYPE_I,frame_par->NumRecode);
         }
 
-        m_ctx.totalDiviation += (bitsEncoded - (mfxI32)m_par.inputBitsPerFrame);
+        m_ctx.totalDiviation += ((mfxF64)bitsEncoded - m_par.inputBitsPerFrame);
 
         //printf("-- %d (%d)) Total diviation %d, old scene %d, bNeedUpdateQP %d, m_ctx.Quant %d, type %d\n", frame_par->EncodedOrder, frame_par->DisplayOrder,m_ctx.totalDiviation, oldScene , bNeedUpdateQP, m_ctx.Quant,picType);
 


### PR DESCRIPTION
MDP-41356

BRC_ctx::totalDiviation is defined as mfxI32,
but target frame size (inputBitsPerFrame) is defined as mfxF64.
So it is rounded before BRC_ctx::totalDiviation calculation.
Error is accumulated on long stream.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>