### PR TITLE
Fixes for SMT

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -900,9 +900,15 @@ mfxStatus CTranscodingPipeline::PreEncOneFrame(ExtendedSurface *pInSurface, Exte
 // signal that there are no more frames
 void CTranscodingPipeline::NoMoreFramesSignal()
 {
+    SafetySurfaceBuffer *pNextBuffer = m_pBuffer;
+
+    // For transcoding pipelines (PipelineMode::Native) this pointer is null
+    if (!pNextBuffer)
+        return;
+
     ExtendedSurface surf={};
-    SafetySurfaceBuffer   *pNextBuffer = m_pBuffer;
     pNextBuffer->AddSurface(surf);
+
     /*if 1_to_N mode */
     if (0 == m_nVPPCompEnable)
     {

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -4463,14 +4463,27 @@ mfxStatus CTranscodingPipeline::Join(MFXVideoSession *pChildSession)
 
 mfxStatus CTranscodingPipeline::Run()
 {
+    mfxStatus sts = MFX_ERR_NONE;
+
     if (m_bDecodeEnable && m_bEncodeEnable)
-        return Transcode();
+    {
+        sts = Transcode();
+        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Transcode() failed");
+    }
     else if (m_bDecodeEnable)
-        return Decode();
+    {
+        sts = Decode();
+        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Decode() failed");
+    }
     else if (m_bEncodeEnable)
-        return Encode();
+    {
+        sts = Encode();
+        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Encode() failed");
+    }
     else
         return MFX_ERR_UNSUPPORTED;
+
+    return sts;
 }
 
 void IncreaseReference(mfxFrameData *ptr)


### PR DESCRIPTION
The issue was the following. In transcoding pipelines we don't use SafetySurfaceBuffers at all (they are used to pass surfaces from decoder to encoder if they are in separate threads, which isn' t a trancoding case (I mean pipelines with PipelineMode::Native)). So the class is holding a null pointer to such buffers  (m_pBuffer) in described scenario. The issue ONLY takes place in case if some pipeline will receive error status, that will result in stopping all the pipelines, including transcoding pipelines. If transcoding pipeline was at decode stage it will trigger NoMoreFrames function call (this is shared code between Trancode and Decode pipelines, so this call is sufficient for Decode case) that in result will lead to null pointer (m_pBuffer) dereferencing since Trancode pipelines don't have those buffers.

So issue won't take place in case of none error. Actually we have broken mechanism of error processing in Transcoding pipelines.

I also added some error logging, because as I see from code there exist code passes where captured error doesn't produce any print to console 