### PR TITLE
metrics_monitor: use stdio.h instead of libio.h in the tests

### DIFF
--- a/samples/metrics_monitor/test/igt_load.cpp
+++ b/samples/metrics_monitor/test/igt_load.cpp
@@ -27,10 +27,10 @@
 /* Source file content was taken from Intel GPU Tools */
 
 #include "igt_load.h"
-#include <libio.h>
 #include <errno.h>
 #include <time.h>
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes: #484

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>