### PR TITLE
[ASC] New descriptors integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,21 @@ if( CMAKE_SYSTEM_NAME MATCHES Linux )
 endif()
 
 option( ENABLE_ITT "Build targets with ITT instrumentation support (requires VTune)?" OFF )
-option( ENABLE_TEXTLOG "Enable textlog tracing?" OFF )
-option( ENABLE_STAT "Enable stat tracing?" OFF )
+
+# -DENABLE_ALL will enable all the dependencies and features unless user did not
+# explicitly switched some of them OFF, i.e. configuring in the following way
+# is possible:
+#   cmake -DENABLE_ALL=ON -DENABLE_TEXTLOG=OFF
+# and it will configure all targets except samples.
+#
+# TODO: As of now ENABLE_ALL is not fully implemented, it will not affect all
+#   of the ENABLE_* options. Those options it don't affect are placed above
+#   ENABLE_ALL definition and require some rework and/or pending CI adoption.
+#
+option( ENABLE_ALL "Enable all dependencies and features?" OFF )
+
+cmake_dependent_option( ENABLE_TEXTLOG "Enable textlog tracing?" ON "ENABLE_ALL" OFF)
+cmake_dependent_option( ENABLE_STAT "Enable stat tracing?" ON "ENABLE_ALL" OFF)
 
 # -DBUILD_ALL will enable all the build targets unless user did not explicitly
 # switched some targets OFF, i.e. configuring in the following way is possible:

--- a/_studio/shared/asc/include/asc.h
+++ b/_studio/shared/asc/include/asc.h
@@ -43,6 +43,13 @@ public:
     ASCYUV Image;
     ASCMVector
         *pInteger;
+    mfxI32
+        var,
+        jtvar,
+        mcjtvar;
+    mfxI16
+        tcor,
+        mcTcor;
     CmSurface2DUP
         *gpuImage;
     SurfaceIndex

