### PR TITLE
Fix _mfxSession::Cleanup

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_session.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_session.cpp
@@ -622,15 +622,6 @@ void _mfxSession::Cleanup(void)
         m_plgVPP->PluginClose();
     }
 
-    if (m_pScheduler)
-    {
-        m_pScheduler->Release();
-    }
-    if (m_pSchedulerAllocated)
-    {
-        m_pSchedulerAllocated->Release();
-    }
-
     // release the components the excplicit way.
     // do not relay on default deallocation order,
     // somebody could change it.
@@ -641,6 +632,9 @@ void _mfxSession::Cleanup(void)
     m_pDECODE.reset();
     m_pENCODE.reset();
     m_pCORE.reset();
+
+    // release m_pScheduler and m_pSchedulerAllocated
+    ReleaseScheduler();
 
     //delete m_coreInt.ExternalSurfaceAllocator;
     Clear();
@@ -765,10 +759,10 @@ mfxStatus _mfxSession::ReleaseScheduler(void)
         m_pScheduler->Release();
     
     if(m_pSchedulerAllocated)
-    m_pSchedulerAllocated->Release();
+        m_pSchedulerAllocated->Release();
 
-    m_pScheduler = NULL;
-    m_pSchedulerAllocated = NULL;
+    m_pScheduler = nullptr;
+    m_pSchedulerAllocated = nullptr;
     
     return MFX_ERR_NONE;
 


### PR DESCRIPTION
-Safe release m_pScheduler, m_pSchedulerAllocated.
 these pointers should be zeroid for avoid calls of unaccesible methods