### PR TITLE
[sample_hevc_fei_abr] Refactored design of LA BRC

### DIFF
--- a/samples/sample_hevc_fei_abr/include/abr_brc.h
+++ b/samples/sample_hevc_fei_abr/include/abr_brc.h
@@ -22,17 +22,12 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include "task.h"
 #include "brc_routines.h"
 
-#include <cmath>
 #include <algorithm>
-#include <vector>
-
-#ifdef DEBUG_OUTPUT
-#include<cstdio>
-#endif
+#include <mutex>
 
 namespace
 {
-    // Magic part
+    // LA BRC auxiliary functions
     constexpr mfxU32 BRC3_RATE_BLUR_LENGTH    = 10;
     constexpr mfxF64 BRC3_GAUSS_VARIANCE      = 160.0;
     constexpr mfxF64 BRC3_BLUR_STOP           = 0.001;
@@ -47,37 +42,22 @@ namespace
         57.018, 64.000, 71.838, 80.635, 90.510, 101.594, 114.035, 128.000, 143.675, 161.270, 181.019, 203.187, 228.070
     };
 
-#if 0
-    mfxU8 QStep2QpCeil(mfxF64 qstep) // QSTEP[qp] > qstep, may return qp=52
-    {
-        return mfxU8(std::lower_bound(QSTEP, QSTEP + 52, qstep) - QSTEP);
-    }
-#endif
-
-    mfxU8 QStep2QpFloor(mfxF64 qstep) // QSTEP[qp] <= qstep, return 0<=qp<=51
+    inline mfxU8 QStep2QpFloor(mfxF64 qstep) // QSTEP[qp] <= qstep, return 0<=qp<=51
     {
         mfxU8 qp = mfxU8(std::upper_bound(QSTEP, QSTEP + 52, qstep) - QSTEP);
         return qp > 0 ? qp - 1 : 0;
     }
 
-    mfxU8 QStep2QpNearest(mfxF64 qstep) // return 0<=qp<=51
+    inline mfxU8 QStep2QpNearest(mfxF64 qstep) // return 0<=qp<=51
     {
         mfxU8 qp = QStep2QpFloor(qstep);
         return (qp == 51 || qstep < (QSTEP[qp] + QSTEP[qp + 1]) / 2) ? qp : qp + 1;
     }
 
-    mfxF64 Qp2QStep(mfxU8 qp)
+    inline mfxF64 Qp2QStep(mfxU8 qp)
     {
         return QSTEP[std::min(mfxU8(51), qp)];
     }
-
-#if 0
-    mfxF64 fQP2Qstep(mfxF64 fqp)
-    {
-        return std::pow(2.0, (fqp - 4.0) / 6.0);
-    }
-#endif
-
 }
 
 // BRC interface
@@ -92,7 +72,7 @@ public:
 
     virtual ~BRC() {}
 
-    virtual void PreEnc(HevcTaskDSO& task /*FrameStatData& statData*/) = 0;
+    virtual void PreEnc(FrameStatData& statData) = 0;
 
     virtual void Report(mfxU32 dataLength) = 0;
 
@@ -101,28 +81,30 @@ public:
     virtual void SubmitNewStat(FrameStatData& stat) = 0;
 };
 
+/*
+    This is not canonical way of using SW BRC, in sample_encode correct approach is implemented.
+    Code below gives for better understanding how actually SW BRC interface works and shows a way
+    how to use BRC without letting MSDK lib know it.
+*/
 class SW_BRC : public BRC
 {
 public:
     SW_BRC(mfxVideoParam const & video, mfxU16 TargetKbps)
     {
-        //prepare mfxVideoParam for BRC
+        //prepare mfxVideoParam for BRC Init
         mfxVideoParam tmp = video;
         tmp.mfx.RateControlMethod = MFX_RATECONTROL_VBR;
         tmp.mfx.TargetKbps        = TargetKbps;
 
-        MSDK_ZERO_MEMORY(m_BRCPar);
-        MSDK_ZERO_MEMORY(m_BRCCtrl);
-
         mfxExtCodingOption CO;
-        MSDK_ZERO_MEMORY(CO);
+        Zero(CO);
 
         CO.Header.BufferId = MFX_EXTBUFF_CODING_OPTION;
         CO.Header.BufferSz = sizeof(mfxExtCodingOption);
         CO.NalHrdConformance = MFX_CODINGOPTION_OFF;
 
         mfxExtBuffer *ext = &CO.Header;
-        tmp.ExtParam = &ext;
+        tmp.ExtParam    = &ext;
         tmp.NumExtParam = 1;
 
         mfxStatus sts = m_SW_BRC.Init(&tmp);
@@ -137,36 +119,24 @@ public:
 
     ~SW_BRC() {}
 
-    void PreEnc(HevcTaskDSO& task /*FrameStatData& statData*/)
+    virtual void PreEnc(FrameStatData& statData) override
     {
-        FrameStatData& statData = task.m_statData;
-
-        MSDK_ZERO_MEMORY(m_BRCPar);
-        MSDK_ZERO_MEMORY(m_BRCCtrl);
+        Zero(m_BRCPar);
+        Zero(m_BRCCtrl);
 
         m_BRCPar.EncodedOrder = statData.EncodedOrder;
         m_BRCPar.DisplayOrder = statData.DisplayOrder;
-        m_BRCPar.FrameType    = statData.frame_type;
+        m_BRCPar.FrameType    = statData.FrameType;
 
         mfxStatus sts = m_SW_BRC.GetFrameCtrl(&m_BRCPar, &m_BRCCtrl);
         if (MFX_ERR_NONE != sts)
             throw mfxError(sts, "m_SW_BRC.GetFrameCtrl failed");
 
         m_curQp = m_BRCCtrl.QpY;
-
-#ifdef DEBUG_OUTPUT
-        std::cout << std::endl << std::endl << "Frame #" << task.m_statData.DisplayOrder << std::endl;
-        std::cout << "initial qp:   " << mfxI32(task.m_statData.qp) << "    qp set:    " << mfxI32(m_curQp) << std::endl;
-        std::cout << "initial size: " << task.m_statData.frame_size << " result size: ";
-#endif
     }
 
-    void Report(mfxU32 dataLength)
+    virtual void Report(mfxU32 dataLength) override
     {
-#ifdef DEBUG_OUTPUT
-        std::cout << dataLength << std::endl;
-#endif
-
         m_BRCPar.CodedFrameSize = dataLength;
 
         mfxBRCFrameStatus bsts;
@@ -178,7 +148,7 @@ public:
             throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "m_SW_BRC.Update failed. Re encode is not supported");
     }
 
-    mfxU8 GetQP()
+    virtual mfxU8 GetQP() override
     {
         return m_curQp;
     }
@@ -187,29 +157,231 @@ public:
 
 private:
     ExtBRC m_SW_BRC;
-    mfxU8  m_curQp         = 0xff;
-    mfxU64 m_BitsEncoded   = 0;
-    mfxF64 m_TargetBitrate = 0.0; // it is bits per frame, actually
-    mfxU32 m_curFrame      = 0;
+    mfxU8  m_curQp = 0xff;
 
     mfxBRCFrameParam m_BRCPar;
     mfxBRCFrameCtrl  m_BRCCtrl;
 };
 
