### PR TITLE
[h264e] Removed extra check nativeHandle for nullptr

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
@@ -2578,9 +2578,6 @@ mfxStatus MfxHwH264Encode::GetNativeHandleToRawSurface(
     else
         return Error(MFX_ERR_UNDEFINED_BEHAVIOR);
 
-    if (nativeHandle == 0)
-        return Error(MFX_ERR_UNDEFINED_BEHAVIOR);
-
     return sts;
 }
 


### PR DESCRIPTION
We can loose more useful error status from function
GetFrameHDL() upper, also nullptr can be processed
in the upper code.

Aligned the same function GetNativeHandleToRawSurface
with h265e

Signed-off-by: Denis Volkov <denis.volkov@intel.com>