### PR TITLE
clang: fixes 'using the result of an assignment as a condition without parentheses' 

### DIFF
--- a/samples/sample_common/src/plugin_utils.cpp
+++ b/samples/sample_common/src/plugin_utils.cpp
@@ -120,7 +120,7 @@ const mfxPluginUID & msdkGetPluginUID(mfxIMPL impl, msdkComponentType type, mfxU
             break;
         }
     }
-    else if (impl |= MFX_IMPL_HARDWARE)
+    else
     {
         switch(type)
         {


### PR DESCRIPTION
Fixes 'using the result of an assignment as a condition without parentheses' in clang 6.0.
I'm not sure that I'm right. But '| = 'looks strange in this context. The condition is always true, and impl is not used in the future, so the best way will be remove second condition at all.