### PR TITLE
[JPEGd] Remove extra nullptr checking

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1121,9 +1121,9 @@ eMFXPlatform MFX_JPEG_Utility::GetPlatform(VideoCORE * core, mfxVideoParam * par
 {
     eMFXPlatform platform = core->GetPlatformType();
 
-    if(platform != MFX_PLATFORM_SOFTWARE)
+    if (platform != MFX_PLATFORM_SOFTWARE)
     {
-        if (par && IsNeedPartialAcceleration(core, par))
+        if (IsNeedPartialAcceleration(core, par))
         {
             return MFX_PLATFORM_SOFTWARE;
         }
@@ -1134,8 +1134,8 @@ eMFXPlatform MFX_JPEG_Utility::GetPlatform(VideoCORE * core, mfxVideoParam * par
         }
 
         bool needVpp = false;
-        if(par->mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_FIELD_TFF ||
-           par->mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_FIELD_BFF)
+        if (par->mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_FIELD_TFF ||
+            par->mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_FIELD_BFF)
         {
             needVpp = true;
         }
@@ -1145,7 +1145,7 @@ eMFXPlatform MFX_JPEG_Utility::GetPlatform(VideoCORE * core, mfxVideoParam * par
 
         VideoDECODEMJPEGBase_HW::AdjustFourCC(&request.Info, &par->mfx, core->GetHWType(), core->GetVAType(), &needVpp);
 
-        if(needVpp)
+        if (needVpp)
         {
 
             if (MFX_ERR_NONE != VideoDECODEMJPEGBase_HW::CheckVPPCaps(core, par))


### PR DESCRIPTION
The problem was found by static code analyze

Input value "par" already checked for nullptr
before every calling function GetPlatform(...).
Also, this pointer checked inside function
IsNeedPartialAcceleration(...)

Signed-off-by: Denis Volkov <denis.volkov@intel.com>