### PR TITLE
Fix condition in VPP reset when checking composition enable/disable changes.

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -1210,7 +1210,7 @@ mfxStatus VideoVPPBase::Reset(mfxVideoParam *par)
     bool isCompositionModeInNewParams = IsCompositionMode(par);
     // Enabling/disabling composition via Reset() doesn't work currently.
     // This is a workaround to prevent undefined behavior.
-    MFX_CHECK(m_errPrtctState.isCompositionModeEnabled != isCompositionModeInNewParams, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+    MFX_CHECK(m_errPrtctState.isCompositionModeEnabled == isCompositionModeInNewParams, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
 
     /* save init params to prevent core crash */
     m_errPrtctState.In  = par->vpp.In;
@@ -1422,4 +1422,3 @@ mfxStatus VideoVPP_HW::RunFrameVPP(mfxFrameSurface1* , mfxFrameSurface1* , mfxEx
 
 #endif // MFX_ENABLE_VPP
 /* EOF */
-


### PR DESCRIPTION
Wrong condition on commit 8ee12dd7c5cbb48df992c83b572343c7a2bad914 when checking if composition has been enabled/disabled.