+class LA_Stat_Queue
+{
+public:
+    LA_Stat_Queue(mfxU16 la_depth = 100, mfxU16 lb_depth = 100, mfxU16 adpt_length = 100)
+        : m_LookAheadDepth(la_depth)
+        , m_LookBackDepth(lb_depth)
+        , m_AdaptationLength(adpt_length)
+        , m_SizeLimit(1 + std::max(m_LookBackDepth, m_AdaptationLength) + m_LookAheadDepth)
+    {
+        for (mfxU32 j = 1; j < BRC3_RATE_BLUR_LENGTH; ++j)
+        {
+            m_normFactors[j - 1] = std::exp(-mfxF64(j*j) / BRC3_GAUSS_VARIANCE);
+        }
+    }
+
+    void Add(FrameStatData& stat)
+    {
+        m_frameStatData.emplace_back(std::move(stat));
+
+        // Update pixel counters for reference frames
+        for (auto fo_amount : m_frameStatData.back().NumPixelsPredictedFromRef)
+        {
+            auto it = std::find_if(std::begin(m_frameStatData), std::end(m_frameStatData),
+                        [fo_amount](FrameStatData& dat) { return dat.DisplayOrder == fo_amount.first; });
+
+            if (it != std::end(m_frameStatData))
+            {
+                it->NPixelsPropagated += fo_amount.second;
+            }
+        }
+
+        if (m_frameStatData.size() > m_SizeLimit)
+        {
+            RemoveLast();
+        }
+
+        m_DistortionAccumulated += m_frameStatData.back().VisualDistortion;
+    }
+
+    void StartNewFrameProcessing()
+    {
+        ++m_curIndex;
+
+        // Store old indexes to detect window bound change
+        mfxU16 lb_old = m_lbIndex, al_old = m_alIndex;
+
+        m_lbIndex = std::max(0, mfxI32(m_curIndex) - mfxI32(m_LookBackDepth));
+        m_alIndex = std::max(0, mfxI32(m_curIndex) - mfxI32(m_AdaptationLength));
+
+        // Calculate transitive propagation of current frame pixels
+
+        // How many pixels were directly propagated to another frames (+1.0 to guarantee positiveness)
+        m_frameStatData[m_curIndex].NPixelsTransitivelyPropagated = 1.0 + mfxF64(m_frameStatData[m_curIndex].NPixelsPropagated) / m_frameStatData[m_curIndex].NPixelsInFrame;
+
+        // Go through future frames and incorporate indirect pixels influence by adding weighted sum which is:
+        // share_of_directly_predicted_pixels_from_frame__m_frameStatData[m_curIndex] * total_propagated_pixels_of_frame__m_frameStatData[i] / amount_of_pixels_in_frame
+        for (mfxU32 i = m_curIndex + 1; i < m_frameStatData.size(); ++i)
+        {
+            if (m_frameStatData[i].Contains(m_frameStatData[m_curIndex].DisplayOrder))
+            {
+                m_frameStatData[m_curIndex].NPixelsTransitivelyPropagated +=
+                    (m_frameStatData[i].ShareOfPredictedPixelsFromRef[m_frameStatData[m_curIndex].DisplayOrder] * m_frameStatData[i].NPixelsPropagated) / m_frameStatData[i].NPixelsInFrame;
+            }
+        }
+
+        // Precalculate temporary values of NPixelsTransitivelyPropagated. We can't guarantee correct values for some of them near the end of LA window but it doesn't harm the algorithm much
+        m_PixelsWeightedPropagation_tmp = 0.0;
+        for (mfxU32 i = m_curIndex + 1; i < m_frameStatData.size(); ++i)
+        {
+            m_frameStatData[i].NPixelsTransitivelyPropagated = 1.0 + mfxF64(m_frameStatData[i].NPixelsPropagated) / m_frameStatData[i].NPixelsInFrame;
+
+            for (mfxU32 j = i + 1; j < m_frameStatData.size(); ++j)
+            {
+                if (m_frameStatData[j].Contains(m_frameStatData[i].DisplayOrder))
+                {
+                    m_frameStatData[i].NPixelsTransitivelyPropagated +=
+                        (m_frameStatData[j].ShareOfPredictedPixelsFromRef[m_frameStatData[i].DisplayOrder] * m_frameStatData[j].NPixelsPropagated) / m_frameStatData[j].NPixelsInFrame;
+                }
+            }
+            m_PixelsWeightedPropagation_tmp += m_frameStatData[i].NPixelsTransitivelyPropagated;
+        }
+
+        m_PixelsWeightedPropagation += m_frameStatData[m_curIndex].NPixelsTransitivelyPropagated;
+
+        if (m_curIndex)
+        {
+            // Update counters if window is shifted - remove frame which falls out of window
+            if (lb_old != m_lbIndex)
+            {
+                m_DistortionAccumulated     -= m_frameStatData[lb_old].VisualDistortion;
+                m_PixelsWeightedPropagation -= m_frameStatData[lb_old].NPixelsTransitivelyPropagated;
+                m_BitsEncodedAccumulated    -= m_frameStatData[lb_old].BitsEncoded;
+            }
+
+            if (al_old != m_alIndex)
+            {
+                if (m_frameStatData.front().FrameType & (MFX_FRAMETYPE_I | MFX_FRAMETYPE_P))
+                {
+                    m_BitsPredictedAccumulatedIP -= m_frameStatData[al_old].BitsPredicted;
+                    m_BitsEncodedAccumulatedIP   -= m_frameStatData[al_old].BitsEncoded;
+                }
+                else
+                {
+                    m_BitsPredictedAccumulatedB -= m_frameStatData[al_old].BitsPredicted;
+                    m_BitsEncodedAccumulatedB   -= m_frameStatData[al_old].BitsEncoded;
+                }
+            }
+
+            m_BitsEncodedAccumulated += m_frameStatData[m_curIndex - 1].BitsEncoded;
+
+            // Update counter with size of recently encoded frame
+            if (m_frameStatData[m_curIndex - 1].FrameType & (MFX_FRAMETYPE_I | MFX_FRAMETYPE_P))
+            {
+                m_BitsPredictedAccumulatedIP += m_frameStatData[m_curIndex - 1].BitsPredicted;
+                m_BitsEncodedAccumulatedIP   += m_frameStatData[m_curIndex - 1].BitsEncoded;
+            }
+            else
+            {
+                m_BitsPredictedAccumulatedB  += m_frameStatData[m_curIndex - 1].BitsPredicted;
+                m_BitsEncodedAccumulatedB    += m_frameStatData[m_curIndex - 1].BitsEncoded;
+            }
+        }
+    }
+
+    FrameStatData& GetCurrentStatData()
+    {
+        return m_frameStatData[m_curIndex];
+    }
+
+    mfxU32 GetCurrentIndex()
+    {
+        return m_curIndex;
+    }
+
+    FrameStatData& operator[] (size_t i)
+    {
+        return m_frameStatData[i];
+    }
+
+    void CalcScaledQsteps(mfxF64 scale);
+
+    mfxF64 GetBitrateAdjustmentRatio(mfxU32 frameType);
+
+    void CalcComplexities();
+
+    mfxF64 CalcBitrate();
+
+private:
+
+    void RemoveLast()
+    {
+        if (m_lbIndex <= m_alIndex)
+        {
+            // Update accumulated values
+            m_DistortionAccumulated     -= m_frameStatData.front().VisualDistortion;
+            m_PixelsWeightedPropagation -= m_frameStatData.front().NPixelsTransitivelyPropagated;
+            m_BitsEncodedAccumulated    -= m_frameStatData.front().BitsEncoded;
+        }
+
+        if (m_alIndex <= m_lbIndex)
+        {
+            // Update accumulators for Predicted / Encoded bits
+            if (m_frameStatData.front().FrameType & (MFX_FRAMETYPE_I | MFX_FRAMETYPE_P))
+            {
+                m_BitsPredictedAccumulatedIP -= m_frameStatData.front().BitsPredicted;
+                m_BitsEncodedAccumulatedIP   -= m_frameStatData.front().BitsEncoded;
+            }
+            else
+            {
+                m_BitsPredictedAccumulatedB  -= m_frameStatData.front().BitsPredicted;
+                m_BitsEncodedAccumulatedB    -= m_frameStatData.front().BitsEncoded;
+            }
+        }
+
+        m_frameStatData.pop_front();
+        --m_curIndex;
+
+        // Update LookBack and Adaptation regions starting indexes
+        m_lbIndex = std::max(0, mfxI32(m_curIndex) - mfxI32(m_LookBackDepth));
+        m_alIndex = std::max(0, mfxI32(m_curIndex) - mfxI32(m_AdaptationLength));
+    }
+
+    std::deque<FrameStatData> m_frameStatData;
+
+    mfxU16 m_LookAheadDepth   = 100; // Frames to look ahead
+    mfxU16 m_LookBackDepth    = 100; // Frames to take into account from past (use already fixed statistics)
+    mfxU16 m_AdaptationLength = 100; // Frames from past to calculate adaptation ratio
+
+    mfxU16 m_SizeLimit        = 0;
+    mfxI16 m_curIndex         = -1;// Current frame index
+    mfxU16 m_lbIndex          = 0; // Starting index for LookBack   region
+    mfxU16 m_alIndex          = 0; // Starting index for Adaptation region
+
+    mfxF64 m_normFactors[BRC3_RATE_BLUR_LENGTH - 1]; // Half of Gaussian blurring kernel
+
+    // Bit counters for bitrate adjustment which use Adjustment window
+    mfxU64 m_BitsPredictedAccumulatedIP = 0;
+    mfxU64 m_BitsEncodedAccumulatedIP   = 0;
+    mfxU64 m_BitsPredictedAccumulatedB  = 0;
+    mfxU64 m_BitsEncodedAccumulatedB    = 0;
+
+    // Bit counter for bitrate calculation which use LookBack window
+    mfxU64 m_BitsEncodedAccumulated     = 0;
+
+    // Accumulator for Distortion
+    mfxF64 m_DistortionAccumulated      = 0.0;
+
+    // Frames which propagates more pixels should be encoded with better quality, because for such frames quality changes propagates more
+    mfxF64 m_PixelsWeightedPropagation     = 0.0; // Accumulated pixel propagation
+    mfxF64 m_PixelsWeightedPropagation_tmp = 0.0; // Accumulated pixel propagation for future frames (contains not final values)
+};
+
 class LA_BRC : public BRC
 {
 public:
-    LA_BRC(mfxVideoParam const & video, mfxU16 TargetKbps, mfxU16 la_depth = 100, msdk_char* yuv_file = nullptr)
-        : m_LookAheadDepth(la_depth)
-        , m_TargetBitrate(mfxF64(1000 * TargetKbps * video.mfx.FrameInfo.FrameRateExtD) / video.mfx.FrameInfo.FrameRateExtN)
+    LA_BRC(mfxVideoParam const & video, mfxU16 TargetKbps, mfxU16 la_depth = 100, mfxU16 lb_depth = 100, mfxU16 adpt_length = 100)
+        : m_TargetBitrate(mfxF64(1000 * TargetKbps * video.mfx.FrameInfo.FrameRateExtD) / video.mfx.FrameInfo.FrameRateExtN)
+        , m_frameStatQueue(la_depth, lb_depth, adpt_length)
     {
-        /*
-        for (mfxU32 j = 1; j < BRC3_RATE_BLUR_LENGTH; ++j)
-        {
-            m_normFactors[j - 1] = exp(-(mfxF64)j*j / BRC3_GAUSS_VARIANCE);
-        }*/
-
-        m_frameStatData.reserve(m_LookAheadDepth);
     }
 
     LA_BRC(LA_BRC const&)            = delete;
@@ -219,51 +391,40 @@ public:
 
     ~LA_BRC() {}
 
-    void PreEnc(HevcTaskDSO& task /*FrameStatData& statData*/);
+    virtual void PreEnc(FrameStatData& /*statData*/) override;
 
-    void Report(mfxU32 dataLength);
+    virtual void Report(mfxU32 dataLength) override;
 
-    mfxU8 GetQP()
+    virtual mfxU8 GetQP() override
     {
         return m_curQp;
     }
 
-    void SubmitNewStat(FrameStatData& stat)
+    virtual void SubmitNewStat(FrameStatData& stat) override
     {
-        // Fill some additional information
-        stat.propagation = 1.0 - std::pow(stat.share_intra, BRC3_PROPAGATION_EXPONENT);
-        stat.qstep0      = Qp2QStep(stat.qp);
-        stat.complexity0 = stat.qstep0*stat.frame_size;
+        queue_mutex.lock();
 
-        m_frameStatData.push_back(stat);
+        // Fill some additional information
+        stat.Propagation        = 1.0 - std::pow(stat.ShareIntra, BRC3_PROPAGATION_EXPONENT);
+        stat.QstepOriginal      = Qp2QStep(stat.QP);
+        stat.ComplexityOriginal = stat.QstepOriginal*stat.FrameSize;
+
+        m_frameStatQueue.Add(stat);
+
+        queue_mutex.unlock();
     }
 
 private:
-    mfxU16 m_LookAheadDepth = 100;
-    mfxU8  m_curQp          = 0xff;
-    mfxF64 m_avMSE          = 0.0;
-    mfxF64 m_TargetBitrate  = 0.0; // it is bits per frame, actually
-    mfxU32 m_curFrame       = 0;
+    mfxU8  m_curQp         = 0xff;
+    mfxF64 m_TargetBitrate = 0.0; // bits per frame
 
-#ifdef SEPARATE_IP_B_PROCESSING
-    mfxU64 m_IP_BitsEncoded   = 0;
-    mfxU64 m_IP_BitsPredicted = 0;
+    LA_Stat_Queue m_frameStatQueue;
 
-    mfxU64 m_B_BitsEncoded    = 0;
-    mfxU64 m_B_BitsPredicted  = 0;
-#else
-    mfxU64 m_BitsEncoded   = 0;
-    mfxU64 m_BitsPredicted = 0;
-#endif
-
-    //mfxF64 m_normFactors[BRC3_RATE_BLUR_LENGTH - 1];
-
-    std::vector<FrameStatData> m_frameStatData;
+    // To protect LA queue from pushing / pulling from different threads
+    std::mutex queue_mutex;
 
     // Update internal state with new frame
-    void UpdateStatData(mfxU32 frame_number);
-
-    bool PossibleEncodeAsIs(mfxU32 start_index = 0);
+    void UpdateStatData();
 };
 
 #endif // __ABR_BRC_H__

