### PR TITLE
Fix GCC8 warnings for bs_parser_hevc

### DIFF
--- a/tools/bs_parser_hevc/include/bs_mem+.h
+++ b/tools/bs_parser_hevc/include/bs_mem+.h
@@ -49,11 +49,11 @@ public:
 
     MemObj(unsigned int count, bool zero)
     {
-        m_obj = new T[count];
-        m_del = true;
-
         if (zero)
-            memset(m_obj, 0, sizeof(T) * count);
+            m_obj = new T[count]{}; // array value-initialization
+        else
+            m_obj = new T[count];
+        m_del = true;
     }
 
     MemObj(T* obj)


### PR DESCRIPTION
Fix copied from 7e79d79fcb56f1e1a15121361a87ab20dcde86fa
Fixes: #567