### PR TITLE
Fix options behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ option( ENABLE_ITT "Build targets with ITT instrumentation support (requires VTu
 #
 option( ENABLE_ALL "Enable all dependencies and features?" OFF )
 
-cmake_dependent_option( ENABLE_TEXTLOG "Enable textlog tracing?" ON "ENABLE_ALL" OFF)
-cmake_dependent_option( ENABLE_STAT "Enable stat tracing?" ON "ENABLE_ALL" OFF)
+option( ENABLE_TEXTLOG "Enable textlog tracing?" "${ENABLE_ALL}")
+option( ENABLE_STAT "Enable stat tracing?" "${ENABLE_ALL}")
 
 # -DBUILD_ALL will enable all the build targets unless user did not explicitly
 # switched some targets OFF, i.e. configuring in the following way is possible:
@@ -75,7 +75,7 @@ option( BUILD_DISPATCHER "Build dispatcher?" ON )
 cmake_dependent_option(BUILD_SAMPLES "Build samples?" ON "BUILD_DISPATCHER" OFF )
 # Tools depend on samples (sample_common) and can't be built without it. The
 # following BUILD_TOOLS option declaration assures that.
-cmake_dependent_option(BUILD_TOOLS "Build tools?" ON "BUILD_ALL;BUILD_SAMPLES" OFF)
+cmake_dependent_option(BUILD_TOOLS "Build tools?" "${BUILD_ALL}" "BUILD_SAMPLES" OFF)
 
 include( ${BUILDER_ROOT}/FindOpenCL.cmake )
 include( ${BUILDER_ROOT}/FindFunctions.cmake )


### PR DESCRIPTION
cmake_dependent_option defines an options if and only if other option
is defined. If other option is not defined, value will be initialized
to the given default and it can _not_ be changed. As a result we lost
opportunity to use such options as ENABLE_TEXTLOG directly without
ENABLE_ALL. This change fixes the behavior. cmake_dependent_options
is not the thing to use here.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>