--- a/samples/sample_hevc_fei_abr/include/fei_utils.h
+++ b/samples/sample_hevc_fei_abr/include/fei_utils.h
@@ -79,7 +79,7 @@ public:
     {
         m_pOutSurfPool = sp;
     }
-    virtual mfxStatus SetBufferAllocator(std::shared_ptr<FeiBufferAllocator> bufferAlloc)
+    virtual mfxStatus SetBufferAllocator(std::shared_ptr<FeiBufferAllocator> & bufferAlloc)
     {
         return MFX_ERR_UNSUPPORTED;
     }

--- a/samples/sample_hevc_fei_abr/include/hevc_fei_encode.h
+++ b/samples/sample_hevc_fei_abr/include/hevc_fei_encode.h
@@ -46,7 +46,7 @@ public:
             return static_cast<BRC*>(new SW_BRC(video_param, brc_params.TargetKbps));
             break;
         case LOOKAHEAD:
-            return static_cast<BRC*>(new LA_BRC(video_param, brc_params.TargetKbps, brc_params.LookAheadDepth));
+            return static_cast<BRC*>(new LA_BRC(video_param, brc_params.TargetKbps, brc_params.LookAheadDepth, brc_params.LookBackDepth, brc_params.AdaptationLength));
             break;
         case NONE:
         default:

--- a/samples/sample_hevc_fei_abr/include/sample_hevc_fei_defs.h
+++ b/samples/sample_hevc_fei_abr/include/sample_hevc_fei_defs.h
@@ -63,11 +63,22 @@ enum BRC_TYPE
     MSDKSW    = 2
 };
 
+enum DIST_EST_ALGO
+{
+    MSE = 0, // Mean Squared Error
+    NNZ = 1, // Number of Non-Zero transform coefficients
+    SSC = 2  // Sum of Squared Coefficients
+};
+
 struct sBrcParams
 {
-    BRC_TYPE eBrcType     = NONE; // bitrate control type
-    mfxU16 TargetKbps     = 0;    // valid if VBR set on
-    mfxU16 LookAheadDepth = 0;    // valid if VBR set on
+    BRC_TYPE eBrcType       = NONE; // bitrate control type
+    mfxU16 TargetKbps       = 0;    // valid if BRC used
+    // Following controls are valid for LA BRC
+    mfxU16 LookAheadDepth   = 0;    // Frames to Look Ahead
+    mfxU16 LookBackDepth    = 0;    // Frames to take into account from past
+    mfxU16 AdaptationLength = 0;    // Frames from past to compute bitrate adjustment ratio
+    DIST_EST_ALGO eAlgType  = NNZ;  // Algorithm to estimate Distortion
 
     msdk_char strYUVFile[MSDK_MAX_FILENAME_LEN] = {0}; // YUV file for MSE calculation
 };
@@ -176,8 +187,8 @@ template<class T, class U> inline void Copy(T & dst, U const & src)
     MSDK_MEMCPY(&dst, &src, sizeof(dst));
 }
 
-template<class T> inline void Zero(std::vector<T> & vec)  { memset(vec.data(), 0, sizeof(T) * vec.size()); }
-template<class T> inline void Zero(T * first, size_t cnt) { memset(first, 0, sizeof(T) * cnt); }
+template<class T> inline void Zero(std::vector<T> & vec)  { std::fill(std::begin(vec), std::end(vec), 0); }
+template<class T> inline void Zero(T * first, size_t cnt) { std::fill(first, first + cnt, 0); }
 template<class T> inline void Fill(T & obj, int val) { memset(&obj, val, sizeof(obj)); }
 template<class T> inline void Zero(T & obj) { Fill(obj, 0); }
 template<class T> inline T Clip3(T min, T max, T x) { return std::min(std::max(min, x), max); }

--- a/samples/sample_hevc_fei_abr/include/task.h
+++ b/samples/sample_hevc_fei_abr/include/task.h
@@ -21,38 +21,70 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #define __HEVC_FEI_ABR_TASK__
 
 #include "buffer_pool.h"
+#include "base_allocator.h"
+
 #include <queue>
 #include <cmath>
-
-//#define DEBUG_OUTPUT
-
-#ifdef DEBUG_OUTPUT
-#include <cstdio>
-#endif
-#include "base_allocator.h"
+#include <map>
 
 struct FrameStatData
 {
-    mfxU32 EncodedOrder   = 0xffffffff;
-    mfxU32 DisplayOrder   = 0xffffffff;
-    mfxU8  qp             = 0xff;
-    mfxF64 qstep0         = -1.0;
-    mfxF64 qstep          = -1.0;
-    mfxU16 frame_type     = MFX_FRAMETYPE_UNKNOWN;
-    mfxI32 poc            = -100;
-    //mfxU32 num_intra      = 0;
-    mfxF64 share_intra    = 0.0;
-    mfxF64 propagation    = 0.0;
-    //mfxU32 num_inter      = 0;
-    //mfxF64 share_inter    = 0.0;
-    //mfxU32 num_skip       = 0;
-    //mfxF64 share_skip     = 0.0;
-    mfxU32 frame_size     = 0;
-    //mfxF64 psnrY          = 0.0;
-    mfxF64 mseY           = 0.0;
-    mfxF64 complexity0    = 0.0;
-    mfxF64 complexity     = 0.0;
-    mfxF64 predicted_size = 0.0;
+    mfxU32 EncodedOrder                  = 0xffffffff;
+    mfxU32 DisplayOrder                  = 0xffffffff;
+    mfxU8  QP                            = 0xff;
+    mfxF64 QstepOriginal                 = -1.0;
+    mfxF64 QstepCalculated               = -1.0;
+    mfxU16 FrameType                     = MFX_FRAMETYPE_UNKNOWN;
+    mfxI32 POC                           = -100;
+    mfxF64 ShareIntra                    = 0.0;
+    mfxF64 Propagation                   = 0.0;
+    mfxU32 FrameSize                     = 0;
+    mfxF64 VisualDistortion              = 0.0; // MSE or any approximation like number of nonzero coefficients
+    mfxF64 ComplexityOriginal            = 0.0;
+    mfxF64 ComplexitySmoothed            = 0.0;
+
+    mfxU32 NPixelsPropagated             = 0;
+    mfxF64 NPixelsTransitivelyPropagated = 1.0;
+    mfxU32 NPixelsInFrame                = 0;
+
+    mfxU64 BitsEncoded                   = 0;
+    mfxU64 BitsPredicted                 = 0;
+
+    // Map of FrameDisplayOrder <=> NumOfPixels.
+    // Stores amount of pixels predicted FROM reference frame.
+    std::map<mfxU32, mfxU32> NumPixelsPredictedFromRef;
+    // Map of FrameDisplayOrder <=> ShareOfPixels.
+    // Shows share of INTER pixels predicted FROM reference frame.
+    std::map<mfxU32, mfxF64> ShareOfPredictedPixelsFromRef;
+
+    bool Contains(mfxU32 fo)
+    {
+        return NumPixelsPredictedFromRef.find(fo) != NumPixelsPredictedFromRef.end();
+    }
+
+    void AddPxlCount(mfxU32 fo, mfxU32 amount)
+    {
+        if (Contains(fo))
+        {
+            NumPixelsPredictedFromRef[fo] += amount;
+        }
+        else
+        {
+            NumPixelsPredictedFromRef[fo] = amount;
+        }
+    }
+
+    void FillProp()
+    {
+        for (auto & item : NumPixelsPredictedFromRef)
+        {
+            mfxF64 denom = (1.0 - ShareIntra) * NPixelsInFrame;
+            if (denom == 0.0)
+                throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "ERROR: FillProp - zero denominator");
+
+            ShareOfPredictedPixelsFromRef[item.first] = mfxF64(item.second) / denom;
+        }
+    }
 };
 
 struct HevcTaskDSO
