### PR TITLE
[vpp] Added RGBP format support

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -70,6 +70,9 @@ mfxStatus CheckFrameInfoCommon(mfxFrameInfo  *info, mfxU32 /* codecId */)
     case MFX_FOURCC_YUY2:
     case MFX_FOURCC_RGB3:
     case MFX_FOURCC_RGB4:
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+#endif
     case MFX_FOURCC_P010:
     case MFX_FOURCC_NV16:
     case MFX_FOURCC_P210:
@@ -428,8 +431,9 @@ mfxStatus CheckFramePointers(mfxFrameInfo const& info, mfxFrameData const& data)
         case MFX_FOURCC_NV16:
         case MFX_FOURCC_P010:
         case MFX_FOURCC_P210:        MFX_CHECK(data.Y && data.UV, MFX_ERR_UNDEFINED_BEHAVIOR); break;
-
-
+#ifdef MFX_ENABLE_RGBP
+        case MFX_FOURCC_RGBP:
+#endif
         case MFX_FOURCC_RGB3:        MFX_CHECK(data.R && data.G && data.B, MFX_ERR_UNDEFINED_BEHAVIOR); break;
 
         case MFX_FOURCC_AYUV:
@@ -846,6 +850,9 @@ mfxU32 GetMinPitch(mfxU32 fourcc, mfxU16 width)
         case MFX_FOURCC_P8_TEXTURE:
         case MFX_FOURCC_NV12:
         case MFX_FOURCC_YV12:
+#ifdef MFX_ENABLE_RGBP
+        case MFX_FOURCC_RGBP:
+#endif
         case MFX_FOURCC_NV16:        return width * 1;
 
         case MFX_FOURCC_R16:         return width * 2;
@@ -880,6 +887,9 @@ mfxU8* GetFramePointer(mfxU32 fourcc, mfxFrameData const& data)
         case MFX_FOURCC_RGB3:
         case MFX_FOURCC_RGB4:
         case MFX_FOURCC_BGR4:
+#ifdef MFX_ENABLE_RGBP
+        case MFX_FOURCC_RGBP:
+#endif
         case MFX_FOURCC_ARGB16:
         case MFX_FOURCC_ABGR16:      return MFX_MIN(MFX_MIN(data.R, data.G), data.B); break;
 

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -1009,6 +1009,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
             out->vpp.Out.FourCC != MFX_FOURCC_NV12 &&
             out->vpp.Out.FourCC != MFX_FOURCC_YUY2 &&
             out->vpp.Out.FourCC != MFX_FOURCC_RGB4 &&
