### PR TITLE
[HEVC E]: fix for interlace (ref list and SWBRC) - part 2

### DIFF
--- a/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -2941,15 +2941,7 @@ void ConstructRPL(
 #elif (HEVCE_FIELD_MODE == 2)
                         MFX_SORT_COMMON(RPL[1], numRefActive[1], (Abs(DPB[RPL[1][_i]].m_poc/2 - poc/2)  + ((DPB[RPL[1][_i]].m_secondField == bSecondField) ? 0 : 16)) > (Abs(DPB[RPL[1][_j]].m_poc/2 - poc/2)  + ((DPB[RPL[1][_j]].m_secondField == bSecondField) ? 0 : 16)));
 #elif (HEVCE_FIELD_MODE == 3 || HEVCE_FIELD_MODE == 4)
-                    if (par.isBPyramid() && l0 > 1)
-                    {
-                       // if the case of B pyramid with multireference frames nearest L1 field is used.
-                        MFX_SORT_COMMON(RPL[1], numRefActive[1], Abs(DPB[RPL[1][_i]].m_poc - poc) > Abs(DPB[RPL[1][_j]].m_poc - poc));
-                    }
-                    else
-                    {
-                        MFX_SORT_COMMON(RPL[1], numRefActive[1], FieldDistancePolarity(poc, bSecondField, bBottomField, DPB[RPL[1][_i]]) > FieldDistancePolarity(poc, bSecondField, bBottomField, DPB[RPL[1][_j]]));
-                    }
+                       MFX_SORT_COMMON(RPL[1], numRefActive[1], FieldDistancePolarity(poc, bSecondField, bBottomField, DPB[RPL[1][_i]]) > FieldDistancePolarity(poc, bSecondField, bBottomField, DPB[RPL[1][_j]]));
 #endif
                 }
                 else

--- a/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
@@ -1052,8 +1052,8 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
     // Check other condions for recoding (update qp is it is needed)
     {
         mfxF64 targetFrameSize = MFX_MAX((mfxF64)m_par.inputBitsPerFrame, fAbLong);
-        mfxF64 dqf = DQF(picType, m_par.iDQp, ((picType == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), (ParSceneChange || m_ctx.encOrder == 0));
-        mfxF64 maxFrameSizeByRatio = dqf * FRM_RATIO(picType, m_ctx.encOrder, bSHStart, m_par.bPyr && (!m_par.bFieldMode)) * targetFrameSize;
+        mfxF64 dqf = (m_par.bFieldMode) ? 1.0 : DQF(picType, m_par.iDQp, ((picType == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), (ParSceneChange || m_ctx.encOrder == 0));
+        mfxF64 maxFrameSizeByRatio = dqf * FRM_RATIO(picType, m_ctx.encOrder, bSHStart, m_par.bPyr) * targetFrameSize;
         if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.bHRDConformance) {
             mfxF64 dev = -1.0*maxFrameSizeByRatio - m_hrd.GetBufferDiviation();
             if (dev > 0) maxFrameSizeByRatio += MFX_MIN(maxFrameSizeByRatio, (dev / (IS_IFRAME(picType) ? 2.0 : 4.0)));


### PR DESCRIPTION
Issue: MDP-46419
Test: manually

reflist was changed: L1 is correspondence field.
SW BRC:
-changes for inner bitrate: MaxFrameSize calculation was changed for B pyr field case (reduced), GopParams changing
-changes for all SW BRC: Layer+1 for second field.