### PR TITLE
[hevce] Writing vui video_full_range and colour_descr into bs

### DIFF
--- a/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/hevce_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1,15 +1,15 @@
 // Copyright (c) 2018 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1144,7 +1144,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
         // For 10 bit encode we need adjust min/max QP
         mfxU16 BitDepthLuma = par.mfx.FrameInfo.BitDepthLuma;
 
-        if (BitDepthLuma == 0 ) 
+        if (BitDepthLuma == 0 )
             BitDepthLuma = (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAIN10 || par.mfx.FrameInfo.FourCC == MFX_FOURCC_P010) ? 10 : 8;
 
         maxQP += 6 * (BitDepthLuma - 8);
@@ -1273,14 +1273,14 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
     else
         changed += CheckOption(par.m_ext.CO2.MBBRC, (mfxU32)MFX_CODINGOPTION_ON, (mfxU32)MFX_CODINGOPTION_OFF, 0);
 
- 
+
     if (IsOn(par.m_ext.CO2.ExtBRC) && par.mfx.RateControlMethod != 0 && par.mfx.RateControlMethod != MFX_RATECONTROL_CBR && par.mfx.RateControlMethod != MFX_RATECONTROL_VBR)
     {
         par.m_ext.CO2.ExtBRC = MFX_CODINGOPTION_OFF;
         changed ++;
     }
 
-    if ((!IsOn(par.m_ext.CO2.ExtBRC)) && 
+    if ((!IsOn(par.m_ext.CO2.ExtBRC)) &&
         (par.m_ext.extBRC.pthis || par.m_ext.extBRC.Init || par.m_ext.extBRC.Close || par.m_ext.extBRC.GetFrameCtrl || par.m_ext.extBRC.Update || par.m_ext.extBRC.Reset))
     {
         par.m_ext.extBRC.pthis = 0;
@@ -1306,7 +1306,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
 
 #ifdef MFX_ENABLE_HEVCE_INTERLACE
 
-    if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP || 
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP ||
         (IsOn(par.m_ext.CO2.ExtBRC) && (par.mfx.RateControlMethod == MFX_RATECONTROL_CBR || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR)))
     {
         changed += CheckOption(par.mfx.FrameInfo.PicStruct, (mfxU16)MFX_PICSTRUCT_PROGRESSIVE, MFX_PICSTRUCT_FIELD_TOP, MFX_PICSTRUCT_FIELD_BOTTOM, MFX_PICSTRUCT_FIELD_SINGLE, MFX_PICSTRUCT_FIELD_TFF, MFX_PICSTRUCT_FIELD_BFF,0);
@@ -1334,7 +1334,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
             invalid += CheckOption(par.mfx.FrameInfo.FourCC, (mfxU32)MFX_FOURCC_NV12, 0);
         else if (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAIN10)
             invalid += CheckOption(par.mfx.FrameInfo.FourCC, (mfxU32)MFX_FOURCC_P010, 0);
-        else if (par.mfx.FrameInfo.FourCC && par.mfx.FrameInfo.FourCC != (mfxU32)MFX_FOURCC_NV12 && par.mfx.FrameInfo.FourCC != (mfxU32)MFX_FOURCC_P010) 
+        else if (par.mfx.FrameInfo.FourCC && par.mfx.FrameInfo.FourCC != (mfxU32)MFX_FOURCC_NV12 && par.mfx.FrameInfo.FourCC != (mfxU32)MFX_FOURCC_P010)
         {
             invalid ++;
             par.mfx.FrameInfo.FourCC = 0;
@@ -1418,8 +1418,8 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
     changed += CheckTriStateOption(par.m_ext.CO.VuiNalHrdParameters);
     changed += CheckTriStateOption(par.m_ext.CO.NalHrdConformance);
 
-    if (par.mfx.RateControlMethod != MFX_RATECONTROL_CBR && 
-        par.mfx.RateControlMethod != MFX_RATECONTROL_VBR && 
+    if (par.mfx.RateControlMethod != MFX_RATECONTROL_CBR &&
+        par.mfx.RateControlMethod != MFX_RATECONTROL_VBR &&
         par.mfx.RateControlMethod != MFX_RATECONTROL_VCM)
     {
        changed += CheckOption(par.m_ext.CO.VuiNalHrdParameters, (mfxU32)MFX_CODINGOPTION_OFF, 0);
@@ -1453,7 +1453,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
             || (par.mfx.NumRefFrame && minRefForPyramid(par.mfx.GopRefDist, par.isField()) > par.mfx.NumRefFrame)))
     {
         if (par.mfx.EncodedOrder
-         && par.mfx.NumRefFrame > 2 
+         && par.mfx.NumRefFrame > 2
          && minRefForPyramid(par.mfx.GopRefDist, par.isField()) > par.mfx.NumRefFrame)
         {
             par.bNonStandardReord = true;  // let's allow this mode in encoding order (may be special B pyr is used)
@@ -1469,7 +1469,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
     {
         if (par.mfx.EncodedOrder && par.isField() && par.mfx.NumRefFrame > 1 && par.mfx.NumRefFrame < 4)
         {
-            par.bNonStandardReord = true;  // let's allow this mode in encoding order 
+            par.bNonStandardReord = true;  // let's allow this mode in encoding order
         }
         else
         {
@@ -1570,8 +1570,8 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
     if (CheckRangeDflt(par.m_ext.VSI.ColourPrimaries,         0, 255, 2)) changed +=1;
     if (CheckRangeDflt(par.m_ext.VSI.TransferCharacteristics, 0, 255, 2)) changed +=1;
     if (CheckRangeDflt(par.m_ext.VSI.MatrixCoefficients,      0, 255, 2)) changed +=1;
-    if (CheckOption(par.m_ext.VSI.VideoFullRange, 0))                     changed +=1;
-    if (CheckOption(par.m_ext.VSI.ColourDescriptionPresent, 0))           changed +=1;
+    if (CheckOption(par.m_ext.VSI.VideoFullRange, 0, 1))                  changed +=1;
+    if (CheckOption(par.m_ext.VSI.ColourDescriptionPresent, 0, 1))        changed +=1;
 
 #if defined(LINUX32) || defined(LINUX64)
     changed += CheckOption(CO3.GPB, (mfxU16)MFX_CODINGOPTION_UNKNOWN, (mfxU16)MFX_CODINGOPTION_ON, (mfxU16)MFX_CODINGOPTION_OFF);
@@ -1663,7 +1663,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
     if (CO3.EnableMBQP !=0 || par.bROIViaMBQP)
     {
         if (par.mfx.RateControlMethod != MFX_RATECONTROL_CQP && !par.isSWBRC())
-            changed += CheckOption(CO3.EnableMBQP, (mfxU16)MFX_CODINGOPTION_UNKNOWN, (mfxU16)MFX_CODINGOPTION_ON); 
+            changed += CheckOption(CO3.EnableMBQP, (mfxU16)MFX_CODINGOPTION_UNKNOWN, (mfxU16)MFX_CODINGOPTION_ON);
         else if (caps.MbQpDataSupport == 0)
         {
 #ifdef MFX_ENABLE_HEVCE_ROI


### PR DESCRIPTION
Previously this functionality was disabled by mistake.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>