### PR TITLE
Pass "-pie" LD flag for executables

### DIFF
--- a/builder/FindGlobals.cmake
+++ b/builder/FindGlobals.cmake
@@ -1,15 +1,15 @@
 # Copyright (c) 2017 Intel Corporation
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -95,7 +95,7 @@ if( Linux OR Darwin )
 
   set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -pipe -fPIC ${c_warnings} ${no_warnings}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -fPIC ${cxx_warnings} ${no_warnings}")
-  append("-fPIE -pie" CMAKE_EXEC_LINKER_FLAGS)
+  append("-fPIE -pie" CMAKE_EXE_LINKER_FLAGS)
 
   # CACHE + FORCE should be used only here to make sure that this parameters applied globally
   # End user is responsible to adjust configuration parameters further if needed. Here


### PR DESCRIPTION
CMAKE_EXEC_LINKER_FLAGS is a misprint.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>