### PR TITLE
[h265d_umc] Use m_pSliceQueue directly w/o GetSlice

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_frame_info.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_frame_info.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -103,8 +103,10 @@ void H265DecoderFrameInfo::EliminateErrors()
     if (!GetSlice(0))
         return;
 
+    uint32_t count = m_SliceCount;
+
     // Remove dependent slices without a corresponding independent slice
-    for (uint32_t sliceId = 0; sliceId < GetSliceCount(); sliceId++)
+    for (uint32_t sliceId = 0; sliceId < count; sliceId++)
     {
         H265Slice * slice = GetSlice(sliceId);
 
@@ -123,7 +125,7 @@ void H265DecoderFrameInfo::EliminateErrors()
         H265Slice *baseSlice = GetSlice(0); // after the for() loop above ,the first slice is treated as 'base' slice
 
         bool bIndepSliceMissing = false;
-        for (uint32_t sliceId = 1; sliceId < GetSliceCount(); sliceId++)
+        for (uint32_t sliceId = 1; sliceId < count; sliceId++)
         {
             H265SliceHeader *sliceHeader = GetSlice(sliceId)->GetSliceHeader();
 
@@ -146,9 +148,9 @@ void H265DecoderFrameInfo::EliminateErrors()
     }
 
     // Remove slices with duplicated slice_segment_address syntax
-    for (uint32_t sliceId = 0; sliceId < GetSliceCount(); sliceId++)
+    for (uint32_t sliceId = 0; sliceId < count; sliceId++)
     {
-        H265Slice * slice = GetSlice(sliceId);
+        H265Slice * slice     = m_pSliceQueue[sliceId];
         H265Slice * nextSlice = GetSlice(sliceId + 1);
 
         if (!nextSlice)
@@ -183,16 +185,16 @@ void H265DecoderFrameInfo::EliminateASO()
     if (!GetSlice(0))
         return;
 
-    uint32_t count = GetSliceCount();
+    uint32_t count = m_SliceCount;
     for (uint32_t sliceId = 0; sliceId < count; sliceId++)
     {
-        H265Slice * curSlice = GetSlice(sliceId);
+        H265Slice * curSlice = m_pSliceQueue[sliceId];
         int32_t minFirst = MAX_MB_NUMBER;
         uint32_t minSlice = 0;
 
         for (uint32_t j = sliceId; j < count; j++)
         {
-            H265Slice * slice = GetSlice(j);
+            H265Slice * slice = m_pSliceQueue[j];
             if (slice->GetFirstMB() < curSlice->GetFirstMB() && minFirst > slice->GetFirstMB())
             {
                 minFirst = slice->GetFirstMB();
@@ -210,7 +212,7 @@ void H265DecoderFrameInfo::EliminateASO()
 
     for (uint32_t sliceId = 0; sliceId < count; sliceId++)
     {
-        H265Slice * slice = GetSlice(sliceId);
+        H265Slice * slice     = m_pSliceQueue[sliceId];
         H265Slice * nextSlice = GetSlice(sliceId + 1);
 
         if (!nextSlice)


### PR DESCRIPTION
Replace GetSlice() to directly using m_pSliceQueue
inside class H265DecoderFrameInfo where it's possible

The problem was found by static code analyze

Signed-off-by: Denis Volkov <denis.volkov@intel.com>