@@ -74,11 +106,10 @@ struct HevcTaskDSO
     mfxU32              m_nMvPredictors[2];
 
     CTUCtrlPool::Type   m_ctuCtrl;
+    bool                m_isGPBFrame = false;
 
     // Data for BRC
     FrameStatData       m_statData;
-
-    bool                m_isGPBFrame = false;
 };
 
 class LA_queue
@@ -86,8 +117,9 @@ class LA_queue
 public:
     LA_queue(mfxU16 la_depth = 1, const msdk_char* yuv_file = nullptr)
         : m_LookAheadDepth(la_depth)
+        , m_calc_mse_from_file(yuv_file[0])
     {
-        if (yuv_file[0])
+        if (m_calc_mse_from_file)
         {
             m_fpYUV = fopen(yuv_file, "rb");
 
@@ -117,10 +149,9 @@ public:
 
         task->m_statData.EncodedOrder = m_submittedTasks;
 
-        // Calc MSE
-        if (m_fpYUV)
+        if (m_calc_mse_from_file)
         {
-            task->m_statData.mseY = CalcMSE(*task);
+            task->m_statData.VisualDistortion = CalcMSE(*task);
         }
 
         la_queue.push(std::move(task));
@@ -137,7 +168,7 @@ public:
                 return false;
         }
 
-        if (!m_drain && la_queue.size() < m_LookAheadDepth)
+        if (!m_drain && la_queue.size() <= m_LookAheadDepth)
         {
             return false;
         }
@@ -184,9 +215,10 @@ public:
 private:
     std::queue<std::shared_ptr<HevcTaskDSO>> la_queue;
 
-    mfxU16 m_LookAheadDepth = 100;
-    mfxU32 m_submittedTasks = 0;
-    bool   m_drain          = false;
+    mfxU16 m_LookAheadDepth     = 100;
+    bool   m_calc_mse_from_file = false;
+    mfxU32 m_submittedTasks     = 0;
+    bool   m_drain              = false;
 
     // for MSE calculation
     MFXFrameAllocator* m_pAllocator = nullptr;
@@ -217,17 +249,17 @@ private:
         if (sts != MFX_ERR_NONE)
             throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "Failed to calculate MSE: m_pAllocator->Lock failed");
 
-        mfxF64 l2normSq = 0.0;
+        mfxU64 l2normSq = 0;
         for (mfxU32 i = 0; i < m_YUVdata.size(); ++i)
         {
-            l2normSq += std::pow(mfxF64(m_YUVdata[i]) - mfxF64(task.m_surf->Data.Y[(i / task.m_surf->Info.Width)*task.m_surf->Data.Pitch + (i % task.m_surf->Info.Width)]), 2);
+            l2normSq += std::pow(m_YUVdata[i] - task.m_surf->Data.Y[(i / task.m_surf->Info.Width)*task.m_surf->Data.Pitch + (i % task.m_surf->Info.Width)], 2);
         }
 
         sts = m_pAllocator->Unlock(m_pAllocator->pthis, task.m_surf->Data.MemId, &(task.m_surf->Data));
         if (sts != MFX_ERR_NONE)
             throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "Failed to calculate MSE: m_pAllocator->Unlock failed");
 
-        return l2normSq / m_YUVdata.size();
+        return mfxF64(l2normSq) / m_YUVdata.size();
     }
 };
 

--- a/samples/sample_hevc_fei_abr/src/abr_brc.cpp
+++ b/samples/sample_hevc_fei_abr/src/abr_brc.cpp
@@ -20,139 +20,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include "abr_brc.h"
 #include <numeric>
 
-#if 0
-namespace
-{
-    constexpr mfxF64 INTRA_QSTEP_COEFF     = 2.0;
-    constexpr mfxF64 INTRA_MODE_BITCOST    = 0.0;
-    constexpr mfxF64 INTER_MODE_BITCOST    = 0.0;
-    constexpr mfxI32 MAX_QP_CHANGE         = 2;
-    constexpr mfxF64 LOG2_64               = 3;
-    constexpr mfxF64 MIN_EST_RATE          = 0.3;
-    constexpr mfxF64 NORM_EST_RATE         = 100.0;
-
-    constexpr mfxF64 MIN_RATE_COEFF_CHANGE = 0.5;
-    constexpr mfxF64 MAX_RATE_COEFF_CHANGE = 2.0;
-    constexpr mfxF64 INIT_RATE_COEFF[] = {
-        1.109, 1.196, 1.225, 1.309, 1.369, 1.428, 1.490, 1.588, 1.627, 1.723, 1.800, 1.851, 1.916,
-        2.043, 2.052, 2.140, 2.097, 2.096, 2.134, 2.221, 2.084, 2.153, 2.117, 2.014, 1.984, 2.006,
-        1.801, 1.796, 1.682, 1.549, 1.485, 1.439, 1.248, 1.221, 1.133, 1.045, 0.990, 0.987, 0.895,
-        0.921, 0.891, 0.887, 0.896, 0.925, 0.917, 0.942, 0.964, 0.997, 1.035, 1.098, 1.170, 1.275
-    };
-
-    mfxF64 const DEP_STRENTH = 2.0;
-
-    mfxU8 GetSkippedQp(MbData const & mb)
-    {
-        if (mb.intraMbFlag)
-            return 52; // never skipped
-        if (abs(mb.mv[0].x - mb.costCenter0.x) >= 4 ||
-            abs(mb.mv[0].y - mb.costCenter0.y) >= 4 ||
-            abs(mb.mv[1].x - mb.costCenter1.x) >= 4 ||
-            abs(mb.mv[1].y - mb.costCenter1.y) >= 4)
-            return 52; // never skipped
-
-        mfxU16 const * sumc = mb.lumaCoeffSum;
-        mfxU8  const * nzc = mb.lumaCoeffCnt;
-
-        if (nzc[0] + nzc[1] + nzc[2] + nzc[3] == 0)
-            return 0; // skipped at any qp
-
-        mfxF64 qoff = 1.0 / 6;
-        mfxF64 norm = 0.1666;
-
-        mfxF64 qskip = IPP_MAX(IPP_MAX(IPP_MAX(
-            nzc[0] ? (sumc[0] * norm / nzc[0]) / (1 - qoff) * LOG2_64 : 0,
-            nzc[1] ? (sumc[1] * norm / nzc[1]) / (1 - qoff) * LOG2_64 : 0),
-            nzc[2] ? (sumc[2] * norm / nzc[2]) / (1 - qoff) * LOG2_64 : 0),
-            nzc[3] ? (sumc[3] * norm / nzc[3]) / (1 - qoff) * LOG2_64 : 0);
-
-        return QStep2QpCeil(qskip);
-    }
-}
-#endif
-
-mfxU8 QPclamp(mfxU8 qp) { return Clip3(mfxU8(1), mfxU8(51), qp); }
-
-
-mfxF64 modifyComplexities(std::vector<FrameStatData> &statData, mfxF64 avMSE, mfxU32 start_index = 0, mfxU32 LookAheadDepth = 100)
-{
-    mfxU32 last_index_plus1 = std::min(mfxU32(statData.size()), start_index + LookAheadDepth);
-
-    for (mfxU32 i = start_index; i < last_index_plus1; ++i)
-    {
-        statData[i].complexity0 = statData[i].qstep0 * statData[i].frame_size * std::pow(avMSE / (statData[i].mseY + 1.0), BRC3_DIST_COMPL_EXPONENT);
-    }
-
-    return std::accumulate(statData.begin() + start_index, statData.begin() + last_index_plus1, 0.0,
-        [](mfxF64 a, FrameStatData& b) { return a + b.complexity0; }) / (last_index_plus1 - start_index);
-}
-
-
-mfxF64 averageComplexities(std::vector<FrameStatData> &statData, mfxU32 start_index = 0, mfxU32 LookAheadDepth = 100)
-{
-    mfxF64 m_normFactors[BRC3_RATE_BLUR_LENGTH - 1];
-
-    for (mfxU32 j = 1; j < BRC3_RATE_BLUR_LENGTH; ++j)
-    {
-        m_normFactors[j - 1] = exp(-(mfxF64)j*j / BRC3_GAUSS_VARIANCE);
-    }
-
-    mfxU32 last_index_plus1 = std::min(mfxU32(statData.size()), start_index + LookAheadDepth);
-
-    for (size_t i = start_index; i < last_index_plus1; i++)
-    {
-        mfxF64 wl = 1.0, wr = 1.0, wnorm;
-        mfxF64 complexity = statData[i].complexity0;
-        mfxF64 w = 1.0;
-
-        // Right tail
-        size_t jLimit = std::min(size_t(BRC3_RATE_BLUR_LENGTH), statData.size() - i);
-        for (size_t j = 1; j < jLimit; j++)
-        {
-            //wr *= 1. - pow(statData[i+j].shareI, BRC3_RATE_BLUR_EXPONENT);
-            wr *= statData[i + j].propagation;
-            if (wr < BRC3_BLUR_STOP)
-                break;
-            wnorm = wr * m_normFactors[j - 1];
-            complexity += statData[i + j].complexity0 * wnorm;
-            w += wnorm;
-        }
-
-        // Left tail
-        jLimit = std::min(size_t(BRC3_RATE_BLUR_LENGTH), i + 1);
-        for (size_t j = 1; j < jLimit; j++)
-        {
-            //wl *= 1. - pow(statData[i-j+1].shareI, BRC3_RATE_BLUR_EXPONENT);
-            wl *= statData[i - j + 1].propagation;
-            if (wl < BRC3_BLUR_STOP || (statData[i - j].frame_type & MFX_FRAMETYPE_I))
-                break;
-            wnorm = wl * m_normFactors[j - 1];
-            complexity += statData[i - j].complexity0 * wnorm;
-            w += wnorm;
-        }
-
-
-        statData[i].complexity = complexity / w;
-    }
-
-    return std::accumulate(statData.begin() + start_index, statData.begin() + last_index_plus1, 0.0,
-        [](mfxF64 a, FrameStatData& b) { return a + b.complexity; }) / (last_index_plus1 - start_index);
-}
-
-mfxF64 calcAverageMSE(std::vector<FrameStatData> &statData, mfxU32 start_index = 0, mfxU32 LookAheadDepth = 100)
-{
-    /*
-    for (size_t i = start_index; i < statData.size(); ++i)
-    {
-        statData[i].mseY = 255 * 255 / std::pow(10.0, statData[i].psnrY * 0.1);
-    } */
-
-    mfxU32 last_index_plus1 = std::min(mfxU32(statData.size()), start_index + LookAheadDepth);
-
-    return std::accumulate(statData.begin() + start_index, statData.begin() + last_index_plus1, 0.0,
-        [](mfxF64 a, FrameStatData& b) { return a + b.mseY; }) / (last_index_plus1 - start_index);
-}
+inline mfxU8 QPclamp(mfxU8 qp) { return Clip3(mfxU8(1), mfxU8(51), qp); }
 
 constexpr mfxF64 BRC3_RATE_RATIO_ACCURACY    = 0.001;
 
