### PR TITLE
clang 6.0: different number of parameters in child and parent class

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -3827,7 +3827,7 @@ mfxStatus CTranscodingPipeline::Init(sInputParams *pParams,
     if (m_pmfxVPP.get())
     {
         if (m_bIsPlugin && m_bIsVpp)
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);
         else
@@ -3938,7 +3938,7 @@ mfxStatus CTranscodingPipeline::CompleteInit()
     if (m_pmfxVPP.get())
     {
         if (m_bIsPlugin && m_bIsVpp)
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);
         else
@@ -4366,7 +4366,7 @@ mfxStatus CTranscodingPipeline::Reset()
             sts = m_pmfxVPP->QueryIOSurf(&m_mfxPluginParams, request, &m_mfxVppParams);
             MSDK_CHECK_STATUS(sts, "m_pmfxVPP->QueryIOSurf failed");
 
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         }
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -3348,7 +3348,7 @@ mfxStatus CTranscodingPipeline::CalculateNumberOfReqFrames(mfxFrameAllocRequest 
         MSDK_ZERO_MEMORY(VppRequest);
         if (m_bIsPlugin && m_bIsVpp)
         {
-            sts = m_pmfxVPP.get()->QueryIOSurf(&m_mfxPluginParams, &(VppRequest[0]), &m_mfxVppParams);
+            sts = m_pmfxVPP.get()->QueryIOSurfMulti(&m_mfxPluginParams, &(VppRequest[0]), &m_mfxVppParams);
             if (!CheckAsyncDepth(VppRequest[0], m_mfxPluginParams.AsyncDepth) ||
                 !CheckAsyncDepth(VppRequest[1], m_mfxPluginParams.AsyncDepth) ||
                 !CheckAsyncDepth(VppRequest[0], m_mfxVppParams.AsyncDepth) ||
@@ -4363,7 +4363,7 @@ mfxStatus CTranscodingPipeline::Reset()
         if (m_bIsPlugin && m_bIsVpp)
         {
             mfxFrameAllocRequest request[2] {};
-            sts = m_pmfxVPP->QueryIOSurf(&m_mfxPluginParams, request, &m_mfxVppParams);
+            sts = m_pmfxVPP->QueryIOSurfMulti(&m_mfxPluginParams, request, &m_mfxVppParams);
             MSDK_CHECK_STATUS(sts, "m_pmfxVPP->QueryIOSurf failed");
 
             sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);

--- a/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
@@ -32,17 +32,23 @@ public:
     virtual ~MFXVideoMultiVPP(void) { Close(); }
 
     // topology methods
-    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    virtual mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { (void)par1; (void)par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
+
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2]) final
+    { return QueryIOSurfMulti(par, request); }
 
     virtual mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { (void)par1; (void)par2; return MFXVideoVPP_Init(m_session, par); }
 
-    virtual mfxStatus Init(mfxVideoParam *par)
+    virtual mfxStatus Init(mfxVideoParam *par) final
     {  return InitMulti(par);  }
 
-    virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
-    { return MFXVideoVPP_Reset(m_session, par); }
+    virtual mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    { (void)par1; (void)par2; return MFXVideoVPP_Reset(m_session, par); }
+
+    virtual mfxStatus Reset(mfxVideoParam *par) final
+    { return ResetMulti(par); }
 
     virtual mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp)
     { return MFXVideoVPP_RunFrameVPPAsync(m_session, in, out, aux, syncp); }
@@ -53,14 +59,23 @@ public:
     virtual mfxStatus Close(void) { return MFXVideoVPP_Close(m_session); }
 
     // per-component methods
-    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 /*component_idx*/)
-    { return MFXVideoVPP_Query(m_session, in, out); }
+    virtual mfxStatus QueryMulti(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_Query(m_session, in, out); }
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 /*component_idx*/)
-    { return MFXVideoVPP_GetVideoParam(m_session, par); }
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) final
+    { return QueryMulti(in, out); }
 
-    virtual mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 /*component_idx*/)
-    { return MFXVideoVPP_GetVPPStat(m_session, stat); }
+    virtual mfxStatus GetVideoParamMulti(mfxVideoParam *par, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_GetVideoParam(m_session, par); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) final
+    { return GetVideoParamMulti(par); }
+
+    virtual mfxStatus GetVPPStatMulti(mfxVPPStat *stat, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_GetVPPStat(m_session, stat); }
+
+    virtual mfxStatus GetVPPStat(mfxVPPStat *stat) final
+    { return GetVPPStatMulti(stat); }
 };
 
 #endif//__MFX_MULTI_VPP_H

