### PR TITLE
[vp8d] fix partition size

### DIFF
--- a/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_vp8_defs.h
+++ b/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_vp8_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -250,10 +250,10 @@ typedef struct _vp8_FrameInfo
 
   mfxSize frameSize; // actual width/height without padding cols/rows
 
-  uint32_t firstPartitionSize;
+  uint32_t firstPartitionSize; // Header info bits rounded up to byte
   uint16_t version;
 
-  uint32_t entropyDecSize;
+  uint32_t entropyDecSize; // Header info consumed bits
   uint32_t entropyDecOffset;
 
 } vp8_FrameInfo;

--- a/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
@@ -1287,10 +1287,11 @@ mfxStatus VideoDECODEVP8_HW::DecodeFrameHeader(mfxBitstream *in)
         while (++i < 2);
     }
 
+    // Header info consumed bits
     m_frame_info.entropyDecSize = m_boolDecoder[VP8_FIRST_PARTITION].pos() * 8 - 3*8 - m_boolDecoder[VP8_FIRST_PARTITION].bitcount();
 
-    mfxU32 remaining_bits = m_boolDecoder[VP8_FIRST_PARTITION].bitcount() & 0x7;
-    m_frame_info.firstPartitionSize = first_partition_size - (m_boolDecoder[VP8_FIRST_PARTITION].pos() - 3 + (remaining_bits ? 1 : 0) );
+    // Subtract completely consumed bytes + current byte. Current is completely consumed if bitcount is 8.
+    m_frame_info.firstPartitionSize = first_partition_size - ((m_frame_info.entropyDecSize + 7) >> 3);
 
     return MFX_ERR_NONE;
 }

--- a/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw_vaapi.cpp
@@ -221,6 +221,8 @@ mfxStatus VideoDECODEVP8_HW::PackHeaders(mfxBitstream *p_bistream)
          picParams->mv_probs[1][i] = m_frameProbs.mvContexts[1][i];
      }
 
+     // Note that va says that count is a number of remained bits in value,
+     // but in fact when count is 0 it does need next byte in value. That is what we have.
      picParams->bool_coder_ctx.range = m_boolDecoder[VP8_FIRST_PARTITION].range();
      picParams->bool_coder_ctx.value = (m_boolDecoder[VP8_FIRST_PARTITION].value() >> 24) & 0xff;
      picParams->bool_coder_ctx.count = m_boolDecoder[VP8_FIRST_PARTITION].bitcount() & 0x7;


### PR DESCRIPTION
The fix is to align changes in lib and in driver, that
improve use of bitcount and 1st partion size computation.
No more special code for count==8.
Should be merged together with lakulako/media-driver#1,
or with https://github.com/intel/media-driver/pull/239

Issue: MDP-46726
Test: manual, debug with driver