@@ -172,46 +40,30 @@ constexpr mfxF64 BRC3_B_QP_DELTA_MAX   = 6.0;
 constexpr mfxF64 BRC3_B_QSTEP_FACTOR   = 1.4;
 constexpr mfxF64 BRC3_B_QP_DELTA       = 6.0 * std::log2(BRC3_B_QSTEP_FACTOR);
 
-
-void calcQsteps(std::vector<FrameStatData> &statData, mfxF64 scale, mfxU32 start_index = 0, mfxU32 LookAheadDepth = 100)
+void LA_Stat_Queue::CalcScaledQsteps(mfxF64 scale)
 {
-    mfxU32 last_index_plus1 = std::min(mfxU32(statData.size()), start_index + LookAheadDepth);
-
-    for (mfxU32 i = start_index; i < last_index_plus1; ++i)
+    // First - Set the P frames at correct level
+    for (mfxU32 i = m_curIndex; i < m_frameStatData.size(); ++i)
     {
-#if 0
-        statData[i].qstep = std::max(std::pow(statData[i].complexity0, BRC3_QSTEP_COMPL_EXPONENT) / scale, statData[i].qstep0);
-#else
-#if 1
-        statData[i].qstep = std::pow(statData[i].complexity, BRC3_QSTEP_COMPL_EXPONENT) / scale;
-#else
-        statData[i].qstep = std::max(std::pow(statData[i].complexity,  BRC3_QSTEP_COMPL_EXPONENT) / scale, statData[i].qstep0);
-#endif
-#endif
+        m_frameStatData[i].QstepCalculated = std::pow(m_frameStatData[i].ComplexitySmoothed, BRC3_QSTEP_COMPL_EXPONENT) / scale;
     }
-}
 
+    // Second - Set I and B frames to correct levels from P frames baseline
+    mfxF64 norm = 0.0, logq = 0.0;
+    mfxI32 lastrefPos = m_frameStatData.size();
 