+#ifdef MFX_ENABLE_RGBP
+            out->vpp.Out.FourCC != MFX_FOURCC_RGBP &&
+#endif
             out->vpp.Out.FourCC != MFX_FOURCC_P010 &&
             out->vpp.Out.FourCC != MFX_FOURCC_P210 &&
             out->vpp.Out.FourCC != MFX_FOURCC_AYUV &&

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
@@ -1341,6 +1341,9 @@ mfxStatus CheckFrameInfo(mfxFrameInfo* info, mfxU32 request, eMFXHWType /* platf
             if (VPP_OUT == request)
                 return MFX_ERR_INVALID_VIDEO_PARAM;
             break;
+#ifdef MFX_ENABLE_RGBP
+        case MFX_FOURCC_RGBP:
+#endif
         case MFX_FOURCC_A2RGB10:
             // 10bit RGB supported as output format only
             if (VPP_IN == request)

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -210,6 +210,7 @@
 // after THE API is switched to 1.27
 #if MFX_VERSION >= MFX_VERSION_NEXT
     #define MFX_ENABLE_VPP_RUNTIME_HSBC
+    #define MFX_ENABLE_RGBP
 #endif
 
 #endif // _MFX_CONFIG_H_

--- a/_studio/shared/include/mfx_vpp_interface.h
+++ b/_studio/shared/include/mfx_vpp_interface.h
@@ -76,6 +76,9 @@ namespace MfxHwVideoProcessing
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
         MFX_FOURCC_RGB565    ,
 #endif
+#ifdef MFX_ENABLE_RGBP
+        MFX_FOURCC_RGBP      ,
+#endif
         MFX_FOURCC_P8        ,
         MFX_FOURCC_P8_TEXTURE,
         MFX_FOURCC_P010      ,

--- a/_studio/shared/include/mfxstructures-int.h
+++ b/_studio/shared/include/mfxstructures-int.h
@@ -95,7 +95,10 @@ enum
     MFX_FOURCC_YUV422H      = MFX_MAKEFOURCC('4','2','2','H'),
     MFX_FOURCC_YUV422V      = MFX_MAKEFOURCC('4','2','2','V'),
     MFX_FOURCC_YUV444       = MFX_MAKEFOURCC('4','4','4','P'),
-    MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P')
+#if (MFX_VERSION <= 1027)
+    MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P'),
+#else
+#endif
 };
 
 #ifdef __cplusplus

--- a/_studio/shared/include/mfxstructures-int.h
+++ b/_studio/shared/include/mfxstructures-int.h
@@ -86,7 +86,13 @@ enum {
     // AVC Profiles & Levels
     MFX_PROFILE_AVC_HIGH10      =110,
 };
-
+/*
+Some components (samples, JPEG decoder) has used MFX_FOURCC_RGBP already.
+So, for API 1.27 and below "MFX_FOURCC_RGBP" defined inside of msdk library
+and samples.
+Since next version of API (1.28) "MFX_FOURCC_RGBP" should officially
+defined in API "mfxstructures.h".
+*/
 enum
 {
     MFX_FOURCC_IMC3         = MFX_MAKEFOURCC('I','M','C','3'),

--- a/_studio/shared/src/libmfx_allocator.cpp
+++ b/_studio/shared/src/libmfx_allocator.cpp
@@ -190,6 +190,9 @@ mfxStatus mfxDefaultAllocator::AllocFrames(mfxHDL pthis, mfxFrameAllocRequest *r
         nbytes=Pitch*Height2 + (Pitch>>1)*(Height2) + (Pitch>>1)*(Height2);
         break;
     case MFX_FOURCC_RGB3:
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+#endif
         if ((request->Type & MFX_MEMTYPE_FROM_VPPIN) ||
             (request->Type & MFX_MEMTYPE_FROM_VPPOUT) )
         {
@@ -344,6 +347,15 @@ mfxStatus mfxDefaultAllocator::LockFrame(mfxHDL pthis, mfxHDL mid, mfxFrameData 
         ptr->PitchHigh = (mfxU16)((3*ALIGN32(fs->info.Width)) / (1 << 16));
         ptr->PitchLow  = (mfxU16)((3*ALIGN32(fs->info.Width)) % (1 << 16));
         break;
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+        ptr->B = sptr;
+        ptr->G = ptr->B + ptr->Pitch*Height2;
+        ptr->R = ptr->B + 2*ptr->Pitch*Height2;;
+        ptr->PitchHigh = (mfxU16)((3*ALIGN32(fs->info.Width)) / (1 << 16));
+        ptr->PitchLow  = (mfxU16)((3*ALIGN32(fs->info.Width)) % (1 << 16));
+        break;
+#endif
     case MFX_FOURCC_RGB4:
         ptr->B = sptr;
         ptr->G = ptr->B + 1;

--- a/_studio/shared/src/libmfx_core.cpp
+++ b/_studio/shared/src/libmfx_core.cpp
@@ -1386,6 +1386,27 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int c
             MFX_CHECK_STS(sts);
             break;
         }
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+        {
+            mfxU8* ptrSrc = pSrc->Data.B;
+            mfxU8* ptrDst = pDst->Data.B;
+            sts = FastCopy::Copy(ptrDst, dstPitch, ptrSrc, srcPitch, roi, copyFlag);
+            MFX_CHECK_STS(sts);
+
+            ptrSrc = pSrc->Data.G;
+            ptrDst = pDst->Data.G;
+            sts = FastCopy::Copy(ptrDst, dstPitch, ptrSrc, srcPitch, roi, copyFlag);
+            MFX_CHECK_STS(sts);
+
+            ptrSrc = pSrc->Data.R;
+            ptrDst = pDst->Data.R;
+            sts = FastCopy::Copy(ptrDst, dstPitch, ptrSrc, srcPitch, roi, copyFlag);
+            MFX_CHECK_STS(sts);
+
+            break;
+        }
+#endif
 
     case MFX_FOURCC_AYUV:
     case MFX_FOURCC_RGB4:

--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -452,6 +452,9 @@ mfxStatus VAAPIVideoProcessing::QueryCapabilities(mfxVppCaps& caps)
         if (MFX_FOURCC_NV12    == g_TABLE_SUPPORTED_FOURCC[indx] ||
             MFX_FOURCC_YUY2    == g_TABLE_SUPPORTED_FOURCC[indx] ||
             MFX_FOURCC_RGB4    == g_TABLE_SUPPORTED_FOURCC[indx] ||
+#ifdef MFX_ENABLE_RGBP
+            MFX_FOURCC_RGBP    == g_TABLE_SUPPORTED_FOURCC[indx] ||
+#endif
             MFX_FOURCC_A2RGB10 == g_TABLE_SUPPORTED_FOURCC[indx])
             caps.mFormatSupport[g_TABLE_SUPPORTED_FOURCC[indx]] |= MFX_FORMAT_SUPPORT_OUTPUT;
     }
@@ -1037,6 +1040,12 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
     switch (refFourcc)
     {
     case MFX_FOURCC_RGB4:
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+#endif
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    case MFX_FOURCC_RGB565:
+#endif
         m_pipelineParam[0].surface_color_standard = VAProcColorStandardNone;
         ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].input_color_properties.color_range = VA_SOURCE_RANGE_FULL);
         break;
@@ -1051,6 +1060,12 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
     switch (targetFourcc)
     {
     case MFX_FOURCC_RGB4:
+#ifdef MFX_ENABLE_RGBP
+    case MFX_FOURCC_RGBP:
+#endif
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    case MFX_FOURCC_RGB565:
+#endif
         m_pipelineParam[0].output_color_standard = VAProcColorStandardNone;
         ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].output_color_properties.color_range = VA_SOURCE_RANGE_FULL);
         break;

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -94,6 +94,7 @@ enum {
     MFX_FOURCC_YUY2         = MFX_MAKEFOURCC('Y','U','Y','2'),
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
     MFX_FOURCC_RGB565       = MFX_MAKEFOURCC('R','G','B','2'),
+    MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P'),
 #endif
     MFX_FOURCC_RGB3         = MFX_MAKEFOURCC('R','G','B','3'),   /* deprecated */
     MFX_FOURCC_RGB4         = MFX_MAKEFOURCC('R','G','B','4'),   /* ARGB in that order, A channel is 8 MSBs */

--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -99,7 +99,10 @@ enum
     MFX_FOURCC_YUV422H      = MFX_MAKEFOURCC('4','2','2','H'),
     MFX_FOURCC_YUV422V      = MFX_MAKEFOURCC('4','2','2','V'),
     MFX_FOURCC_YUV444       = MFX_MAKEFOURCC('4','4','4','P'),
+#if (MFX_VERSION <= 1027)
     MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P'),
+#else
+#endif
     MFX_FOURCC_I420         = MFX_MAKEFOURCC('I','4','2','0')
 };
 

--- a/samples/sample_common/src/sysmem_allocator.cpp
+++ b/samples/sample_common/src/sysmem_allocator.cpp
@@ -18,6 +18,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 \**********************************************************************************/
 
 #include "sysmem_allocator.h"
+#include "sample_utils.h"
 
 #define MSDK_ALIGN32(X) (((mfxU32)((X)+31)) & (~ (mfxU32)31))
 #define ID_BUFFER MFX_MAKEFOURCC('B','U','F','F')
@@ -142,6 +143,11 @@ mfxStatus SysMemFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData *ptr)
         ptr->R = ptr->B + 2;
         ptr->Pitch = 3 * Width2;
         break;
