### PR TITLE
[MJPEGe] Enable encode YUY2 422H content for Linux

### DIFF
--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
@@ -353,9 +353,7 @@ mfxStatus MFXVideoENCODEMJPEG_HW::Query(VideoCORE * core, mfxVideoParam *in, mfx
 
         if ((fourCC == 0 && chromaFormat == 0) ||
             (fourCC == MFX_FOURCC_NV12 && (chromaFormat == MFX_CHROMAFORMAT_YUV420 || chromaFormat == MFX_CHROMAFORMAT_YUV400)) ||
-#if !defined(LINUX)
             (fourCC == MFX_FOURCC_YUY2 && chromaFormat == MFX_CHROMAFORMAT_YUV422H) ||
-#endif
             (fourCC == MFX_FOURCC_RGB4 && chromaFormat == MFX_CHROMAFORMAT_YUV444))
         {
             out->mfx.FrameInfo.FourCC = in->mfx.FrameInfo.FourCC;


### PR DESCRIPTION
-FourCC = YUY2, CromaFormat = YUV422 is supported input fomat for HW JPEG encode on Linux
-Tested manually