-void calcQsteps_IB(std::vector<FrameStatData> &statData, mfxU32 start_index = 0)
-{
-    mfxF64 norm = 0.0;
-    mfxF64 logq = 0.0;
-    //    mfxF64 refqstep = statData[statData.size() - 1].qstep; // tmp kta
-    mfxI32 lastrefPos = mfxI32(statData.size());
-
-    for (mfxI32 i = mfxI32(statData.size()) - 1; i >= mfxI32(start_index); --i)
+    for (mfxI32 i = m_frameStatData.size() - 1; i >= mfxI32(m_curIndex); --i)
     {
 
-        if (statData[i].frame_type & MFX_FRAMETYPE_B)
+        if (m_frameStatData[i].FrameType & MFX_FRAMETYPE_B)
             continue;
 
-        mfxF64 qstep = statData[i].qstep;
+        mfxF64 qstep = m_frameStatData[i].QstepCalculated;
 
-        if (statData[i].frame_type & MFX_FRAMETYPE_I)
+        if (m_frameStatData[i].FrameType & MFX_FRAMETYPE_I)
         {
             if (norm > 0.0)
             {
-                // mfxF64 qstep_propagated = pow(q, 1./norm) / BRC3_INTRA_QSTEP_FACTOR;
                 mfxF64 qstep_propagated = std::exp(logq / norm) / BRC3_INTRA_QSTEP_FACTOR;
 
                 if (norm >= 1.0)
@@ -224,97 +76,123 @@ void calcQsteps_IB(std::vector<FrameStatData> &statData, mfxU32 start_index = 0)
         }
         else // P-frame
         {
-            logq = (logq + std::log(qstep))*statData[i].propagation;
-            norm = (norm + 1.0            )*statData[i].propagation;
+            logq = (logq + std::log(qstep))*m_frameStatData[i].Propagation;
+            norm = (norm + 1.0)*m_frameStatData[i].Propagation;
         }
 
         // Update qpstep of B-frames
-        if (i + 1 < lastrefPos) // there are B-frames
+        for (mfxI32 j = i + 1; j < lastrefPos; ++j) // if (i + 1 < lastrefPos) => there are B-frames
         {
-            for (mfxI32 j = i + 1; j < lastrefPos; ++j)
-            {
-                statData[j].qstep = Clip3(qstep, qstep*2.0, qstep * std::pow(statData[i].complexity0 / statData[j].complexity0, BRC3_B_QSTEP_EXPONENT));
-            }
+            m_frameStatData[j].QstepCalculated = Clip3(qstep, qstep*2.0, qstep * std::pow(m_frameStatData[i].ComplexityOriginal / m_frameStatData[j].ComplexityOriginal, BRC3_B_QSTEP_EXPONENT));
         }
 
-        //if (statData[i].frame_type & MFX_FRAMETYPE_B) {
-        //    qstep = refqstep * BRC_B_QSTEP_FACTOR;
-        //} else
-        //    refqstep = qstep;
 
         lastrefPos = i;
-        statData[i].qstep = qstep;
+        m_frameStatData[i].QstepCalculated = qstep;
     }
-
-    return;
 }
 
-
-mfxF64 calcBitrate(std::vector<FrameStatData> &statData, mfxU32 start_index = 0, mfxU32 LookAheadDepth = 100)
+mfxF64 LA_Stat_Queue::GetBitrateAdjustmentRatio(mfxU32 frameType)
 {
-    mfxU32 last_index_plus1 = std::min(mfxU32(statData.size()), start_index + LookAheadDepth);
-
-    for (mfxU32 i = start_index; i < last_index_plus1; ++i)
-    {
-        statData[i].predicted_size = std::pow(statData[i].qstep0 / statData[i].qstep, BRC3_BITRATE_QSTEP_EXPONENT) * statData[i].frame_size;
-    }
-
-    return std::accumulate(statData.begin() + start_index, statData.begin() + last_index_plus1, 0.0,
-        [](mfxF64 a, FrameStatData& b) { return a + b.predicted_size; }) / (last_index_plus1 - start_index);
+    return (frameType & (MFX_FRAMETYPE_I | MFX_FRAMETYPE_P)) ?
+        (m_BitsPredictedAccumulatedIP ? mfxF64(m_BitsEncodedAccumulatedIP) / m_BitsPredictedAccumulatedIP : 1.0) :
+        (m_BitsPredictedAccumulatedB  ? mfxF64(m_BitsEncodedAccumulatedB)  / m_BitsPredictedAccumulatedB  : 1.0);
 }
 
-
-void LA_BRC::UpdateStatData(mfxU32 curFrameIndex)
+void LA_Stat_Queue::CalcComplexities()
 {
-    m_avMSE = calcAverageMSE(m_frameStatData, curFrameIndex);
+    mfxF64 average_Distortion       = m_DistortionAccumulated                                         / (m_frameStatData.size() - m_lbIndex),
+           average_PixelPropagation = (m_PixelsWeightedPropagation_tmp + m_PixelsWeightedPropagation) / (m_frameStatData.size() - m_lbIndex);
 
-    modifyComplexities(m_frameStatData, m_avMSE, curFrameIndex);
-
-    averageComplexities(m_frameStatData, curFrameIndex);
-
-    mfxF64 scale = 1.0;
-    mfxF64 ratio = 999.9; // just to suppress a stupid warning
-    mfxF64 predictedBitrate;
-    mfxF64 lR, rR;
-    mfxF64 lS, rS;
-    mfxF64 ratio_accuracy = BRC3_RATE_RATIO_ACCURACY;
-
-#if 0
-    // no HRD for now
-    if (video.mfx.BufferSizeInKB > 0)
+    for (mfxU32 i = m_curIndex; i < m_frameStatData.size(); ++i)
     {
-        ratio_accuracy = std::min(ratio_accuracy, video.mfx.BufferSizeInKB * 1600.0 / (m_TargetBitrate * m_frameStatData.size())); // video.mfx.BufferSizeInKB * 8000.0 * 0.2
+        m_frameStatData[i].ComplexityOriginal = m_frameStatData[i].QstepOriginal * m_frameStatData[i].FrameSize *                                 // Incorporate dependence between size and QpStep.
+                                         std::pow(average_Distortion / (m_frameStatData[i].VisualDistortion + 1.0), BRC3_DIST_COMPL_EXPONENT) *   // Reflects relative subjective quality of frame.
+                                         (m_frameStatData[i].NPixelsTransitivelyPropagated != 1.0 ?
+                                                            m_frameStatData[i].NPixelsTransitivelyPropagated / average_PixelPropagation : 1.0);   // Relative propagation of current frame.
     }
-#endif
 
-    rS = Qp2QStep(51) / Qp2QStep(1);
-    lS = 1.0 / rS;
+    // Smooth complexities with Gaussian
+    for (mfxU32 i = m_curIndex; i < m_frameStatData.size(); ++i)
+    {
+        mfxF64 wl = 1.0, wr = 1.0, wnorm;
+        mfxF64 complexity = m_frameStatData[i].ComplexityOriginal;
+        mfxF64 w = 1.0;
 
-    calcQsteps(m_frameStatData, lS, curFrameIndex);
-    lR = calcBitrate(m_frameStatData, curFrameIndex) / m_TargetBitrate;
+        // Right tail
+        mfxU32 jLimit = std::min(BRC3_RATE_BLUR_LENGTH, mfxU32(m_frameStatData.size() - i));
+        for (mfxU32 j = 1; j < jLimit; ++j)
+        {
+            wr *= m_frameStatData[i + j].Propagation;
+            if (wr < BRC3_BLUR_STOP)
+                break;
+            wnorm = wr * m_normFactors[j - 1];
+            complexity += m_frameStatData[i + j].ComplexityOriginal * wnorm;
+            w += wnorm;
+        }
+
+        // Left tail
+        jLimit = std::min(BRC3_RATE_BLUR_LENGTH, i + 1);
+        for (mfxU32 j = 1; j < jLimit; ++j)
+        {
+            wl *= m_frameStatData[i - j + 1].Propagation;
+            if (wl < BRC3_BLUR_STOP || (m_frameStatData[i - j].FrameType & MFX_FRAMETYPE_I))
+                break;
+            wnorm = wl * m_normFactors[j - 1];
+            complexity += m_frameStatData[i - j].ComplexityOriginal * wnorm;
+            w += wnorm;
+        }
+
+        m_frameStatData[i].ComplexitySmoothed = complexity / w;
+    }
+}
+
+mfxF64 LA_Stat_Queue::CalcBitrate()
+{
+    for (mfxU32 i = m_curIndex; i < m_frameStatData.size(); ++i)
+    {
+        m_frameStatData[i].BitsPredicted = std::pow(m_frameStatData[i].QstepOriginal / m_frameStatData[i].QstepCalculated, BRC3_BITRATE_QSTEP_EXPONENT) * m_frameStatData[i].FrameSize;
+    }
+
+    return (std::accumulate(std::begin(m_frameStatData) + m_curIndex, std::end(m_frameStatData), 0.0,
+                [](mfxF64 a, FrameStatData& b) { return a + b.BitsPredicted; }) + // Future frames, so use predicted size.
+            m_BitsEncodedAccumulated)                                             // Already encoded frames, so use actual encoded size.
+                / (m_frameStatData.size() - m_lbIndex);
+}
+
+void LA_BRC::UpdateStatData()
+{
+    // Precalculate complexities for frames in LA window
+    m_frameStatQueue.CalcComplexities();
+
+    mfxF64 scale, ratio;
+
+    mfxF64 rS = Qp2QStep(51) / Qp2QStep(1); // Right bound of Scale parameter
+    mfxF64 lS = 1.0 / rS;                   // Left  bound of Scale parameter
+
+    // Left bound of possible bitrate for LA window
+    m_frameStatQueue.CalcScaledQsteps(lS);                         // Set up Qsteps for left Scale
+    mfxF64 lR = m_frameStatQueue.CalcBitrate() / m_TargetBitrate;  // Get left bound for ratio of Predicted / Target bitrate
 
     if (lR >= 1.0)
         return;
 
-    calcQsteps(m_frameStatData, rS, curFrameIndex);
-    rR = calcBitrate(m_frameStatData, curFrameIndex) / m_TargetBitrate;
+    m_frameStatQueue.CalcScaledQsteps(rS);                        // Set up Qsteps for right Scale
+    mfxF64 rR = m_frameStatQueue.CalcBitrate() / m_TargetBitrate; // Get right bound for ratio of Predicted / Target bitrate
 
     if (rR <= 1.0)
         return;
 
+    // Start iterative fork search to find optimal quantization steps
     for (mfxU32 i = 0; i < 30; ++i)
     {
         scale = lS + (1.0 - lR)*(rS - lS) / (rR - lR);
 
-        calcQsteps(m_frameStatData, scale, curFrameIndex);
+        m_frameStatQueue.CalcScaledQsteps(scale);
 
-        calcQsteps_IB(m_frameStatData, curFrameIndex);
+        ratio = m_frameStatQueue.CalcBitrate() / m_TargetBitrate;
 
-        predictedBitrate = calcBitrate(m_frameStatData, curFrameIndex);
-
-        ratio = predictedBitrate / m_TargetBitrate;
-
-        if (std::abs(ratio - 1.0) < ratio_accuracy)
+        if (std::abs(ratio - 1.0) < BRC3_RATE_RATIO_ACCURACY)
             break;
 
         if (ratio < 1.0)
@@ -338,53 +216,47 @@ void LA_BRC::UpdateStatData(mfxU32 curFrameIndex)
     return;
 }
 
-constexpr mfxF64 BRC3_QSTEP_CORRECTION_EXPONENT = 1.0;
-
-void LA_BRC::PreEnc(HevcTaskDSO& task)
+void LA_BRC::PreEnc(FrameStatData& /*statData*/)
 {
-#ifdef DEBUG_OUTPUT
-    std::cout << std::endl << std::endl << "Frame #" << task.m_statData.DisplayOrder << std::endl;
-    std::cout << "initial qp:   " << mfxI32(task.m_statData.qp);
-#endif
+    queue_mutex.lock();
 
-    mfxU32 curFrameIndex = std::distance(m_frameStatData.begin(), std::find_if(m_frameStatData.begin(), m_frameStatData.end(),
-        [&task](FrameStatData& dat) { return dat.EncodedOrder == task.m_statData.EncodedOrder; }));
+    // Shift index of current frame
+    m_frameStatQueue.StartNewFrameProcessing();
 
-    if (curFrameIndex == m_frameStatData.size())
-        throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "Current stat wasn't found in LookAhead cache");
+    // Precalculate optimal parameters
+    UpdateStatData();
 
-    FrameStatData& statData = m_frameStatData[curFrameIndex];
+    FrameStatData& statData = m_frameStatQueue.GetCurrentStatData();
 
-    UpdateStatData(curFrameIndex);
+    // This ratio is used for correction of final bitrate on base of AdaptationDepth frames statistics
+    mfxF64 corr_ratio = m_frameStatQueue.GetBitrateAdjustmentRatio(statData.FrameType);
 
-    mfxF64 qstep;
-
-#ifdef SEPARATE_IP_B_PROCESSING
-    if (statData.frame_type & MFX_FRAMETYPE_B)
+    // Additional refinement for B frames
+    if (statData.FrameType & MFX_FRAMETYPE_B)
     {
-        mfxI32 poc = statData.poc;
-        mfxF64 complexity = statData.complexity0;
+        mfxI32 poc = statData.POC;
+        mfxF64 complexity = statData.ComplexitySmoothed;
         mfxI32 typeR = MFX_FRAMETYPE_UNKNOWN, typeL = MFX_FRAMETYPE_UNKNOWN, pocR = poc + 1, pocL = poc - 1;
         mfxF64 qp, qpR = 0.0, qpL = 0.0;
         mfxF64 complR = complexity, complL = complexity, complP = complexity;
 
-        for (mfxI32 i = mfxI32(curFrameIndex) - 1; i >= 0; --i)
+        for (mfxI32 i = mfxI32(m_frameStatQueue.GetCurrentIndex()) - 1; i >= 0; --i)
         {
-            if (!(m_frameStatData[i].frame_type & MFX_FRAMETYPE_B))
+            if (!(m_frameStatQueue[i].FrameType & MFX_FRAMETYPE_B))
             {
                 if (typeR == MFX_FRAMETYPE_UNKNOWN)
                 {
-                    qpR    = m_frameStatData[i].qp;
-                    typeR  = m_frameStatData[i].frame_type;
-                    pocR   = m_frameStatData[i].poc;
-                    complR = m_frameStatData[i].complexity0;
+                    qpR    = m_frameStatQueue[i].QP;
+                    typeR  = m_frameStatQueue[i].FrameType;
+                    pocR   = m_frameStatQueue[i].POC;
+                    complR = m_frameStatQueue[i].ComplexityOriginal;
                 }
                 else
                 {
-                    qpL    = m_frameStatData[i].qp;
-                    typeL  = m_frameStatData[i].frame_type;
-                    pocL   = m_frameStatData[i].poc;
-                    complL = m_frameStatData[i].complexity0;
+                    qpL    = m_frameStatQueue[i].QP;
+                    typeL  = m_frameStatQueue[i].FrameType;
+                    pocL   = m_frameStatQueue[i].POC;
+                    complL = m_frameStatQueue[i].ComplexityOriginal;
                     break;
                 }
             }
@@ -401,8 +273,6 @@ void LA_BRC::PreEnc(HevcTaskDSO& task)
             if (crR > 1.0)
                 crR = 1.0 / crR;
 
-            //            qp = (qpL * (pocR - poc) + qpR * (poc - pocL)) / (pocR - pocL);
-            //            complP = (complL * (pocR - poc) + complR * (poc - pocL)) / (pocR - pocL);
             qp = (qpL * (pocR - poc) * crL + qpR * (poc - pocL) * crR) / ((pocR - poc)*crL + (poc - pocL)*crR);
 
             complP = (complL * crL * (pocR - poc) + complR * crR * (poc - pocL)) / ((pocR - poc)*crL + (poc - pocL)*crR);
@@ -421,75 +291,30 @@ void LA_BRC::PreEnc(HevcTaskDSO& task)
         {
             qp = (qpL + qpR)*0.5 + BRC3_INTRA_QP_DELTA;
         }
-#if 1
+
         // qp_B_delta
-        qp += Clip3(BRC3_B_QP_DELTA_MIN, BRC3_B_QP_DELTA_MAX, std::log2((complP / complexity)*((m_B_BitsEncoded + 1.0) / (m_B_BitsPredicted + 1.0))) * BRC3_B_QP_FACTOR);
-#else
-        qp += BRC3_B_QP_DELTA;
-#endif
+        qp += Clip3(BRC3_B_QP_DELTA_MIN, BRC3_B_QP_DELTA_MAX, std::log2((complP / complexity)*corr_ratio) * BRC3_B_QP_FACTOR);
 
         m_curQp = QPclamp(mfxU8(qp + 0.5));
 
-        statData.qstep = Qp2QStep(m_curQp);
-        statData.qp    = m_curQp;
+        statData.QstepCalculated = Qp2QStep(m_curQp);
+        statData.QP              = m_curQp;
     }
     else
-#endif
     {
-        qstep = statData.qstep;
+        m_curQp = QPclamp(QStep2QpNearest(statData.QstepCalculated * corr_ratio));
 
-        mfxF64 expnnt = BRC3_QSTEP_CORRECTION_EXPONENT;
-
-        if (m_curFrame < m_LookAheadDepth)
-            expnnt *= 0.01 * m_curFrame;
-
-#ifdef SEPARATE_IP_B_PROCESSING
-        mfxF64 qstep_n = qstep * std::pow((m_IP_BitsEncoded + 1.0) / (m_IP_BitsPredicted + 1.0), expnnt);
-#else
-        mfxF64 qstep_n = qstep * std::pow((m_BitsEncoded + 1.0) / (m_BitsPredicted + 1.0), expnnt);
-#endif
-
-        m_curQp = QPclamp(QStep2QpNearest(qstep_n));
-
-        statData.qstep = qstep_n;
-        statData.qp    = m_curQp;
+        statData.QstepCalculated = Qp2QStep(m_curQp);
+        statData.QP              = m_curQp;
     }
 
-#ifdef DEBUG_OUTPUT
-    std::cout << "    qp set:    " << mfxI32(m_curQp) << std::endl;
-    std::cout << "initial size: " << task.m_statData.frame_size << " result size: ";
-#endif
+    queue_mutex.unlock();
 }
 
 void LA_BRC::Report(mfxU32 dataLength)
 {
-#ifdef DEBUG_OUTPUT
-    std::cout << dataLength << std::endl;
-#endif
+    FrameStatData& statData = m_frameStatQueue.GetCurrentStatData();
 
-#ifdef SEPARATE_IP_B_PROCESSING
-    switch (m_frameStatData[m_curFrame].frame_type & (MFX_FRAMETYPE_I | MFX_FRAMETYPE_P | MFX_FRAMETYPE_B))
-    {
-    case MFX_FRAMETYPE_I:
-    case MFX_FRAMETYPE_P:
-        m_IP_BitsPredicted += m_frameStatData[m_curFrame].predicted_size;
-        m_IP_BitsEncoded   += dataLength << 3;
-        break;
-    case MFX_FRAMETYPE_B:
-        m_B_BitsPredicted += m_frameStatData[m_curFrame].predicted_size;
-        m_B_BitsEncoded   += dataLength << 3;
-        break;
-
-    default:
-        throw mfxError(MFX_ERR_UNDEFINED_BEHAVIOR, "Invalid m_frameStatData[m_curFrame].frame_type");
-        break;
-    }
-#else
-    m_BitsPredicted += m_frameStatData[m_curFrame].predicted_size;
-    m_BitsEncoded   += dataLength << 3;
-#endif
-
-    ++m_curFrame;
-
-    return;
+    statData.BitsPredicted = statData.FrameSize * statData.QstepOriginal / statData.QstepCalculated;
+    statData.BitsEncoded   = dataLength << 3;
 }

--- a/samples/sample_hevc_fei_abr/src/cmd_processor.cpp
+++ b/samples/sample_hevc_fei_abr/src/cmd_processor.cpp
@@ -54,7 +54,7 @@ void PrintHelp(const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("\n"));
     msdk_printf(MSDK_STRING("Options: \n"));
     msdk_printf(MSDK_STRING("   [-i::h265 <file-name>] - input file and decoder type\n"));
-    msdk_printf(MSDK_STRING("   [-sink] - pipeline makes decode only and put data to shared buffer\n"));
+    msdk_printf(MSDK_STRING("   [-sink]   - pipeline makes decode only and put data to shared buffer\n"));
     msdk_printf(MSDK_STRING("   [-source] - pipeline makes vpp + encode and get data from shared buffer\n"));
     msdk_printf(MSDK_STRING("   [-dso <file-name>] - input stream for DSO extraction\n"));
     msdk_printf(MSDK_STRING("   [-dstw width]  - destination picture width, invokes VPP resizing\n"));
@@ -64,9 +64,14 @@ void PrintHelp(const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-DisableQPOffset] - disable QP offset per pyramid layer\n"));
     msdk_printf(MSDK_STRING("   [-vbr::sw] - use MSDK SW VBR rate control\n"));
     msdk_printf(MSDK_STRING("   [-vbr::la] - use lookahead VBR rate control\n"));
-    msdk_printf(MSDK_STRING("   [-TargetKbps value] - target bitrate for VBR rate control\n"));
-    msdk_printf(MSDK_STRING("   [-LookAheadDepth value] - depth of look ahead (defult is 100)\n"));
-    msdk_printf(MSDK_STRING("   [-yuv <file-name>] - yuv file for MSE calculation, required for LA BRC\n"));
+    msdk_printf(MSDK_STRING("   [-TargetKbps value] - target bitrate\n"));
+    msdk_printf(MSDK_STRING("       Block of LA BRC options:\n"));
+    msdk_printf(MSDK_STRING("       [-LookAheadDepth   value] - depth of look ahead (defult is 100)\n"));
+    msdk_printf(MSDK_STRING("       [-LookBackDepth    value] - depth of look back window for taking into account encoded frames statistics (defult is 100)\n"));
+    msdk_printf(MSDK_STRING("       [-AdaptationLength value] - number of frames to calculate adjustment ratio to minimize Algorithms bitrate estimation error (defult is 100)\n"));
+    msdk_printf(MSDK_STRING("       [-Algorithm::MSE <file-name>] - use yuv file for MSE calculation (not optimized implementation)\n"));
+    msdk_printf(MSDK_STRING("       [-Algorithm::NNZ]             - use number of non-zero transform coefficients as distortion approximation (default)\n"));
+    msdk_printf(MSDK_STRING("       [-Algorithm::SSC]             - use sum of squared transform coefficients as distortion approximation\n"));
     msdk_printf(MSDK_STRING("   [-idr_interval size] - if IdrInterval = 0, then only first I-frame is an IDR-frame\n"));
     msdk_printf(MSDK_STRING("                          if IdrInterval = 1, then every I - frame is an IDR - frame\n"));
     msdk_printf(MSDK_STRING("                          if IdrInterval = 2, then every other I - frame is an IDR - frame, etc (default is 0)\n"));
@@ -74,9 +79,9 @@ void PrintHelp(const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-gop_opt closed|strict] - GOP optimization flags (can be used together)\n"));
     msdk_printf(MSDK_STRING("   [-r (-GopRefDist) distance] - Distance between I- or P- key frames (1 means no B-frames) (0 - by default(I frames))\n"));
     msdk_printf(MSDK_STRING("   [-num_ref (-NumRefFrame) numRefs] - number of reference frames\n"));
-    msdk_printf(MSDK_STRING("   [-NumRefActiveP   numRefs] - number of maximum allowed references for P frames (up to 4)\n"));
-    msdk_printf(MSDK_STRING("   [-NumRefActiveBL0 numRefs] - number of maximum allowed backward references for B frames (up to 4)\n"));
-    msdk_printf(MSDK_STRING("   [-NumRefActiveBL1 numRefs] - number of maximum allowed forward references for B frames (up to 2)\n"));
+    msdk_printf(MSDK_STRING("   [-NumRefActiveP   numRefs]  - number of maximum allowed references for P frames (up to 4)\n"));
+    msdk_printf(MSDK_STRING("   [-NumRefActiveBL0 numRefs]  - number of maximum allowed backward references for B frames (up to 3)\n"));
+    msdk_printf(MSDK_STRING("   [-NumRefActiveBL1 numRefs]  - number of maximum allowed forward references for B frames (up to 2)\n"));
     msdk_printf(MSDK_STRING("   [-NumPredictorsL0 numPreds] - number of maximum L0 predictors (default - assign depending on the frame type)\n"));
     msdk_printf(MSDK_STRING("   [-NumPredictorsL1 numPreds] - number of maximum L1 predictors (default - assign depending on the frame type)\n"));
     msdk_printf(MSDK_STRING("   [-MultiPredL0 type] - use internal L0 MV predictors (0 - no internal MV predictor, 1 - spatial internal MV predictors)\n"));
@@ -90,18 +95,18 @@ void PrintHelp(const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-FastIntra:I] - force encoder to skip HEVC-specific intra modes (use AVC modes only) on I-frames\n"));
     msdk_printf(MSDK_STRING("   [-FastIntra:P] - force encoder to skip HEVC-specific intra modes (use AVC modes only) on P-frames\n"));
     msdk_printf(MSDK_STRING("   [-FastIntra:B] - force encoder to skip HEVC-specific intra modes (use AVC modes only) on B-frames\n"));
-    msdk_printf(MSDK_STRING("   [-gpb:<on,off>] - make HEVC encoder use regular P-frames (off) or GPB (on) (on - by default)\n"));
+    msdk_printf(MSDK_STRING("   [-gpb:<on,off>]  - make HEVC encoder use regular P-frames (off) or GPB (on) (on - by default)\n"));
     msdk_printf(MSDK_STRING("   [-ppyr:<on,off>] - enables P-pyramid\n"));
-    msdk_printf(MSDK_STRING("   [-bref] - arrange B frames in B pyramid reference structure\n"));
+    msdk_printf(MSDK_STRING("   [-bref]   - arrange B frames in B pyramid reference structure\n"));
     msdk_printf(MSDK_STRING("   [-nobref] - do not use B-pyramid (by default the decision is made by library)\n"));
     msdk_printf(MSDK_STRING("   [-l numSlices] - number of slices \n"));
     msdk_printf(MSDK_STRING("   [-PicTimingSEI] - inserts picture timing SEI\n"));
     msdk_printf(MSDK_STRING("   [-SearchWindow value] - specifies one of the predefined search path and window size. In range [1,8] (5 is default).\n"));
     msdk_printf(MSDK_STRING("                           If zero value specified: -RefWidth / RefHeight, -LenSP are required\n"));
-    msdk_printf(MSDK_STRING("   [-RefWidth width] - width of search region (should be multiple of 4), maximum allowed search window is 64x32 for\n"));
-    msdk_printf(MSDK_STRING("                       one direction and 32x32 for bidirectional search\n"));
+    msdk_printf(MSDK_STRING("   [-RefWidth width]   - width of search region (should be multiple of 4), maximum allowed search window is 64x32 for\n"));
+    msdk_printf(MSDK_STRING("                         one direction and 32x32 for bidirectional search\n"));
     msdk_printf(MSDK_STRING("   [-RefHeight height] - height of search region (should be multiple of 4), maximum allowed is 32\n"));
-    msdk_printf(MSDK_STRING("   [-LenSP length] - defines number of search units in search path. In range [1,63] (default is 57)\n"));
+    msdk_printf(MSDK_STRING("   [-LenSP length]     - defines number of search units in search path. In range [1,63] (default is 57)\n"));
     msdk_printf(MSDK_STRING("   [-SearchPath value] - defines shape of search path. 1 - diamond, 2 - full, 0 - default (full)\n"));
     msdk_printf(MSDK_STRING("   [-ForceToIntra] - force CUs to be coded as intra using DSO information\n"));
     msdk_printf(MSDK_STRING("   [-ForceToInter] - force CUs to be coded as inter using DSO information\n"));
@@ -223,11 +228,6 @@ mfxStatus CheckOptions(const sInputParams & params)
             return MFX_ERR_UNSUPPORTED;
         }
 
-        if (params.sBRCparams.eBrcType == LOOKAHEAD && !params.sBRCparams.strYUVFile[0])
-        {
-            PrintHelp("YUV file is mandatory for Look Ahead BRC");
-            return MFX_ERR_UNSUPPORTED;
-        }
         if (!(params.input.DSOMVPBlockSize == 0 || params.input.DSOMVPBlockSize == 1 ||
               params.input.DSOMVPBlockSize == 2 || params.input.DSOMVPBlockSize == 7 ))
         {
@@ -335,11 +335,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char* argv[])
             PARSE_CHECK(msdk_opt_read(argv[++i], params.input.strDsoFile), "Input DSO stream", isParseInvalid);
             params.input.bDSO = true;
         }
