### PR TITLE
[mpeg2d] Improved robustness for using Opaque Memory

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
+++ b/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
@@ -147,6 +147,8 @@ public:
 
     virtual mfxStatus CompleteTasks(void *pParam) = 0;
 
+    bool IsOpaqueMemory() const { return m_isOpaqueMemory; }
+
 public:
     int32_t display_frame_count;
     int32_t cashed_frame_count;
@@ -178,7 +180,6 @@ public:
     std::unique_ptr<UMC::MPEG2VideoDecoderBase> m_implUmc;
 
     bool m_isSWBuf;
-    bool m_isOpaqueMemory;
     mfxVideoParam m_vPar;
     UMC::VideoDecoderParams m_vdPar;
 
@@ -194,6 +195,8 @@ protected:
 
     bool m_resizing;
     bool m_isSWDecoder;
+
+    bool m_isOpaqueMemory;
 
     struct FcState
     {

--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -546,7 +546,7 @@ mfxStatus VideoDECODEMPEG2::Reset(mfxVideoParam *par)
     mfxExtOpaqueSurfaceAlloc *pOpqExt = (mfxExtOpaqueSurfaceAlloc *)GetExtendedBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION);
     if (pOpqExt)
     {
-        if (false == internalImpl->m_isOpaqueMemory)
+        if (false == internalImpl->IsOpaqueMemory())
         {
             // decoder was not initialized with opaque extended buffer
             return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
@@ -1361,7 +1361,7 @@ mfxStatus VideoDECODEMPEG2::DecodeFrameCheck(mfxBitstream *bs,
         return MFX_ERR_NOT_INITIALIZED;
     }
 
-    if (true == internalImpl->m_isOpaqueMemory)
+    if (true == internalImpl->IsOpaqueMemory())
     {
         if (surface_work->Data.MemId || surface_work->Data.Y || surface_work->Data.R || surface_work->Data.A || surface_work->Data.UV) // opaq surface
             return MFX_ERR_UNDEFINED_BEHAVIOR;
@@ -1821,7 +1821,7 @@ mfxStatus VideoDECODEMPEG2InternalBase::AllocFrames(mfxVideoParam *par)
         allocResponse.NumFrameActual = allocRequest.NumFrameSuggested;
 
         mfxStatus mfxSts;
-        if (m_isOpaqueMemory)
+        if (pOpqExt)
         {
             mfxSts  = m_pCore->AllocFrames(&allocRequest,
                                            &allocResponse,


### PR DESCRIPTION
The problem was found by static code analyze

Signed-off-by: Denis Volkov <denis.volkov@intel.com>