### PR TITLE
[plugins] Remove GetPluginType method as it's not part of base interface

### DIFF
--- a/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_hw.h
+++ b/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_hw.h
@@ -152,11 +152,6 @@ public:
 
     virtual mfxStatus GetPluginParam(mfxPluginParam *par) override;
 
-    virtual mfxU32 GetPluginType()
-    {
-        return MFX_PLUGINTYPE_VIDEO_ENCODE;
-    }
-
     virtual void Release() override
     {
         delete this;

--- a/_studio/hevce_hw/h265/include/mfx_h265_encode_plugin_hw.h
+++ b/_studio/hevce_hw/h265/include/mfx_h265_encode_plugin_hw.h
@@ -135,11 +135,6 @@ public:
         return MFX_ERR_UNDEFINED_BEHAVIOR;
     }
 
-    virtual mfxU32 GetPluginType()
-    {
-        return MFX_PLUGINTYPE_VIDEO_ENCODE;
-    }
-
     virtual void Release()
     {
         return;

--- a/_studio/mfx_lib/plugin/include/mfx_h264la_plugin.h
+++ b/_studio/mfx_lib/plugin/include/mfx_h264la_plugin.h
@@ -104,10 +104,7 @@ public:
         tmp_pplg->m_createdByDispatcher = true;
         return MFX_ERR_NONE;
     }
-    virtual mfxU32 GetPluginType()
-    {
-        return MFX_PLUGINTYPE_VIDEO_ENC;
-    }
+
     virtual mfxStatus SetAuxParams(void* , int )
     {
         return MFX_ERR_UNKNOWN;

--- a/_studio/mfx_lib/plugin/include/mfx_vpp_plugin.h
+++ b/_studio/mfx_lib/plugin/include/mfx_vpp_plugin.h
@@ -106,10 +106,7 @@ public:
         tmp_pplg->m_createdByDispatcher = true;
         return MFX_ERR_NONE;
     }
-    virtual mfxU32 GetPluginType()
-    {
-        return MFX_PLUGINTYPE_VIDEO_VPP;
-    }
+
     virtual mfxStatus SetAuxParams(void* , int )
     {
         return MFX_ERR_UNKNOWN;


### PR DESCRIPTION
Plugin type can be obtained by GetPluginParam call