+    case MFX_FOURCC_RGBP:
+        ptr->G = ptr->B + Width2 * Height2;
+        ptr->R = ptr->B + Width2 * Height2 * 2;
+        ptr->Pitch = Width2;
+        break;
     case MFX_FOURCC_RGB4:
     case MFX_FOURCC_A2RGB10:
         ptr->G = ptr->B + 1;
@@ -246,6 +252,7 @@ mfxStatus SysMemFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFram
         nbytes = 2*Width2*Height2;
         break;
 #endif
+    case MFX_FOURCC_RGBP:
     case MFX_FOURCC_RGB3:
         nbytes = Width2*Height2 + Width2*Height2 + Width2*Height2;
         break;

--- a/samples/sample_common/src/vaapi_allocator.cpp
+++ b/samples/sample_common/src/vaapi_allocator.cpp
@@ -52,6 +52,8 @@ unsigned int ConvertMfxFourccToVAFormat(mfxU32 fourcc)
 #endif
     case MFX_FOURCC_RGB4:
         return VA_FOURCC_ARGB;
+    case MFX_FOURCC_RGBP:
+        return VA_FOURCC_RGBP;
     case MFX_FOURCC_P8:
         return VA_FOURCC_P208;
     case MFX_FOURCC_P010:
@@ -164,6 +166,7 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
                        (VA_FOURCC_R5G6B5 != va_fourcc) &&
 #endif
                        (VA_FOURCC_ARGB   != va_fourcc) &&
