### PR TITLE
Fixed clang warnings

### DIFF
--- a/api/opensource/mfx_dispatch/src/main.cpp
+++ b/api/opensource/mfx_dispatch/src/main.cpp
@@ -459,7 +459,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
     {
         pHandle = *candidate;
         //pulling up current mediasdk version, that required to match plugin version
-        mfxVersion apiVerActual = { 0 };
+        mfxVersion apiVerActual = { { 0, 0 } };
         mfxStatus stsQueryVersion = MFXQueryVersion((mfxSession)pHandle, &apiVerActual);
 
         if (MFX_ERR_NONE !=  stsQueryVersion)

--- a/api/opensource/mfx_dispatch/src/mfx_function_table.cpp
+++ b/api/opensource/mfx_dispatch/src/mfx_function_table.cpp
@@ -76,9 +76,9 @@ namespace
 mfxStatus pseudoMFXInit(mfxIMPL impl, mfxVersion *ver, mfxSession *session)
 {
     // touch unreferenced parameters
-    impl = impl;
-    ver = ver;
-    session = session;
+    (void) impl;
+    (void) ver;
+    (void) session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -87,7 +87,7 @@ mfxStatus pseudoMFXInit(mfxIMPL impl, mfxVersion *ver, mfxSession *session)
 mfxStatus pseudoMFXClose(mfxSession session)
 {
     // touch unreferenced parameters
-    session = session;
+    (void) session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -96,8 +96,8 @@ mfxStatus pseudoMFXClose(mfxSession session)
 mfxStatus pseudoMFXJoinSession(mfxSession session, mfxSession child_session)
 {
     // touch unreferenced parameters
-    session = session;
-    child_session = child_session;
+    (void) session;
+    (void) child_session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -106,8 +106,8 @@ mfxStatus pseudoMFXJoinSession(mfxSession session, mfxSession child_session)
 mfxStatus pseudoMFXCloneSession(mfxSession session, mfxSession *clone)
 {
     // touch unreferenced parameters
-    session = session;
-    clone = clone;
+    (void) session;
+    (void) clone;
 
     return MFX_ERR_UNKNOWN;
 


### PR DESCRIPTION
Fixed clang warnings in dispatcher:
'explicitly assigning value of variable' and 'suggest braces around initialization of subobject'

gcc 8.2 checked