### PR TITLE
[h264d] Re-worked a recent fix for frame gap handling

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -125,6 +125,7 @@ class H264DecoderFrame
     bool             m_isInterViewRef[2];
 
     bool             m_bIDRFlag;
+    bool             m_bIFlag;
 
     bool IsFullFrame() const;
     void SetFullFrame(bool isFull);

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_frame.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_frame.cpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -85,6 +85,7 @@ H264DecoderFrame::H264DecoderFrame(MemoryAllocator *pMemoryAllocator, H264_Heap_
     m_LongTermPicNum[0] = m_PicNum[1] = -1;
     m_PicOrderCnt[0] = m_PicOrderCnt[1] = 0;
     m_bIDRFlag = false;
+    m_bIFlag   = false;
 
     // set memory managment tools
     m_pMemoryAllocator = pMemoryAllocator;
@@ -160,6 +161,7 @@ void H264DecoderFrame::Reset()
 
     post_procces_complete = false;
     m_bIDRFlag = false;
+    m_bIFlag   = false;
 
     m_RefPicListResetCount[0] = m_RefPicListResetCount[1] = 0;
     m_PicNum[0] = m_PicNum[1] = -1;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
@@ -632,6 +632,18 @@ Status DecReferencePictureMarking::UpdateRefPicMarking(ViewItem &view, H264Decod
     // set MVC 'inter view flag'
     pFrame->SetInterViewRef(0 != sliceHeader->nal_ext.mvc.inter_view_flag, field_index);
 
+    // corruption recovery
+    if (pFrame->m_bIFlag)
+    {
+        for (H264DecoderFrame *pCurr = view.GetDPBList(0)->head(); pCurr; pCurr = pCurr->future())
+        {
+            if (pCurr->GetError() & ERROR_FRAME_SHORT_TERM_STUCK)
+            {
+                AddItemAndRun(pFrame, pCurr, UNSET_REFERENCE | FULL_FRAME | SHORT_TERM);
+            }
+        }
+    }
+
     if (pFrame->m_bIDRFlag)
     {
         // mark all reference pictures as unused
@@ -3608,27 +3620,11 @@ Status TaskSupplier::AddSlice(H264Slice * pSlice, bool force)
 
                 if (view.GetPOCDecoder(0)->DetectFrameNumGap(slice))
                 {
-                    // gaps_in_frame_num_value_allowed_flag==true is handled in this block
                     view.pCurFrame = 0;
 
                     Status umsRes = ProcessFrameNumGap(slice, 0, 0, maxDId);
                     if (umsRes != UMC_OK)
                         return umsRes;
-                }
-                else if (view.GetPOCDecoder(0)->DetectFrameNumGap(slice, true))
-                {
-                    // corruption prevention/recovery in case of frame gaps and gaps_in_frame_num_value_allowed_flag==false:
-                    //   drop ST frames with frame_num higher than frame_num of the input slice.
-                    //   without this logic, in case of missed MMCO (due to frames dropping),
-                    //   old ST frames can get stuck in DPB forever.
-                    for (H264DecoderFrame *pFrm = view.GetDPBList(0)->head(); pFrm; pFrm = pFrm->future())
-                    {
-                        if ((pFrm->FrameNum() > slice->GetSliceHeader()->frame_num) &&
-                            pFrm->isShortTermRef())
-                        {
-                            AddItemAndRun(pFrm, pFrm, UNSET_REFERENCE | FULL_FRAME | SHORT_TERM);
-                        }
-                    }
                 }
             }
 
@@ -3962,9 +3958,24 @@ void TaskSupplier::InitFrameCounter(H264DecoderFrame * pFrame, const H264Slice *
         uint32_t NumShortTerm, NumLongTerm;
         dpb->countActiveRefs(NumShortTerm, NumLongTerm);
 
-        //set error flag only we have some references in DPB
         if ((NumShortTerm + NumLongTerm > 0))
+        {
+            // set error flag only we have some references in DPB
             pFrame->SetErrorFlagged(ERROR_FRAME_REFERENCE_FRAME);
+
+            // Leaving aside a legal frame_num wrapping cases, when a rapid _decrease_ of frame_num occurs due to frame gaps,
+            // frames marked as short-term prior the gap may get stuck in DPB for a very long sequence (up to '(1 << log2_max_frame_num) - 1').
+            // Reference lists are generated incorrectly. A potential recovery point can be at next I frame (if GOP is closed).
+            // So let's mark these potentially dangereous ST frames
+            // to remove them later from DPB in UpdateRefPicMarking() (if they're still there) at next I frame or SEI recovery point.
+            for (H264DecoderFrame *pFrm = view.GetDPBList(0)->head(); pFrm; pFrm = pFrm->future())
+            {
+                if ((pFrm->FrameNum() > sliceHeader->frame_num) && pFrm->isShortTermRef())
+                {
+                    pFrm->SetErrorFlagged(ERROR_FRAME_SHORT_TERM_STUCK);
+                }
+            }
+        }
     }
 
     if (sliceHeader->IdrPicFlag)
@@ -3975,6 +3986,9 @@ void TaskSupplier::InitFrameCounter(H264DecoderFrame * pFrame, const H264Slice *
     view.GetPOCDecoder(0)->DecodePictureOrderCount(pSlice, sliceHeader->frame_num);
 
     pFrame->m_bIDRFlag = (sliceHeader->IdrPicFlag != 0);
+
+    const int32_t recoveryFrameNum = view.GetDPBList(0)->GetRecoveryFrameCnt();
+    pFrame->m_bIFlag = (sliceHeader->slice_type == INTRASLICE) || (recoveryFrameNum != -1 && pFrame->FrameNum() == recoveryFrameNum);
 
     if (pFrame->m_bIDRFlag)
     {

--- a/_studio/shared/umc/core/umc/include/umc_structures.h
+++ b/_studio/shared/umc/core/umc/include/umc_structures.h
@@ -1,15 +1,15 @@
 // Copyright (c) 2018 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -681,6 +681,7 @@ namespace UMC
         ERROR_FRAME_RECOVERY                = 0x00000010,  // major artifacts at recovery point
         ERROR_FRAME_TOP_FIELD_ABSENT        = 0x00000020,
         ERROR_FRAME_BOTTOM_FIELD_ABSENT     = 0x00000040,
+        ERROR_FRAME_SHORT_TERM_STUCK        = 0x00000100,  // used to mark ST which potentially can get stuck in DPB due to frame gaps
         ERROR_FRAME_DEVICE_FAILURE          = 0x80000000   //if this bit is set, this means the error is [UMC::Status] code
     };
 


### PR DESCRIPTION
Some streams have incorrect log2_max_frame_num value.
So we can't remove _at once_ ST when a gap is detected.
Instead, remove them at a next I frame(as a potential recovery point)
or at SEI recovery point.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>