### PR TITLE
Return an error on warnings from SyncOperation

### DIFF
--- a/samples/sample_common/include/sample_defs.h
+++ b/samples/sample_common/include/sample_defs.h
@@ -148,6 +148,7 @@ enum LibVABackend
 #define MSDK_CHECK_STATUS(X, MSG)                {if ((X) < MFX_ERR_NONE) {MSDK_PRINT_RET_MSG(X, MSG); return X;}}
 #define MSDK_CHECK_STATUS_NO_RET(X, MSG)         {if ((X) < MFX_ERR_NONE) {MSDK_PRINT_RET_MSG(X, MSG);}}
 #define MSDK_CHECK_WRN(X, MSG)                   {if ((X) > MFX_ERR_NONE) {MSDK_PRINT_WRN_MSG(X, MSG);          }}
+#define MSDK_CHECK_ERR_NONE_STATUS(X, ERR,  MSG) {if ((X) != MFX_ERR_NONE) {MSDK_PRINT_RET_MSG(X, MSG); return ERR;}}
 #define MSDK_CHECK_PARSE_RESULT(P, X, ERR)       {if ((X) > (P)) {return ERR;}}
 
 #define MSDK_CHECK_STATUS_SAFE(X, FUNC, ADD)     {if ((X) < MFX_ERR_NONE) {ADD; MSDK_PRINT_RET_MSG(X, FUNC); return X;}}

--- a/samples/sample_fei/src/auxiliary_interfaces.cpp
+++ b/samples/sample_fei/src/auxiliary_interfaces.cpp
@@ -184,8 +184,8 @@ mfxStatus MFX_VppInterface::VPPoneFrame(mfxFrameSurface1* pSurf_in, mfxFrameSurf
         }
         else if (MFX_ERR_NONE < sts && m_SyncPoint)
         {
-            // Ignore warnings if output is available
             sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+            MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
             mdprintf(stderr, "VPP synced : %d\n", sts);
 
             break;
@@ -198,6 +198,7 @@ mfxStatus MFX_VppInterface::VPPoneFrame(mfxFrameSurface1* pSurf_in, mfxFrameSurf
             if (m_SyncPoint)
             {
                 sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
                 mdprintf(stderr, "VPP synced : %d\n", sts);
             }
 
@@ -407,8 +408,8 @@ mfxStatus MFX_DecodeInterface::GetOneFrame(mfxFrameSurface1* & pSurf)
         }
         else if (MFX_ERR_NONE < sts && m_SyncPoint)
         {
-            // Ignore warnings if output is available
             sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+            MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Decode: SyncOperation failed");
             mdprintf(stderr, "DECODE synced : %d\n", sts);
 
             break;
@@ -426,6 +427,7 @@ mfxStatus MFX_DecodeInterface::GetOneFrame(mfxFrameSurface1* & pSurf)
             if (m_SyncPoint)
             {
                 sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Decode: SyncOperation failed");
                 mdprintf(stderr, "DECODE synced : %d\n", sts);
             }
 

--- a/samples/sample_fei/src/fei_encode.cpp
+++ b/samples/sample_fei/src/fei_encode.cpp
@@ -737,9 +737,8 @@ mfxStatus FEI_EncodeInterface::EncodeOneFrame(iTask* eTask)
             }
             else if (MFX_ERR_NONE < sts && m_SyncPoint)
             {
-                // ignore warnings if output is available
                 sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
-                MSDK_CHECK_STATUS(sts, "FEI ENCODE: SyncOperation failed");
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENCODE: SyncOperation failed");
                 break;
             }
             else if (MFX_ERR_NOT_ENOUGH_BUFFER == sts)
@@ -752,7 +751,7 @@ mfxStatus FEI_EncodeInterface::EncodeOneFrame(iTask* eTask)
                 if (m_SyncPoint)
                 {
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
-                    MSDK_CHECK_STATUS(sts, "FEI ENCODE: SyncOperation failed");
+                    MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENCODE: SyncOperation failed");
                 }
                 break;
             }