+                       (VA_FOURCC_RGBP   != va_fourcc) &&
                        (VA_FOURCC_P208   != va_fourcc) &&
                        (VA_FOURCC_P010   != va_fourcc)))
     {
@@ -217,6 +220,10 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
             else if (fourcc == MFX_FOURCC_A2RGB10)
             {
                 format = VA_RT_FORMAT_RGB32_10BPP;
+            }
+            else if (fourcc == MFX_FOURCC_RGBP)
+            {
+                format = VA_RT_FORMAT_RGBP;
             }
 
             va_res = m_libva->vaCreateSurfaces(m_dpy,
@@ -493,6 +500,16 @@ mfxStatus vaapiFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData *ptr)
                     ptr->G = ptr->B;
                     ptr->R = ptr->B;
                     ptr->A = ptr->B;
+                }
+                else mfx_res = MFX_ERR_LOCK_MEMORY;
+                break;
+            case VA_FOURCC_RGBP:
+                if (mfx_fourcc == MFX_FOURCC_RGBP)
+                {
+                    ptr->Pitch = (mfxU16)vaapi_mid->m_image.pitches[0];
+                    ptr->B = pBuffer + vaapi_mid->m_image.offsets[0];
+                    ptr->G = pBuffer + vaapi_mid->m_image.offsets[1];
+                    ptr->R = pBuffer + vaapi_mid->m_image.offsets[2];
                 }
                 else mfx_res = MFX_ERR_LOCK_MEMORY;
                 break;