--- a/_studio/shared/asc/include/asc_structures.h
+++ b/_studio/shared/asc/include/asc_structures.h
@@ -222,6 +222,9 @@ typedef struct ASCstats_structure {
         AbsMVSize,
         AbsMVHSize,
         AbsMVVSize;
+    mfxI16
+        tcor,
+        mcTcor;
     mfxU16
         AFD;
     mfxI32

--- a/_studio/shared/asc/include/me_asc.h
+++ b/_studio/shared/asc/include/me_asc.h
@@ -77,6 +77,45 @@ mfxU16 ME_SAD_8x8_Block(mfxU8 *pSrc, mfxU8 *pRef, mfxU32 srcPitch, mfxU32 refPit
     return (mfxU16)_mm_extract_epi16(s0, 0);
 }
 
+void ME_VAR_8x8_Block(mfxU8 *pSrc, mfxU8 *pRef, mfxU8 *pMCref, mfxI16 srcAvgVal, mfxI16 refAvgVal, mfxU32 srcPitch, mfxU32 refPitch, mfxI32 &var, mfxI32 &jtvar, mfxI32 &jtMCvar)
+{
+    __m128i srcAvg = _mm_set1_epi16(srcAvgVal);
+    __m128i refAvg = _mm_set1_epi16(refAvgVal);
+
+    __m128i src[8],
+            ref[8],
+            rmc[8],
+        accuVar = { 0 },
+        accuJtvar = { 0 },
+        accuMcJtvar = { 0 };
+
+    for (mfxU8 i = 0; i < 8; i++)
+    {
+        src[i] = _mm_cvtepu8_epi16(_mm_loadu_si128((__m128i *)&pSrc[i * srcPitch]));
+        ref[i] = _mm_cvtepu8_epi16(_mm_loadu_si128((__m128i *)&pRef[i * refPitch]));
+        rmc[i] = _mm_cvtepu8_epi16(_mm_loadu_si128((__m128i *)&pMCref[i * refPitch]));
+        src[i] = _mm_sub_epi16(src[i], srcAvg);
+        ref[i] = _mm_sub_epi16(ref[i], refAvg);
+        rmc[i] = _mm_sub_epi16(rmc[i], refAvg);
+        accuVar = _mm_add_epi32(_mm_madd_epi16(src[i], src[i]),accuVar);
+        accuJtvar = _mm_add_epi32(_mm_madd_epi16(src[i], ref[i]),accuJtvar);
+        accuMcJtvar = _mm_add_epi32(_mm_madd_epi16(src[i], rmc[i]),accuMcJtvar);
+    }
+
+    accuVar = _mm_hadd_epi32(accuVar, accuVar);
+    accuVar = _mm_hadd_epi32(accuVar, accuVar);
+
+    accuJtvar = _mm_hadd_epi32(accuJtvar, accuJtvar);
+    accuJtvar = _mm_hadd_epi32(accuJtvar, accuJtvar);
+
+    accuMcJtvar = _mm_hadd_epi32(accuMcJtvar, accuMcJtvar);
+    accuMcJtvar = _mm_hadd_epi32(accuMcJtvar, accuMcJtvar);
+
+    var += _mm_extract_epi32(accuVar, 0);
+    jtvar += _mm_extract_epi32(accuJtvar, 0);
+    jtMCvar += _mm_extract_epi32(accuMcJtvar, 0);
+}
+
 mfxU16 ME_preSAD_8x8_Block(mfxU8 *pSrc, mfxU8 *pRef, mfxU32 srcPitch, mfxU32 refPitch)
 {
     __m128i s0 = _mm_loadh_epi64(_mm_loadl_epi64((__m128i *)&pSrc[0*srcPitch]), (__m128i *)&pSrc[1*srcPitch]);

--- a/_studio/shared/asc/src/motion_estimation_engine.cpp
+++ b/_studio/shared/asc/src/motion_estimation_engine.cpp
@@ -101,6 +101,15 @@ bool MVcalcSAD8x8(ASCMVector MV, pmfxU8 curY, pmfxU8 refY, ASCImDetails *dataIn,
     return false;
 }
 
+void MVcalcVar8x8(ASCMVector MV, pmfxU8 curY, pmfxU8 refY, mfxI16 curAvg, mfxI16 refAvg, mfxI32 &var, mfxI32 &jtvar, mfxI32 &jtMCvar, ASCImDetails *dataIn) {
+    mfxI32
+        _fPos = MV.x + (MV.y * dataIn->Extended_Width);
+    pmfxU8
+        fRef = &refY[_fPos];
+
+    ME_VAR_8x8_Block(curY, refY, fRef, curAvg, refAvg, dataIn->Extended_Width, dataIn->Extended_Width, var, jtvar, jtMCvar);
+}
+
 bool MVcalcSAD16x8(ASCMVector MV, pmfxU8 curY, pmfxU8 refY, ASCImDetails dataIn, mfxU16 *bestSAD, mfxI32 *distance) {
     mfxI32
         preDist = (MV.x * MV.x) + (MV.y * MV.y);
@@ -344,6 +353,7 @@ mfxU16 __cdecl ME_simple(ASCVidRead *videoIn, mfxI32 fPos, ASCImDetails *dataIn,
         }
     }
     videoIn->average += (current[fPos].x * current[fPos].x) + (current[fPos].y * current[fPos].y);
+    MVcalcVar8x8(current[fPos], objFrame, refFrame, scale->avgval, scaleRef->avgval, scale->var, scale->jtvar, scale->mcjtvar, dataIn);
     return(zeroSAD);
 }
 };


### PR DESCRIPTION
[ASC] New descriptors integration

Integration of two new descriptors for ASC module, which
is preliminary work for implementation of fade detection
new feature in ASC. The new descriptors are 1) temporal
correlation and 2) motion compensated temporal correlation

Issue: -
Test: Manual test