--- a/samples/sample_fei/src/fei_encpak.cpp
+++ b/samples/sample_fei/src/fei_encpak.cpp
@@ -1083,8 +1083,8 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                 }
                 else if (MFX_ERR_NONE < sts && m_SyncPoint)
                 {
-                    // Ignore warnings if output is available
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                    MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENC: SyncOperation failed");
                     mdprintf(stderr, "ENC synced : %d\n", sts);
 
                     break;
@@ -1097,6 +1097,7 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                     if (m_SyncPoint)
                     {
                         sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENC: SyncOperation failed");
                         mdprintf(stderr, "ENC synced : %d\n", sts);
                     }
 
@@ -1150,6 +1151,7 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                 {
                     // Ignore warnings if output is available
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                    MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI PAK: SyncOperation failed");
                     mdprintf(stderr, "PAK synced : %d\n", sts);
 
                     break;
@@ -1167,6 +1169,7 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                     if (m_SyncPoint)
                     {
                         sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI PAK: SyncOperation failed");
                         mdprintf(stderr, "PAK synced : %d\n", sts);
                     }
 

--- a/samples/sample_fei/src/fei_preenc.cpp
+++ b/samples/sample_fei/src/fei_preenc.cpp
@@ -533,8 +533,8 @@ mfxStatus FEI_PreencInterface::DownSampleInput(iTask* eTask)
         }
         else if (MFX_ERR_NONE < sts && m_SyncPoint)
         {
-            // Ignore warnings if output is available
             sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+            MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
             mdprintf(stderr, "PreENC DS synced : %d\n", sts);
 
             break;
@@ -547,6 +547,7 @@ mfxStatus FEI_PreencInterface::DownSampleInput(iTask* eTask)
             if (m_SyncPoint)
             {
                 sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
                 mdprintf(stderr, "PreENC DS synced : %d\n", sts);
             }
 
@@ -826,8 +827,8 @@ mfxStatus FEI_PreencInterface::ProcessMultiPreenc(iTask* eTask)
                 }
                 else if (MFX_ERR_NONE < sts && m_SyncPoint)
                 {
-                    // Ignore warnings if output is available
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                    MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI PreENC: SyncOperation failed");
                     mdprintf(stderr, "PreENC synced : %d\n", sts);
 
                     break;
@@ -840,6 +841,7 @@ mfxStatus FEI_PreencInterface::ProcessMultiPreenc(iTask* eTask)
                     if (m_SyncPoint)
                     {
                         sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
+                        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI PreENC: SyncOperation failed");
                         mdprintf(stderr, "PreENC synced : %d\n", sts);
                     }
 

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -676,7 +676,7 @@ mfxStatus CTranscodingPipeline::DecodeOneFrame(ExtendedSurface *pExtSurface)
     {
         sts = m_pmfxSession->SyncOperation(pExtSurface->Syncp, MSDK_WAIT_INTERVAL);
         HandlePossibleGpuHang(sts);
-        MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Decode: SyncOperation failed");
     }
     return sts;
 
@@ -723,7 +723,7 @@ mfxStatus CTranscodingPipeline::DecodeLastFrame(ExtendedSurface *pExtSurface)
     {
         sts = m_pmfxSession->SyncOperation(pExtSurface->Syncp,  MSDK_WAIT_INTERVAL);
         HandlePossibleGpuHang(sts);
-        MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Decode: SyncOperation failed");
     }
 
     return sts;
@@ -1158,7 +1158,7 @@ mfxStatus CTranscodingPipeline::Decode()
             sts = m_pmfxSession->SyncOperation(PreEncExtSurface.Syncp, MSDK_WAIT_INTERVAL);
             HandlePossibleGpuHang(sts);
             PreEncExtSurface.Syncp = NULL;
-            MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+            MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "PreEnc: SyncOperation failed");
         }
 
         size_t i = 0;
@@ -1209,7 +1209,7 @@ mfxStatus CTranscodingPipeline::Decode()
             {
                 sts = m_pmfxSession->SyncOperation(frontSurface.Syncp, MSDK_WAIT_INTERVAL);
                 HandlePossibleGpuHang(sts);
-                MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "SyncOperation failed");
                 frontSurface.Syncp=NULL;
             }
         }
@@ -1290,7 +1290,7 @@ mfxStatus CTranscodingPipeline::Encode()
                     MFX_ITT_TASK("SyncOperation");
                     sts = m_pParentPipeline->m_pmfxSession->SyncOperation(DecExtSurface.Syncp, MSDK_WAIT_INTERVAL);
                     HandlePossibleGpuHang(sts);
-                    MSDK_CHECK_STATUS(sts, "m_pParentPipeline->m_pmfxSession->SyncOperation failed");
+                    MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Encode: SyncOperation failed");
                 }
             }
 
@@ -1368,7 +1368,7 @@ mfxStatus CTranscodingPipeline::Encode()
                 // Sync to ensure VPP is completed to avoid flicker
                 sts = m_pmfxSession->SyncOperation(VppExtSurface.Syncp, MSDK_WAIT_INTERVAL);
                 HandlePossibleGpuHang(sts);
-                MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+                MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
 
                 /* in case if enabled dumping into file for after VPP composition */
                 if (DUMP_FILE_VPP_COMP == m_vppCompDumpRenderMode)
@@ -1493,7 +1493,7 @@ mfxStatus CTranscodingPipeline::Encode()
 //                    if(m_nVPPCompEnable != VppCompOnlyEncode)
 //                    {
 //                        sts = m_pmfxSession->SyncOperation(VppExtSurface.Syncp, MSDK_WAIT_INTERVAL);
-//                        MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+//                        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "VPP: SyncOperation failed");
 //                    }
 //#if defined(_WIN32) || defined(_WIN64)
 //                    sts = m_hwdev4Rendering->RenderFrame(VppExtSurface.pSurface, m_pMFXAllocator);
@@ -2032,7 +2032,7 @@ mfxStatus CTranscodingPipeline::PutBS()
     {
         sts = m_pmfxSession->SyncOperation(pBitstreamEx->Syncp, MSDK_WAIT_INTERVAL);
         HandlePossibleGpuHang(sts);
-        MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "Encode: SyncOperation failed");
     }
 
     m_nOutputFramesNum++;
@@ -2087,7 +2087,7 @@ mfxStatus CTranscodingPipeline::Surface2BS(ExtendedSurface* pSurf,mfxBitstream* 
     {
         sts = m_pmfxSession->SyncOperation(pSurf->Syncp, MSDK_WAIT_INTERVAL);
         HandlePossibleGpuHang(sts);
-        MSDK_CHECK_STATUS(sts, "m_pmfxSession->SyncOperation failed");
+        MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "SyncOperation failed");
         pSurf->Syncp=0;
 
         //--- Copying data from surface to bitstream


### PR DESCRIPTION
Currently the timeout used in SMT and sample_fei is 1500 seconds.
In regular case, it's even too much for task synchronization.
However in case of driver/MSDK synchronization problems,
SyncOperation may return MFX_WRN_IN_EXECUTION which was ignored.
It leaded to undefined behavior hard to debug.
So it's better to catch synchronization issues at once.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>