### PR TITLE
[HEVCe FEI] Workaround for PreENC driver bug

### DIFF
--- a/samples/sample_hevc_fei/src/hevc_fei_preenc.cpp
+++ b/samples/sample_hevc_fei/src/hevc_fei_preenc.cpp
@@ -125,6 +125,12 @@ FEI_Preenc::FEI_Preenc(MFXVideoSession* session, MfxVideoParamsWrapper& preenc_p
             m_default_MVMB.MV[i][j].y = (mfxI16)0x8000;
         }
     }
+
+    // Important!
+    // When DisableMVOutput and DisableStatisticsOutput are 1 on some particular frame (e.g. I frame),
+    // driver produces wrong MVs on further frames.
+    // So we always need to enable statistic output even if we don't need it at application side.
+    m_defFrameCtrl.DisableStatisticsOutput = 0;
 }
 
 FEI_Preenc::~FEI_Preenc()


### PR DESCRIPTION
We always need to enable statistic output even if we don't need it at
application side.

MDP-45308

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>