### PR TITLE
[builder]: fix [make_library] linker options

### DIFF
--- a/builder/FindFunctions.cmake
+++ b/builder/FindFunctions.cmake
@@ -207,6 +207,10 @@ function( make_library name variant type )
       target_link_libraries( ${target} ${lib} )
     endforeach()
 
+    if( Linux )
+      target_link_libraries( ${target} "-Xlinker --end-group" )
+    endif()
+
 #    set_target_properties( ${target} PROPERTIES LINK_INTERFACE_LIBRARIES "" )
   endif()
 
@@ -224,7 +228,7 @@ function( make_library name variant type )
   set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_LIB_DIR}/${CMAKE_BUILD_TYPE} FOLDER ${folder} )
 
   if( Linux )
-    target_link_libraries( ${target} "-Xlinker --end-group -lgcc" )
+    target_link_libraries( ${target} "-lgcc" )
   endif()
 
   set( target ${target} PARENT_SCOPE )


### PR DESCRIPTION
 -  [make_library] produces incorrect linker flags for STATIC library.
    Linker error is '/usr/bin/ld: group ended before it began'.
    RC is [make_library] adds "-Xlinker --start-group" only for SHARED
    target but puts "-Xlinker --end-group" for any variant.

Issue: https://github.com/Intel-Media-SDK/MediaSDK/issues/531
Test: compilation