### PR TITLE
[sample FEI ABR] GCC 8.1 warning fix

### DIFF
--- a/samples/sample_hevc_fei_abr/include/dso/bs_mem+.h
+++ b/samples/sample_hevc_fei_abr/include/dso/bs_mem+.h
@@ -49,11 +49,11 @@ public:
 
     MemObj(unsigned int count, bool zero)
     {
-        m_obj = new T[count];
-        m_del = true;
-
         if (zero)
-            memset(m_obj, 0, sizeof(T) * count);
+            m_obj = new T[count]{}; // array value-initialization
+        else
+            m_obj = new T[count];
+        m_del = true;
     }
 
     MemObj(T* obj)

--- a/samples/sample_hevc_fei_abr/include/dso/hevc2_parser.h
+++ b/samples/sample_hevc_fei_abr/include/dso/hevc2_parser.h
@@ -431,28 +431,28 @@ private:
         if (std::is_same<CTU, T>::value)
         {
             assert(m_ctu.capacity() >= m_ctu.size() + 1);
-            CTU z = {};
+            CTU z{};
             m_ctu.push_back(z);
             return (T*)&m_ctu.back();
         }
         if (std::is_same<CU, T>::value)
         {
             assert(m_cu.capacity() >= m_cu.size() + 1);
-            CU z = {};
+            CU z{};
             m_cu.push_back(z);
             return (T*)&m_cu.back();
         }
         if (std::is_same<PU, T>::value)
         {
             assert(m_pu.capacity() >= m_pu.size() + 1);
-            PU z = {};
+            PU z{};
             m_pu.push_back(z);
             return (T*)&m_pu.back();
         }
         if (std::is_same<TU, T>::value)
         {
             assert(m_tu.capacity() >= m_tu.size() + 1);
-            TU z = {};
+            TU z{};
             m_tu.push_back(z);
             return (T*)&m_tu.back();
         }

--- a/samples/sample_hevc_fei_abr/include/dso/hevc2_struct.h
+++ b/samples/sample_hevc_fei_abr/include/dso/hevc2_struct.h
@@ -819,7 +819,7 @@ struct TU
 
     Bs16s QP[3];
 
-    Bs32s* tc_levels_luma = nullptr;
+    Bs32s* tc_levels_luma;
 
     TU* Next;
 };

--- a/samples/sample_hevc_fei_abr/src/dso/hevc2_ssdata.cpp
+++ b/samples/sample_hevc_fei_abr/src/dso/hevc2_ssdata.cpp
@@ -1187,7 +1187,7 @@ TU* SDParser::parseTT(CU& cu, TU& tu, TU& tuBase, Bs16u blkIdx)
             pTU = parseTT(cu, *pTU, tu0, blk);
         };
 
-        memset(&tu, 0, sizeof(tu));
+        tu = TU();
         transform_tree(x0, y0, 0);
 
         pTU->Next = Alloc<TU>();


### PR DESCRIPTION
It fixes "memset() clearing an object of non-trivial type"
warring.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>