### PR TITLE
[HEVCE] Fix possible DPB overflow

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -2030,10 +2030,10 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, ENCODE_CAPS_HEVC const & caps, boo
         invalid ++;
     }
 
-    changed += CheckMax(par.mfx.NumRefFrame, maxDPB);
+    changed += CheckMax(par.mfx.NumRefFrame, maxDPB - 1);
 
     if (par.mfx.NumRefFrame)
-        maxDPB = par.mfx.NumRefFrame;
+        maxDPB = par.mfx.NumRefFrame + 1;
 
 
     if (   (par.mfx.RateControlMethod == MFX_RATECONTROL_VBR

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -2833,7 +2833,7 @@ void UpdateDPB(
         }
         else
         {
-            for (st0 = 0; dpb[st0].m_ltr && st0 < end; st0 ++); // excess?
+            //for (st0 = 0; st0 < end && dpb[st0].m_ltr; st0 ++); // st0 is first !ltr
 
             if (par.LTRInterval)
             {
@@ -2857,7 +2857,7 @@ void UpdateDPB(
 
     }
 
-    if (end < MAX_DPB_SIZE) //just for KW
+    if (end < MAX_DPB_SIZE)
         dpb[end++] = task;
     else
         assert(!"DPB overflow, no space for new frame");


### PR DESCRIPTION
Dpb index was checked against NumRefFrame instead of array size
On ICL where NumRefFrame can be > DPB_SIZE led to assertion fail.

Issue: MDP-45453