--- a/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
@@ -35,8 +35,11 @@ public:
     virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { (void)par1; (void)par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
 
-    virtual mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    virtual mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { (void)par1; (void)par2; return MFXVideoVPP_Init(m_session, par); }
+
+    virtual mfxStatus Init(mfxVideoParam *par)
+    {  return InitMulti(par);  }
 
     virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
     { return MFXVideoVPP_Reset(m_session, par); }

--- a/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
@@ -33,13 +33,13 @@ public:
 
     // topology methods
     virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
-    { par1; par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
+    { (void)par1; (void)par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
 
     virtual mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
-    { par1; par2; return MFXVideoVPP_Init(m_session, par); }
+    { (void)par1; (void)par2; return MFXVideoVPP_Init(m_session, par); }
 
-    virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
-    { par1; par2; return MFXVideoVPP_Reset(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
+    { return MFXVideoVPP_Reset(m_session, par); }
 
     virtual mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp)
     { return MFXVideoVPP_RunFrameVPPAsync(m_session, in, out, aux, syncp); }
@@ -50,14 +50,14 @@ public:
     virtual mfxStatus Close(void) { return MFXVideoVPP_Close(m_session); }
 
     // per-component methods
-    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_Query(m_session, in, out); }
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 /*component_idx*/)
+    { return MFXVideoVPP_Query(m_session, in, out); }
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_GetVideoParam(m_session, par); }
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 /*component_idx*/)
+    { return MFXVideoVPP_GetVideoParam(m_session, par); }
 
-    virtual mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_GetVPPStat(m_session, stat); }
+    virtual mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 /*component_idx*/)
+    { return MFXVideoVPP_GetVPPStat(m_session, stat); }
 };
 
 #endif//__MFX_MULTI_VPP_H

--- a/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
@@ -20,6 +20,9 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #ifndef __MFX_MULTI_VPP_H
 #define __MFX_MULTI_VPP_H
 
+#include <memory>
+#include "mfxvideo++.h"
+
 // An interface for a pipeline consisting of multiple (maximum 3) VPP-like components. Base implementation - for single VPP.
 // The application should use this interface to be able to seamlessly switch from MFXVideoVPP to MFXVideoVPPPlugin in the pipeline.
 
@@ -32,19 +35,19 @@ public:
     virtual ~MFXVideoMultiVPP(void) { Close(); }
 
     // topology methods
-    virtual mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    virtual mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = nullptr, mfxVideoParam *par2 = nullptr)
     { (void)par1; (void)par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
 
     virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2]) final
     { return QueryIOSurfMulti(par, request); }
 
-    virtual mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    virtual mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = nullptr, mfxVideoParam *par2 = nullptr)
     { (void)par1; (void)par2; return MFXVideoVPP_Init(m_session, par); }
 
     virtual mfxStatus Init(mfxVideoParam *par) final
     {  return InitMulti(par);  }
 
-    virtual mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    virtual mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam *par1 = nullptr, mfxVideoParam *par2 = nullptr)
     { (void)par1; (void)par2; return MFXVideoVPP_Reset(m_session, par); }
 
     virtual mfxStatus Reset(mfxVideoParam *par) final

--- a/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
@@ -52,17 +52,17 @@ public:
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported
     // QueryIOSurf must be called prior to Init to create topology
-    mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
+    mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported; topology must be the same as in QueryIOSurf
-    mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
-    mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp);
-    mfxStatus Reset(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
-    mfxStatus Close(void);
+    mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override;
+    mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/) override;
+    mfxStatus Close(void) override;
 
-    mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0);
-    mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 component_idx = 0);
-    mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx = 0);
+    mfxStatus Query(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/) override;
+    mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 /*component_idx*/) override;
+    mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 /*component_idx*/) override;
 
 protected:
     mfxFrameAllocator   m_FrameAllocator;

--- a/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
@@ -20,8 +20,6 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #ifndef __MFX_PLUGIN_2_VPP_H
 #define __MFX_PLUGIN_2_VPP_H
 
-#include <memory>
-#include "mfxvideo++.h"
 #include "mfx_multi_vpp.h"
 #include "sample_defs.h"
 #include "vm/so_defs.h"
@@ -52,10 +50,10 @@ public:
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported
     // QueryIOSurf must be called prior to Init to create topology
-    mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = nullptr, mfxVideoParam *par2 = nullptr) override;
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported; topology must be the same as in QueryIOSurf
-    mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = nullptr, mfxVideoParam *par2 = nullptr) override;
     mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override;
     mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/) override;
     mfxStatus Close(void) override;
@@ -83,7 +81,7 @@ protected:
         mfxU16            m_nPoolSize;
     public:
         SurfacePool()
-            : m_ppSurfacesPool(NULL)
+            : m_ppSurfacesPool(nullptr)
             , m_nPoolSize(0){}
         ~SurfacePool(){
             Free();

--- a/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
@@ -52,17 +52,17 @@ public:
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported
     // QueryIOSurf must be called prior to Init to create topology
-    mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported; topology must be the same as in QueryIOSurf
     mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
     mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override;
-    mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/) override;
+    mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/) override;
     mfxStatus Close(void) override;
 
