### PR TITLE
[MDP-50731][AVC FEI] Add correct condition for reset point in the case with frame resize

### DIFF
--- a/samples/sample_fei/src/pipeline_fei.cpp
+++ b/samples/sample_fei/src/pipeline_fei.cpp
@@ -1903,7 +1903,7 @@ mfxStatus CEncodingPipeline::ResizeFrame(mfxU32 m_frameCount, mfxU16 picstruct)
 {
     mfxStatus sts = MFX_ERR_NONE;
 
-    bool reset_point = m_DRCqueue.size() && m_DRCqueue[m_nDRC_idx].start_frame == m_frameCount;
+    bool reset_point = (m_DRCqueue.size() > m_nDRC_idx) && (m_DRCqueue[m_nDRC_idx].start_frame == m_frameCount);
 
     if (!reset_point)
         return sts;


### PR DESCRIPTION

Checking of the index for reset point was added into ResizeFrame function.
It allows to have correct number of the resizes into encoding pipeline.