### PR TITLE
[h264e] Replace GetExtBuffer() to reference for MfxVideoParam

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
@@ -2946,8 +2946,8 @@ mfxStatus MfxHwH264Encode::CheckEncodeFrameParam(
             MFX_CHECK(feiParam.Func != MFX_FEI_FUNCTION_ENCODE, MFX_ERR_UNDEFINED_BEHAVIOR);
         }
 
-        mfxExtOpaqueSurfaceAlloc * extOpaq = GetExtBuffer(video);
-        bool opaq = extOpaq->In.Surfaces != 0;
+        mfxExtOpaqueSurfaceAlloc & extOpaq = GetExtBufferRef(video);
+        bool opaq = extOpaq.In.Surfaces != 0;
 
         MFX_CHECK((surface->Data.Y == 0) == (surface->Data.UV == 0), MFX_ERR_UNDEFINED_BEHAVIOR);
         MFX_CHECK(surface->Data.Pitch < 0x8000, MFX_ERR_UNDEFINED_BEHAVIOR);

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1917,9 +1917,9 @@ mfxStatus MfxHwH264Encode::CheckVideoParam(
 
     if (IsMvcProfile(par.mfx.CodecProfile))
     {
-        mfxExtCodingOption * extOpt = GetExtBuffer(par);
+        mfxExtCodingOption & extOpt = GetExtBufferRef(par);
         mfxExtMVCSeqDesc * extMvc   = GetExtBuffer(par);
-        sts = CheckAndFixMVCSeqDesc(extMvc, extOpt->ViewOutput == MFX_CODINGOPTION_ON);
+        sts = CheckAndFixMVCSeqDesc(extMvc, extOpt.ViewOutput == MFX_CODINGOPTION_ON);
         if (MFX_WRN_INCOMPATIBLE_VIDEO_PARAM == sts)
         {
             checkSts = sts;
@@ -5209,17 +5209,17 @@ void MfxHwH264Encode::InheritDefaultValues(
 
 
 
-    mfxExtBRC*   extBRCInit       = GetExtBuffer(parInit);
-    mfxExtBRC*   extBRCReset      = GetExtBuffer(parReset);
+    mfxExtBRC & extBRCInit  = GetExtBufferRef(parInit);
+    mfxExtBRC & extBRCReset = GetExtBufferRef(parReset);
 
-    if (!extBRCReset->pthis &&
-        !extBRCReset->Init &&
-        !extBRCReset->Reset &&
-        !extBRCReset->Close &&
-        !extBRCReset->GetFrameCtrl &&
-        !extBRCReset->Update)
+    if (!extBRCReset.pthis &&
+        !extBRCReset.Init &&
+        !extBRCReset.Reset &&
+        !extBRCReset.Close &&
+        !extBRCReset.GetFrameCtrl &&
+        !extBRCReset.Update)
     {
-        *extBRCReset = *extBRCInit;
+        extBRCReset = extBRCInit;
     }
 
 
@@ -8798,14 +8798,14 @@ namespace
         std::vector<mfxExtSpsHeader> &      sps,
         std::vector<mfxExtPpsHeader> &      pps)
     {
-        mfxExtSpsHeader const *  extSps = GetExtBuffer(par);
-        mfxExtPpsHeader const *  extPps = GetExtBuffer(par);
+        mfxExtSpsHeader const & extSps = GetExtBufferRef(par);
+        mfxExtPpsHeader const & extPps = GetExtBufferRef(par);
 
-        mfxU16 numViews  = extSps->profileIdc == MFX_PROFILE_AVC_STEREO_HIGH ? 2 : 1;
-        mfxU16 heightMul = 2 - extSps->frameMbsOnlyFlag;
+        mfxU16 numViews  = extSps.profileIdc == MFX_PROFILE_AVC_STEREO_HIGH ? 2 : 1;
+        mfxU16 heightMul = 2 - extSps.frameMbsOnlyFlag;
 
         // prepare sps for base layer
-        sps[0] = *extSps;
+        sps[0] = extSps;
         sps[0].picWidthInMbsMinus1       = par.mfx.FrameInfo.Width / 16 - 1;
         sps[0].picHeightInMapUnitsMinus1 = par.mfx.FrameInfo.Height / 16 / heightMul - 1;
 
@@ -8818,8 +8818,8 @@ namespace
             // Second SPS will be re-packed to SubsetSPS after return from driver.
             for (mfxU16 view = 0; view < numViews; view++)
             {
-                sps[view] = *extSps;
-                pps[view] = *extPps;
+                sps[view] = extSps;
+                pps[view] = extPps;
 
                 if (numViews > 1 && view == 0) // MVC base view
                     sps[view].profileIdc = MFX_PROFILE_AVC_HIGH;
@@ -8832,7 +8832,7 @@ namespace
         }
 
 
-        pps[0] = *extPps;
+        pps[0] = extPps;
 
     }
 };


### PR DESCRIPTION
Intention of GetExtBufferRef is to get ext buffers
from MfxVideoParam structure which always has full set
of extension buffers ("MfxHwH264Encode::GetExtBuffer" can't return zero).

So, for MfxVideoParam it's better to use function GetExtBufferRef()
instead GetExtBuffer(), we can wrap issues from static code analyze
to one place (body of function GetExtBufferRef()) instead several
places (every calling GetExtBuffer())

Signed-off-by: Denis Volkov <denis.volkov@intel.com>