-    mfxStatus Query(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/) override;
-    mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 /*component_idx*/) override;
-    mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 /*component_idx*/) override;
+    mfxStatus QueryMulti(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/) override;
+    mfxStatus GetVideoParamMulti(mfxVideoParam *par, mfxU8 /*component_idx*/) override;
+    mfxStatus GetVPPStatMulti(mfxVPPStat *stat, mfxU8 /*component_idx*/) override;
 
 protected:
     mfxFrameAllocator   m_FrameAllocator;

--- a/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
@@ -55,7 +55,7 @@ public:
     mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported; topology must be the same as in QueryIOSurf
-    mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
     mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override;
     mfxStatus Reset(mfxVideoParam *par, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/) override;
     mfxStatus Close(void) override;

--- a/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
+++ b/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
@@ -93,21 +93,18 @@ MFXVideoVPPPlugin::~MFXVideoVPPPlugin(void)
 }
 
 // per-component methods currently not implemented, you can add your own implementation if needed
-mfxStatus MFXVideoVPPPlugin::Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::Query(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/)
 {
-    in;out;component_idx;
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVideoParam(mfxVideoParam *par, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::GetVideoParam(mfxVideoParam */*par*/, mfxU8 /*component_idx*/)
 {
-    par;component_idx;
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::GetVPPStat(mfxVPPStat */*stat*/, mfxU8 /*component_idx*/)
 {
-    stat;component_idx;
     return MFX_ERR_UNSUPPORTED;
 }
 
@@ -425,9 +422,8 @@ mfxStatus MFXVideoVPPPlugin::Init(mfxVideoParam *par, mfxVideoParam *par1, mfxVi
     return MFX_ERR_NONE;
 }
 
-mfxStatus MFXVideoVPPPlugin::Reset(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::Reset(mfxVideoParam */*par*/, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
 {
-    par;par1;par2;
     return MFX_ERR_UNSUPPORTED;
 }
 

--- a/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
+++ b/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
@@ -93,17 +93,17 @@ MFXVideoVPPPlugin::~MFXVideoVPPPlugin(void)
 }
 
 // per-component methods currently not implemented, you can add your own implementation if needed
-mfxStatus MFXVideoVPPPlugin::Query(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/)
+mfxStatus MFXVideoVPPPlugin::QueryMulti(mfxVideoParam */*in*/, mfxVideoParam */*out*/, mfxU8 /*component_idx*/)
 {
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVideoParam(mfxVideoParam */*par*/, mfxU8 /*component_idx*/)
+mfxStatus MFXVideoVPPPlugin::GetVideoParamMulti(mfxVideoParam */*par*/, mfxU8 /*component_idx*/)
 {
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVPPStat(mfxVPPStat */*stat*/, mfxU8 /*component_idx*/)
+mfxStatus MFXVideoVPPPlugin::GetVPPStatMulti(mfxVPPStat */*stat*/, mfxU8 /*component_idx*/)
 {
     return MFX_ERR_UNSUPPORTED;
 }
@@ -271,7 +271,7 @@ mfxStatus MFXVideoVPPPlugin::AllocateFrames(mfxVideoParam *par, mfxVideoParam *p
     return sts;
 }
 
-mfxStatus MFXVideoVPPPlugin::QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1, mfxVideoParam *par2)
 {
     MSDK_CHECK_POINTER(par, MFX_ERR_NULL_PTR);
 
@@ -422,7 +422,7 @@ mfxStatus MFXVideoVPPPlugin::InitMulti(mfxVideoParam *par, mfxVideoParam *par1, 
     return MFX_ERR_NONE;
 }
 
-mfxStatus MFXVideoVPPPlugin::Reset(mfxVideoParam */*par*/, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
+mfxStatus MFXVideoVPPPlugin::ResetMulti(mfxVideoParam */*par*/, mfxVideoParam */*par1*/, mfxVideoParam */*par2*/)
 {
     return MFX_ERR_UNSUPPORTED;
 }

--- a/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
+++ b/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
@@ -369,7 +369,7 @@ mfxStatus MFXVideoVPPPlugin::QueryIOSurf(mfxVideoParam *par, mfxFrameAllocReques
     return MFX_ERR_NONE;
 }
 
-mfxStatus MFXVideoVPPPlugin::Init(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::InitMulti(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
 {
     mfxStatus sts = MFX_ERR_NONE;
 


### PR DESCRIPTION
Different number of function parameters in child and parent class leads to warnings in clang
('member function hides overloaded virtual function' in declaration and 'call to member function is ambiguous' in code)

Idea is in defining second set of functions for MFXVideoMultiVPP with new set of parameters (instead of dangerous functions overloading with arguments number changing). Functions inherited from base class calls new versions with default arguments.

Then, we should use QueryIOSurfMulti instead of QueryIOSurf for Multi version of VPP with additional parameters.