### PR TITLE
Pass GPB frames with MFX_FRAMETYPE_P type

### DIFF
--- a/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
+++ b/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
@@ -380,8 +380,8 @@ mfxStatus PredictorsRepaking::RepackPredictorsQuality(const HevcTask& task, mfxE
                     mv[j][1].x <<= m_downsample_power2;
                     mv[j][1].y <<= m_downsample_power2;
 
-                    distortion[j][0] = (j < task.m_numRefActive[0]) ? mbs_vec[j]->MB[preencCUIdx].Inter[0].BestDistortion : 0xffff;
-                    distortion[j][1] = (j < task.m_numRefActive[1]) ? mbs_vec[j]->MB[preencCUIdx].Inter[1].BestDistortion : 0xffff;
+                    distortion[j][0] = (j < numFinalL0Predictors) ? mbs_vec[j]->MB[preencCUIdx].Inter[0].BestDistortion : 0xffff;
+                    distortion[j][1] = (j < numFinalL1Predictors) ? mbs_vec[j]->MB[preencCUIdx].Inter[1].BestDistortion : 0xffff;
                 }
             }
 

--- a/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
+++ b/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
@@ -386,6 +386,12 @@ void FillHEVCRefLists(const HevcTask& task, mfxExtHEVCRefLists & refLists)
 mfxStatus FEI_Encode::SetCtrlParams(const HevcTask& task)
 {
     m_encodeCtrl.FrameType = task.m_frameType;
+    if (task.m_ldb)
+    {
+        // According to MediaSDK manual GPB frames should be passed as MFX_FRAMETYPE_P, not MFX_FRAMETYPE_B
+        m_encodeCtrl.FrameType &= ~MFX_FRAMETYPE_B;
+        m_encodeCtrl.FrameType |= MFX_FRAMETYPE_P;
+    }
 
     mfxExtHEVCRefLists* pRefLists = m_encodeCtrl.GetExtBuffer<mfxExtHEVCRefLists>();
     MSDK_CHECK_POINTER(pRefLists, MFX_ERR_NOT_INITIALIZED);


### PR DESCRIPTION
This is MediaSDK manual limitation.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>