### PR TITLE
[cmake] Add right location for sha execution

### DIFF
--- a/builder/FindFunctions.cmake
+++ b/builder/FindFunctions.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2018 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -357,6 +357,7 @@ function( git_describe git_commit )
     COMMAND git rev-parse --short HEAD
     OUTPUT_VARIABLE git_commit
     OUTPUT_STRIP_TRAILING_WHITESPACE
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
   if( NOT ${git_commit} MATCHES "^$" )
     set( git_commit ".${git_commit}" PARENT_SCOPE )


### PR DESCRIPTION
This commit will fix adding of sha for files:
`mediasdk_file_version: 1.18.6.21.27c61fb`

Fix requested by @vshalimo 