--- a/samples/sample_vpp/src/sample_vpp_parser.cpp
+++ b/samples/sample_vpp/src/sample_vpp_parser.cpp
@@ -87,7 +87,7 @@ msdk_printf(MSDK_STRING("   [-dcrY  y]                  - cropY  of dst video (d
 msdk_printf(MSDK_STRING("   [-dcrW  w]                  - cropW  of dst video (def: width)\n"));
 msdk_printf(MSDK_STRING("   [-dcrH  h]                  - cropH  of dst video (def: height)\n"));
 msdk_printf(MSDK_STRING("   [-df  frameRate]            - frame rate of dst video (def: 30.0)\n"));
-msdk_printf(MSDK_STRING("   [-dcc format]               - format (FourCC) of dst video (def: nv12. support i420|nv12|yuy2|rgb4|yv12|ayuv)\n"));
+msdk_printf(MSDK_STRING("   [-dcc format]               - format (FourCC) of dst video (def: nv12. support i420|nv12|yuy2|rgb4|rgbp|yv12|ayuv)\n"));
 msdk_printf(MSDK_STRING("   [-dbitshift 0|1]            - shift data to right or keep it the same way as in Microsoft's P010\n"));
 msdk_printf(MSDK_STRING("   [-dbitdepthluma value]      - shift luma channel to left to \"16 - value\" bytes\n"));
 msdk_printf(MSDK_STRING("   [-dbitdepthchroma value]    - shift chroma channel to left to \"16 - value\" bytes\n"));
@@ -338,6 +338,10 @@ mfxU32 Str2FourCC( msdk_char* strInput )
     else if ( 0 == msdk_stricmp(strInput, MSDK_STRING("rgb4")) )
     {
         fourcc = MFX_FOURCC_RGB4;
+    }
+    else if ( 0 == msdk_stricmp(strInput, MSDK_STRING("rgbp")) )
+    {
+        fourcc = MFX_FOURCC_RGBP;
     }
     else if ( 0 == msdk_stricmp(strInput, MSDK_STRING("yuy2")) )
     {

--- a/samples/sample_vpp/src/sample_vpp_utils.cpp
+++ b/samples/sample_vpp/src/sample_vpp_utils.cpp
@@ -82,6 +82,8 @@ static
         return MSDK_STRING("RGB3");
     case MFX_FOURCC_RGB4:
         return MSDK_STRING("RGB4");
+    case MFX_FOURCC_RGBP:
+        return MSDK_STRING("RGBP");
     case MFX_FOURCC_YUV400:
         return MSDK_STRING("YUV400");
     case MFX_FOURCC_YUV411:
@@ -1829,6 +1831,28 @@ mfxStatus CRawVideoWriter::WriteFrame(
         for(i = 0; i < h; i++)
         {
             MSDK_CHECK_NOT_EQUAL( fwrite(ptr + i * pitch, 1, 4*w, m_fDst), 4u*w, MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+    }
+    else if (pInfo->FourCC == MFX_FOURCC_RGBP)
+    {
+        MSDK_CHECK_POINTER(pData->R, MFX_ERR_NOT_INITIALIZED);
+        MSDK_CHECK_POINTER(pData->G, MFX_ERR_NOT_INITIALIZED);
+        MSDK_CHECK_POINTER(pData->B, MFX_ERR_NOT_INITIALIZED);
+
+        ptr = pData->R + pInfo->CropX + pInfo->CropY * pitch;
+        for(i = 0; i < h; i++)
+        {
+            MSDK_CHECK_NOT_EQUAL( fwrite(ptr + i * pitch, 1, w, m_fDst), w, MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+        ptr = pData->G + pInfo->CropX + pInfo->CropY * pitch;
+        for(i = 0; i < h; i++)
+        {
+            MSDK_CHECK_NOT_EQUAL( fwrite(ptr + i * pitch, 1, w, m_fDst), w, MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+        ptr = pData->B + pInfo->CropX + pInfo->CropY * pitch;
+        for(i = 0; i < h; i++)
+        {
+            MSDK_CHECK_NOT_EQUAL( fwrite(ptr + i * pitch, 1, w, m_fDst), w, MFX_ERR_UNDEFINED_BEHAVIOR);
         }
     }
     else if (pInfo->FourCC == MFX_FOURCC_AYUV)


### PR DESCRIPTION
- This is 8 bit planar format without alpha channel
- RGBP supported for VPP output only
- Main usage case is NV12->RGBP conversion
- Decoders and encoders do not work with RGBP format!

Signed-off-by: Andrey Larionov <andrey.larionov@intel.com>