### PR TITLE
[mpeg2d] check when BITSTREAM_COMPLETE_FRAME is set

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2327,6 +2327,9 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
 
                     MoveBitstreamData(*in, len);
 
+                    if (len < (8-4) + 9) // (min pic. header - startcode) + min pic.coding ext.
+                        return MFX_ERR_NOT_ENOUGH_BUFFER; // to start again with next picture
+
                     m_fcState.picStart = 0;
                     m_fcState.picHeader = FcState::NONE;
                     memset(m_last_bytes, 0, NUM_REST_BYTES);


### PR DESCRIPTION
When BITSTREAM_COMPLETE_FRAME flag is set for input,
decoder trusts input too much, but later it works with
short input as it is end of stream.
In added check if input data size is less than picture
header and picture coding extension, it is dropped.
And finally ERR_MORE_DATA is returned from DecodeFrameAsync.