-        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-yuv")))
-        {
-            CHECK_NEXT_VAL(i + 1 >= argc, argv[i]);
-            PARSE_CHECK(msdk_opt_read(argv[++i], params.sBRCparams.strYUVFile), "Input YUV file", isParseInvalid);
-        }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-i::source")))
         {
             if (params.pipeMode != Full)
@@ -389,6 +384,37 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char* argv[])
                 PrintHelp(MSDK_STRING("ERROR: LookAheadDepth is invalid"));
                 return MFX_ERR_UNSUPPORTED;
             }
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-LookBackDepth")))
+        {
+            if (!argv[++i] || MFX_ERR_NONE != msdk_opt_read(argv[i], params.sBRCparams.LookBackDepth))
+            {
+                PrintHelp(MSDK_STRING("ERROR: LookBackDepth is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-AdaptationLength")))
+        {
+            if (!argv[++i] || MFX_ERR_NONE != msdk_opt_read(argv[i], params.sBRCparams.AdaptationLength))
+            {
+                PrintHelp(MSDK_STRING("ERROR: AdaptationLength is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-Algorithm::NNZ")))
+        {
+            params.sBRCparams.eAlgType = NNZ;
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-Algorithm::SSC")))
+        {
+            params.sBRCparams.eAlgType = SSC;
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-Algorithm::MSE")))
+        {
+            params.sBRCparams.eAlgType = MSE;
+
+            CHECK_NEXT_VAL(i + 1 >= argc, argv[i]);
+            PARSE_CHECK(msdk_opt_read(argv[++i], params.sBRCparams.strYUVFile), "Input YUV file", isParseInvalid);
         }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-dstw")))
         {

--- a/samples/sample_hevc_fei_abr/src/hevc_fei_encode.cpp
+++ b/samples/sample_hevc_fei_abr/src/hevc_fei_encode.cpp
@@ -140,7 +140,7 @@ mfxStatus FEI_Encode::DoWork(std::shared_ptr<HevcTaskDSO> & task)
         // Set up BRC frame QP
         if (m_pBRC.get())
         {
-            m_pBRC->PreEnc(*task /*task->m_statData*/);
+            m_pBRC->PreEnc(task->m_statData);
             m_encodeCtrl.QP = m_pBRC->GetQP();
         }
     }
@@ -157,7 +157,6 @@ mfxStatus FEI_Encode::EncodeFrame(mfxFrameSurface1* pSurf)
 
     for (;;)
     {
-
         sts = m_mfxENCODE.EncodeFrameAsync(&m_encodeCtrl, pSurf, &m_bitstream, &m_syncPoint);
         MSDK_CHECK_WRN(sts, "FEI EncodeFrameAsync");
 


### PR DESCRIPTION
Introduced new class for Look Ahead queue (not storing all history anymore, only required frames)
Clean up variable/class names, removed dead code
Added comments

Test results for LA BRC relative to HW BRC are following:
+4.54% of BD-Rate Y for real MSE (requires original YUV)
+3.19% for algorithm which approximate distortion with number of nonzero transform coefficients