### PR TITLE
clang: removes warning class HevcTaskDSO was previously declared as a struct

### DIFF
--- a/samples/sample_hevc_fei_abr/include/fei_utils.h
+++ b/samples/sample_hevc_fei_abr/include/fei_utils.h
@@ -59,7 +59,7 @@ private:
 
 /**********************************************************************************/
 
-class HevcTaskDSO;
+struct HevcTaskDSO;
 class IYUVSource
 {
 public:


### PR DESCRIPTION
Removes warning class 'HevcTaskDSO' was previously declared as a struct in clang 6.0
Issue #422