### PR TITLE
[h264e] Fix assert in encoding with MaxSliceSize

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -1263,7 +1263,7 @@ namespace MfxHwH264Encode
     {
         memset(&par,0,sizeof(par));
         par.FrameType = task->m_type[task->m_fid[0]];
-        par.picStruct = 0;
+        par.picStruct = task->GetPicStructForEncode();
         par.DisplayOrder = task->m_frameOrder;
         par.EncodedOrder = task->m_encOrder;
         par.PyramidLayer = (mfxU16)task->m_loc.level;


### PR DESCRIPTION
MFX_PICSTRUCT_UNKNOWN was used which couldn't be converted to
UMC type in BRC implementation. The change sets correct frame's
picstruct for BRC.