### PR TITLE
[sample_hevc_fei] Revert using MFX_FRAMETYPE_B for GPB frames in sample

### DIFF
--- a/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
+++ b/samples/sample_hevc_fei/src/fei_predictors_repaking.cpp
@@ -230,6 +230,7 @@ mfxStatus PredictorsRepaking::RepackPredictorsPerformance(const HevcTask& task, 
 
                 block.RefIdx[0].RefL1 = block.RefIdx[0].RefL0;
                 block.MV[0][1] = block.MV[0][0];
+                numFinalL1Predictors = 1;
             }
         }
     }

--- a/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
+++ b/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
@@ -386,12 +386,6 @@ void FillHEVCRefLists(const HevcTask& task, mfxExtHEVCRefLists & refLists)
 mfxStatus FEI_Encode::SetCtrlParams(const HevcTask& task)
 {
     m_encodeCtrl.FrameType = task.m_frameType;
-    if (task.m_ldb)
-    {
-        // According to MediaSDK manual GPB frames should be passed as MFX_FRAMETYPE_P, not MFX_FRAMETYPE_B
-        m_encodeCtrl.FrameType &= ~MFX_FRAMETYPE_B;
-        m_encodeCtrl.FrameType |= MFX_FRAMETYPE_P;
-    }
 
     mfxExtHEVCRefLists* pRefLists = m_encodeCtrl.GetExtBuffer<mfxExtHEVCRefLists>();
     MSDK_CHECK_POINTER(pRefLists, MFX_ERR_NOT_INITIALIZED);
@@ -498,4 +492,3 @@ mfxStatus FEI_Encode::ResetIOState()
 
     return sts;
 }
-

--- a/samples/sample_hevc_fei/src/ref_list_manager.cpp
+++ b/samples/sample_hevc_fei/src/ref_list_manager.cpp
@@ -746,9 +746,7 @@ HevcTask* EncodeOrderControl::ReorderFrame(mfxFrameSurface1 * surface)
         mfxExtCodingOption3 * CO3 = m_par;
         if (CO3 && CO3->GPB == MFX_CODINGOPTION_ON && task.m_frameType & MFX_FRAMETYPE_P)
         {
-            // encode P as GPB
-            task.m_frameType &= ~MFX_FRAMETYPE_P;
-            task.m_frameType |= MFX_FRAMETYPE_B;
+            // mark GPB frame
             task.m_ldb = true;
         }
 

--- a/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
+++ b/samples/sample_hevc_fei/src/sample_hevc_fei.cpp
@@ -85,7 +85,7 @@ void PrintHelp(const msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("   [-gop_opt closed|strict] - GOP optimization flags (can be used together)\n"));
     msdk_printf(MSDK_STRING("   [-r (-GopRefDist) distance] - Distance between I- or P- key frames (1 means no B-frames) (0 - by default(I frames))\n"));
     msdk_printf(MSDK_STRING("   [-num_ref (-NumRefFrame) numRefs] - number of available reference frames (DPB size)\n"));
-    msdk_printf(MSDK_STRING("   [-NumRefActiveP   numRefs] - number of maximum allowed references for P frames (valid range is [1, 3])\n"));
+    msdk_printf(MSDK_STRING("   [-NumRefActiveP   numRefs] - number of maximum allowed references for P/GPB frames (valid range is [1, 3])\n"));
     msdk_printf(MSDK_STRING("   [-NumRefActiveBL0 numRefs] - number of maximum allowed backward references for B frames (valid range is [1, 3])\n"));
     msdk_printf(MSDK_STRING("   [-NumRefActiveBL1 numRefs] - number of maximum allowed forward references for B frames (only 1 is supported)\n"));
     msdk_printf(MSDK_STRING("   [-NumPredictorsL0 numPreds] - number of maximum L0 predictors (default - assign depending on the frame type)\n"));
@@ -649,7 +649,7 @@ void AdjustOptions(sInputParams& params)
     params.nNumSlices       = tune(params.nNumSlices, 0, 1);
     params.nIdrInterval     = tune(params.nIdrInterval, 0, 0xffff);
 
-    if (params.nRefDist < 2 && params.GPB != MFX_CODINGOPTION_ON)
+    if (params.nRefDist < 2) // avoid impact of NumRefActiveBL0/L1 in gop with P/GPB only
     {
         params.NumRefActiveBL0 = params.NumRefActiveBL1 = 0;
     }


### PR DESCRIPTION
MediaSDK treats GPB frames as P until it submits to driver. It helps
to distinguish options for GPB and B frames: NumRefActive for L0,
BRefType, PRefType. For the same reason MFX_FRAMETYPE_P is used for
GPB frames in sample_hevc_fei.