### PR TITLE
Y410 allocator fix

### DIFF
--- a/_studio/shared/src/libmfx_allocator.cpp
+++ b/_studio/shared/src/libmfx_allocator.cpp
@@ -415,8 +415,9 @@ mfxStatus mfxDefaultAllocator::LockFrame(mfxHDL pthis, mfxHDL mid, mfxFrameData 
     case MFX_FOURCC_Y410:
         ptr->PitchHigh = (mfxU16)((4 * ALIGN32(fs->info.Width)) / (1 << 16));
         ptr->PitchLow  = (mfxU16)((4 * ALIGN32(fs->info.Width)) % (1 << 16));
-        ptr->Y = ptr->U = ptr->V = ptr->A = 0;
         ptr->Y410 = (mfxY410*)sptr;
+        ptr->Y = (mfxU8*)(ptr->Y410);
+        ptr->U = ptr->V = ptr->A = nullptr;
         break;
 #endif
 

--- a/_studio/shared/src/libmfx_allocator_vaapi.cpp
+++ b/_studio/shared/src/libmfx_allocator_vaapi.cpp
@@ -495,8 +495,9 @@ mfxStatus mfxDefaultAllocatorVAAPI::SetFrameData(const VAImage &va_image, mfxU32
         {
             ptr->PitchHigh = (mfxU16)(va_image.pitches[0] / (1 << 16));
             ptr->PitchLow  = (mfxU16)(va_image.pitches[0] % (1 << 16));
-            ptr->Y = ptr->U = ptr->V = ptr->A = 0;
+            ptr->U = ptr->V = ptr->A = nullptr;
             ptr->Y410 = (mfxY410*)(pBuffer + va_image.offsets[0]);
+            ptr->Y = (mfxU8*)(ptr->Y410);
         }
         else mfx_res = MFX_ERR_LOCK_MEMORY;
         break;


### PR DESCRIPTION
Set Y pointer in Y410 when Y410 surfaces is used,
as library heavily relies on Y pointer.