### PR TITLE
clang 6.0: fixed warning: 'operator delete' has a non-throwing exception specification

### DIFF
--- a/_studio/shared/umc/codec/vc1_dec/include/umc_vc1_dec_task_store.h
+++ b/_studio/shared/umc/codec/vc1_dec/include/umc_vc1_dec_task_store.h
@@ -173,28 +173,6 @@ namespace UMC
         VC1TaskStore & operator = (const VC1TaskStore &);
 
     public:
-
-        void* operator new(size_t size, void* p)
-        {
-            if (!p)
-                throw VC1Exceptions::vc1_exception(VC1Exceptions::mem_allocation_er);
-            return new(p) uint8_t[size];
-        };
-
-        // external memory management. No need to delete memory
-        void operator delete(void *p) THROWSEXCEPTION
-        {
-            //Anyway its incorrect when we trying free null pointer
-            if (!p)
-                throw VC1Exceptions::vc1_exception(VC1Exceptions::mem_allocation_er);
-        };
-
-        void operator delete(void *, void *) THROWSEXCEPTION
-        {
-            // delete for system exceptions case
-            throw VC1Exceptions::vc1_exception(VC1Exceptions::mem_allocation_er);
-        };
-
         virtual bool     Init(uint32_t iConsumerNumber,
                       uint32_t iMaxFramesInParallel,
                       VC1VideoDecoder* pVC1Decoder);

--- a/_studio/shared/umc/codec/vc1_dec/include/umc_vc1_video_decoder_hw.h
+++ b/_studio/shared/umc/codec/vc1_dec/include/umc_vc1_video_decoder_hw.h
@@ -93,7 +93,6 @@ namespace UMC
                 // special header (with frame size) in case of .rcv format
                 SCoffset = -VC1FHSIZE;
 
-            m_pStore = m_pStore;
             Status umcRes = UMC_ERR_NOT_ENOUGH_DATA;
             try
             {

--- a/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
+++ b/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
@@ -74,8 +74,7 @@ Status VC1VideoDecoderHW::Init(BaseCodecParams *pInit)
     try
     // memory allocation and Init all env for frames/tasks store - VC1TaskStore object
     {
-        m_pStore = (VC1TaskStore*)m_pHeap->s_alloc<VC1TaskStore>();
-        m_pStore = new(m_pStore) VC1TaskStore(m_pMemoryAllocator);
+        m_pStore = new(m_pHeap->s_alloc<VC1TaskStore>()) VC1TaskStore(m_pMemoryAllocator);
 
         if (!m_pStore->Init(m_iThreadDecoderNum,
                             m_iMaxFramesInProcessing,
@@ -149,10 +148,10 @@ Status VC1VideoDecoderHW::Close(void)
 
     if (m_pStore)
     {
-        delete m_pStore;
-        m_pStore = 0;
+        m_pStore->~VC1TaskStore();
+        m_pStore = nullptr;
     }
-    
+
     FreeAlloc(m_pContext);
 
     if(m_pMemoryAllocator)

--- a/_studio/shared/umc/core/umc/include/umc_defs.h
+++ b/_studio/shared/umc/core/umc/include/umc_defs.h
@@ -73,7 +73,6 @@ typedef struct {
 
   #define ALIGN_DECL(X) __attribute__ ((aligned(X)))
 
-#define THROWSEXCEPTION
 /******************************************************************************/
 
 #endif // __UMC_DEFS_H__


### PR DESCRIPTION
THROWSEXCEPTION is empty and used only in umc_vc1_dec_task_store.h
Tested on gcc 8.2 and clang 6.0, not sure about icc.