### PR TITLE
Libmfx refactor: component inits

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -173,13 +173,6 @@ namespace MfxHwH264EncodeHW
 }
 using namespace MfxHwH264EncodeHW;
 
-VideoENCODE * CreateMFXHWVideoENCODEH264(
-    VideoCORE * core,
-    mfxStatus * res)
-{
-    return new MFXHWVideoENCODEH264(core, res);
-}
-
 mfxStatus MFXHWVideoENCODEH264::Init(mfxVideoParam * par)
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "MFXHWVideoENCODEH264::Init");

--- a/_studio/mfx_lib/shared/include/mfx_session.h
+++ b/_studio/mfx_lib/shared/include/mfx_session.h
@@ -163,6 +163,8 @@ struct _mfxSession
         return (NULL == m_pSchedulerAllocated);
     }
     
+    template<class T>
+    T* Create(mfxVideoParam& par);
 
 protected:
     // Release the object

--- a/_studio/mfx_lib/shared/include/mfx_session.h
+++ b/_studio/mfx_lib/shared/include/mfx_session.h
@@ -135,11 +135,8 @@ struct _mfxSession
 
     MFXIPtr<OperatorCORE> m_pOperatorCore;
 
-    // if there are no Enc HW capabilities but HW library is used
-    bool m_bIsHWENCSupport;
-
-    // if there are no Dec HW capabilities but HW library is used
-    bool m_bIsHWDECSupport;
+    bool m_reserved1;
+    bool m_reserved2;
 
 
     inline

--- a/_studio/mfx_lib/shared/include/mfx_tools.h
+++ b/_studio/mfx_lib/shared/include/mfx_tools.h
@@ -23,15 +23,6 @@
 
 #include <mfxvideo++int.h>
 
-// Declare functions for components creation
-VideoENCODE *CreateENCODESpecificClass(mfxU32 codecId, VideoCORE *pCore, mfxSession session, mfxVideoParam *par);
-VideoDECODE *CreateDECODESpecificClass(mfxU32 codecId, VideoCORE *pCore);
-VideoVPP *CreateVPPSpecificClass(mfxU32 reserved, VideoCORE *pCore);
-VideoENC *CreateENCSpecificClass(mfxU32 codecId, VideoCORE *pCore);
-VideoPAK *CreatePAKSpecificClass(mfxU32 codecId, mfxU32 codecProfile, VideoCORE *pCore);
-
-VideoENCODE* CreateMFXHWVideoENCODEH264(VideoCORE *core, mfxStatus *res);
-
 namespace MFX
 {
     unsigned int CreateUniqId();

--- a/_studio/mfx_lib/shared/src/libmfxsw_enc.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_enc.cpp
@@ -202,30 +202,11 @@ mfxStatus MFXVideoENC_Init(mfxSession session, mfxVideoParam *par)
         if (!session->m_pENC.get())
         {
             // create a new instance
-            session->m_bIsHWENCSupport = true;
             session->m_pENC.reset(session->Create<VideoENC>(*par));
             MFX_CHECK(session->m_pENC.get(), MFX_ERR_INVALID_VIDEO_PARAM);
         }
 
         mfxRes = session->m_pENC->Init(par);
-
-        if (MFX_WRN_PARTIAL_ACCELERATION == mfxRes)
-        {
-            session->m_bIsHWENCSupport = false;
-            session->m_pENC.reset(session->Create<VideoENC>(*par));
-            MFX_CHECK(session->m_pENC.get(), MFX_ERR_NULL_PTR);
-            mfxRes = session->m_pENC->Init(par);
-        }
-        else if (mfxRes >= MFX_ERR_NONE)
-            session->m_bIsHWENCSupport = true;
-
-        // SW fallback if EncodeGUID is absence
-        if (MFX_PLATFORM_HARDWARE == session->m_currentPlatform &&
-            !session->m_bIsHWENCSupport &&
-            MFX_ERR_NONE <= mfxRes)
-        {
-            mfxRes = MFX_WRN_PARTIAL_ACCELERATION;
-        }
     }
     // handle error(s)
     catch(MFX_CORE_CATCH_TYPE)

