### PR TITLE
Delete hardcode value for VAConfigAttribRTFormat

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -953,7 +953,6 @@ mfxStatus VAAPIEncoder::CreateAccelerationService(MfxVideoParam const & par)
     if ((attrib[1].value & vaRCType) == 0)
         return MFX_ERR_DEVICE_FAILED;
 
-    attrib[0].value = VA_RT_FORMAT_YUV420;
     attrib[1].value = vaRCType;
 
     sts = CheckExtraVAattribs(attrib);


### PR DESCRIPTION
- Delete hardcode value for VAConfigAttribRTFormat because
function vaGetConfigAttributes get valid params for
attributes.