### PR TITLE
clang: Fixes warning overrides a member function but is not marked override

### DIFF
--- a/samples/sample_hevc_fei_abr/include/abr_brc.h
+++ b/samples/sample_hevc_fei_abr/include/abr_brc.h
@@ -156,7 +156,7 @@ public:
         return m_curQp;
     }
 
-    void SubmitNewStat(FrameStatData& /*stat*/) { return; }
+    void SubmitNewStat(FrameStatData& /*stat*/) override { return; }
 
 private:
     ExtBRC m_SW_BRC;


### PR DESCRIPTION
Fixes 'SubmitNewStat' overrides a member function but is not marked 'override' warning on clang 6.0
Issue #422
