### PR TITLE
gcc8 warning 'specified bound depends on the length of the source'

### DIFF
--- a/api/opensource/mfx_dispatch/include/mfx_dispatcher_defs.h
+++ b/api/opensource/mfx_dispatch/include/mfx_dispatcher_defs.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "mfxdefs.h"
 #include <cstring>
+#include <cstdio>
 
 #if defined(MFX_DISPATCHER_LOG)
 #include <string>
@@ -35,10 +36,7 @@ typedef char msdk_disp_char;
 
 inline void msdk_disp_char_cpy_s(char * to, size_t to_size, const char * from)
 {
-    size_t source_len = strlen(from);
-    size_t num_chars = (to_size - 1) < source_len ? (to_size - 1) : source_len;
-    strncpy(to, from, num_chars);
-    to[num_chars] = 0;
+    snprintf(to, to_size, "%s", from);
 }
 
 #if defined(MFX_DISPATCHER_LOG)


### PR DESCRIPTION
Fixed gcc8 warning 'specified bound depends on the length of the source argument'
First - Why was strncpy (not memcpy) used here? We exactly knows number of bytes to copy ...
Second - code still dangerous, we rely on the fact that the callers understands what it does
Maybe it should be replaced with simple **snprintf(to, to_size, "%s", from)** ?

(And, I think, this c-style code can be removed 376a72044859cdb42ecd19f096d0f5f91936ef60 )
