### PR TITLE
[HEVC][lib] Fix for get valid MaxNum_Reference1

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -823,6 +823,11 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
             attrs[ idx_map[VAConfigAttribEncMaxRefFrames] ].value & 0xffff;
         m_caps.MaxNum_Reference1 =
             (attrs[ idx_map[VAConfigAttribEncMaxRefFrames] ].value >>16) & 0xffff;
+
+        if(!m_caps.MaxNum_Reference1 || (m_caps.MaxNum_Reference1 > m_caps.MaxNum_Reference0))
+        {
+            m_caps.MaxNum_Reference1 = m_caps.MaxNum_Reference0;
+        }
     }
     else
     {


### PR DESCRIPTION
-MaxNum_Reference1:  Maximum number of reference per
list1 supported. If number is n, that means list 1
can have maximum n reference. If number is 0 or
bigger than MaxNum_Reference0, it shall be
treated as MaxNum_Reference0.