### PR TITLE
[SMT] Print session to log in case of error

### DIFF
--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -617,6 +617,14 @@ namespace TranscodingSample
         void StopSession();
         bool IsOverlayUsed();
         size_t GetRobustFlag();
+
+        void GetSessionText(msdk_char* buf)
+        {
+            if (buf && m_pmfxSession)
+            {
+                msdk_sprintf(buf, MSDK_STRING("%p"), m_pmfxSession->operator mfxSession());
+            }
+        }
     protected:
         virtual mfxStatus CheckRequiredAPIVersion(mfxVersion& version, sInputParams *pParams);
 

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -4469,20 +4469,26 @@ mfxStatus CTranscodingPipeline::Run()
 {
     mfxStatus sts = MFX_ERR_NONE;
 
+    msdk_char buffer[10] = {};
+    GetSessionText(buffer);
+
     if (m_bDecodeEnable && m_bEncodeEnable)
     {
         sts = Transcode();
-        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Transcode() failed");
+        msdk_string msg = MSDK_STRING("CTranscodingPipeline::Run::Transcode() [") + msdk_string(buffer) + MSDK_STRING("] failed");
+        MSDK_CHECK_STATUS(sts, msg);
     }
     else if (m_bDecodeEnable)
     {
         sts = Decode();
-        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Decode() failed");
+        msdk_string msg = MSDK_STRING("CTranscodingPipeline::Run::Decode() [") + msdk_string(buffer) + MSDK_STRING("] failed");
+        MSDK_CHECK_STATUS(sts, msg);
     }
     else if (m_bEncodeEnable)
     {
         sts = Encode();
-        MSDK_CHECK_STATUS(sts, "CTranscodingPipeline::Run::Encode() failed");
+        msdk_string msg = MSDK_STRING("CTranscodingPipeline::Run::Encode() [") + msdk_string(buffer) + MSDK_STRING("] failed");
+        MSDK_CHECK_STATUS(sts, msg);
     }
     else
         return MFX_ERR_UNSUPPORTED;

--- a/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
+++ b/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
@@ -494,6 +494,8 @@ mfxStatus Launcher::ProcessResult()
 
     mfxStatus FinalSts = MFX_ERR_NONE;
     msdk_printf(MSDK_STRING("-------------------------------------------------------------------------------\n"));
+    msdk_char buffer[10] = {};
+
     for (mfxU32 i = 0; i < m_pSessionArray.size(); i++)
     {
         mfxStatus _sts = m_pSessionArray[i]->transcodingSts;
@@ -504,8 +506,9 @@ mfxStatus Launcher::ProcessResult()
         msdk_string SessionStsStr = _sts ? msdk_string(MSDK_STRING("FAILED"))
             : msdk_string((MSDK_STRING("PASSED")));
 
+        m_pSessionArray[i]->pPipeline->GetSessionText(buffer);
         msdk_stringstream ss;
-        ss << MSDK_STRING("*** session ") << i << MSDK_STRING(" ") << SessionStsStr <<MSDK_STRING(" (") << StatusToString(_sts) << MSDK_STRING(") ")
+        ss << MSDK_STRING("*** session ") << i << MSDK_STRING(" [") << msdk_string(buffer) << MSDK_STRING("] ") << SessionStsStr <<MSDK_STRING(" (") << StatusToString(_sts) << MSDK_STRING(") ")
             << m_pSessionArray[i]->working_time << MSDK_STRING(" sec, ") << m_pSessionArray[i]->numTransFrames << MSDK_STRING(" frames") << std::endl
             << m_parser.GetLine(i) << std::endl << std::endl;
 


### PR DESCRIPTION
This information helps to identify first failed pipeline during application shutdown. Massive error messages creates noise which makes hard to restore the initial sequence of fails