--- a/_studio/mfx_lib/shared/src/libmfxsw_pak.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_pak.cpp
@@ -141,13 +141,6 @@ mfxStatus MFXVideoPAK_Init(mfxSession session, mfxVideoParam *par)
     MFX_CHECK(par, MFX_ERR_NULL_PTR);
     try
     {
-        // close the existing PAK unit,
-        // if it is initialized.
-        if (session->m_pPAK.get())
-        {
-            MFXVideoPAK_Close(session);
-        }
-
         // create a new instance
         session->m_pPAK.reset(session->Create<VideoPAK>(*par));
         MFX_CHECK(session->m_pPAK.get(), MFX_ERR_INVALID_VIDEO_PARAM);

--- a/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
@@ -201,6 +201,12 @@ mfxStatus MFXVideoUSER_Register(mfxSession session, mfxU32 type,
             return MFX_ERR_UNDEFINED_BEHAVIOR;
         }
 
+#ifndef MFX_ENABLE_USER_VPP
+        if (sessionPtr.isNeedVPP()) {
+            return MFX_ERR_UNSUPPORTED;
+        }
+#endif
+
         //check is this plugin was included into MSDK lib as a native component
         mfxRes = par->GetPluginParam(par->pthis, &pluginParam);
         MFX_CHECK_STS(mfxRes);

--- a/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
@@ -33,23 +33,25 @@
 #include "mfx_vpp_main.h"       // this VideoVPP class builds VPP pipeline and run the VPP pipeline
 #endif
 
-VideoVPP *CreateVPPSpecificClass(mfxU32 /* reserved */, VideoCORE *core)
+template<>
+VideoVPP* _mfxSession::Create<VideoVPP>(mfxVideoParam& par)
 {
-    VideoVPP *pVPP = (VideoVPP *) 0;
-    mfxStatus mfxRes = MFX_ERR_MEMORY_ALLOC;
+    VideoVPP *pVPP = nullptr;
 
 #ifdef MFX_ENABLE_VPP
+    VideoCORE* core = m_pCORE.get();
+    mfxStatus mfxRes = MFX_ERR_MEMORY_ALLOC;
+
     pVPP = new VideoVPPMain(core, &mfxRes);
     if (MFX_ERR_NONE != mfxRes)
     {
         delete pVPP;
-        pVPP = (VideoVPP *) 0;
+        pVPP = nullptr;
     }
 #endif // MFX_ENABLE_VPP
 
     return pVPP;
-
-} // VideoVPP *CreateVPPSpecificClass(mfxU32 reserved)
+}
 
 mfxStatus MFXVideoVPP_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out)
 {
@@ -167,7 +169,7 @@ mfxStatus MFXVideoVPP_Init(mfxSession session, mfxVideoParam *par)
 
 
             // create a new instance
-            session->m_pVPP.reset(CreateVPPSpecificClass(0 ,session->m_pCORE.get()));
+            session->m_pVPP.reset(session->Create<VideoVPP>(*par));
             MFX_CHECK(session->m_pVPP.get(), MFX_ERR_INVALID_VIDEO_PARAM);
             mfxRes = session->m_pVPP->Init(par);
 #endif // MFX_ENABLE_VPP

--- a/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
@@ -150,32 +150,20 @@ mfxStatus MFXVideoVPP_Init(mfxSession session, mfxVideoParam *par)
 
     try
     {
-#ifdef MFX_ENABLE_USER_VPP
-        if (session->m_plgVPP.get())
+        // check existence of component
+        if (!session->m_pVPP.get())
         {
-            mfxRes = session->m_plgVPP->Init(par);
-        }
-        else
-        {
-#endif
-
-#ifdef MFX_ENABLE_VPP
-            // close the existing video processor,
-            // if it is initialized.
-            if (session->m_pVPP.get())
-            {
-                MFXVideoVPP_Close(session);
-            }
-
-
             // create a new instance
             session->m_pVPP.reset(session->Create<VideoVPP>(*par));
-            MFX_CHECK(session->m_pVPP.get(), MFX_ERR_INVALID_VIDEO_PARAM);
-            mfxRes = session->m_pVPP->Init(par);
-#endif // MFX_ENABLE_VPP
-#ifdef MFX_ENABLE_USER_VPP
-        }
+#ifdef MFX_ENABLE_VPP
+            MFX_CHECK(session->m_pENCODE.get(), MFX_ERR_INVALID_VIDEO_PARAM);
+#else
+            MFX_CHECK(session->m_pENCODE.get(), MFX_ERR_UNSUPPORTED);
 #endif
+        }
+
+        // create a new instance
+        mfxRes = session->m_pVPP->Init(par);
     }
     // handle error(s)
     catch(MFX_CORE_CATCH_TYPE)

--- a/_studio/mfx_lib/shared/src/mfx_session.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_session.cpp
@@ -577,8 +577,8 @@ _mfxSession::_mfxSession(const mfxU32 adapterNum)
     , m_priority()
     , m_version()
     , m_pOperatorCore()
-    , m_bIsHWENCSupport()
-    , m_bIsHWDECSupport()
+    , m_reserved1()
+    , m_reserved2()
 {
     m_currentPlatform = MFX_PLATFORM_HARDWARE;
 
@@ -597,9 +597,6 @@ void _mfxSession::Clear(void)
     m_pSchedulerAllocated = NULL;
 
     m_priority = MFX_PRIORITY_NORMAL;
-    m_bIsHWENCSupport = false;
-    //m_coreInt.ExternalSurfaceAllocator = 0;
-
 } // void _mfxSession::Clear(void)
 
 void _mfxSession::Cleanup(void)


### PR DESCRIPTION
That's a refactor towards a bigger goal which I will submit if we will agree on this series: https://github.com/dvrogozh/MediaSDK/tree/scheduler_threads. And even further I am trying to get single place where mediasdk components are being initialized/closed to effectively add a hook to the scheduler.