### PR TITLE
[h265d_umc] Fixed possible nullptr dereference

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1849,7 +1849,7 @@ UMC::Status TaskSupplier_H265::AddOneFrame(UMC::MediaData * pSource)
 
     } while ((pSource) && (MINIMAL_DATA_SIZE_H265 < pSource->GetDataSize()));
 
-    if (m_checkCRAInsideResetProcess)
+    if (pSource && m_checkCRAInsideResetProcess)
     {
         pSource->MoveDataPointer(int32_t(pSource->GetDataSize() - moveToSpsOffset));
         m_pNALSplitter->Reset();


### PR DESCRIPTION
The problem was found by static code analyze

Signed-off-by: Denis Volkov <denis.volkov@intel.com>