### PR TITLE
Using of platform definitions removed from copyright strings

### DIFF
--- a/_studio/mfx_lib/shared/src/libmfxsw.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw.cpp
@@ -46,37 +46,12 @@ void* g_hModule = NULL; // DLL handle received in DllMain
 #define MFX_PRODUCT_VERSION "0.0.000.0000"
 #endif
 
-// Copyright strings
 #if defined(mfxhw64_EXPORTS) || defined(mfxhw32_EXPORTS) || defined(mfxsw64_EXPORTS) || defined(mfxsw32_EXPORTS)
-
-#if defined(LINUX_TARGET_PLATFORM_BDW)
 const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK";
-#elif defined(LINUX_TARGET_PLATFORM_BXT) || defined (LINUX_TARGET_PLATFORM_BXTMIN)
-const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK for Embedded Linux";
-#else
-const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK";
-#endif
-
-const char* g_MfxCopyright = "mediasdk_copyright: Copyright(c) 2018 Intel Corporation";
+const char* g_MfxCopyright = "mediasdk_copyright: Copyright(c) 2011-2018 Intel Corporation";
 const char* g_MfxFileVersion = "mediasdk_file_version: " MFX_FILE_VERSION;
 const char* g_MfxProductVersion = "mediasdk_product_version: " MFX_PRODUCT_VERSION;
-
-#endif // mfxhwXX_EXPORTS
-
-#if defined(mfxaudiosw64_EXPORTS) || defined(mfxaudiosw32_EXPORTS)
-#if defined(LINUX_TARGET_PLATFORM_BDW)
-const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK - Audio for Linux*";
-#elif defined(LINUX_TARGET_PLATFORM_BXT) || defined (LINUX_TARGET_PLATFORM_BXTMIN)
-const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK for Embedded Linux";
-#else
-const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK - Audio for Linux*";
 #endif
-
-const char* g_MfxCopyright = "mediasdk_copyright: Copyright(c) 2014-2018 Intel Corporation";
-const char* g_MfxFileVersion = "mediasdk_file_version: " MFX_FILE_VERSION;
-const char* g_MfxProductVersion = "mediasdk_product_version: " MFX_PRODUCT_VERSION;
-
-#endif // mfxaudioswXX_EXPORTS
 
 #if defined(ANDROID)
 const char* g_MfxProductName = "mediasdk_product_name: Intel(R) Media SDK 2018 for Android";


### PR DESCRIPTION
Using of platform definitions removed from copyright strings. Copyright strings can be defined in cmake (like it was made before for plugins)