### PR TITLE
[VP9] Fix PackPicParams for streams starting w/ inter frame

### DIFF
--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -106,7 +106,7 @@ VideoDECODEVP9_HW::VideoDECODEVP9_HW(VideoCORE *p_core, mfxStatus *sts)
       m_uv_ac_delta_q(0)
 {
     memset(&m_sizesOfRefFrame, 0, sizeof(m_sizesOfRefFrame));
-    memset(&m_frameInfo.ref_frame_map, -1, sizeof(m_frameInfo.ref_frame_map)); // TODO: move to another place
+    memset(&m_frameInfo.ref_frame_map, VP9_INVALID_REF_FRAME, sizeof(m_frameInfo.ref_frame_map)); // TODO: move to another place
     ResetFrameInfo();
 
     if (sts)
@@ -375,7 +375,7 @@ void VideoDECODEVP9_HW::ResetFrameInfo()
     m_frameInfo.currFrame = -1;
     m_frameInfo.frameCountInBS = 0;
     m_frameInfo.currFrameInBS = 0;
-    memset(&m_frameInfo.ref_frame_map, -1, sizeof(m_frameInfo.ref_frame_map)); // TODO: move to another place
+    memset(&m_frameInfo.ref_frame_map, VP9_INVALID_REF_FRAME, sizeof(m_frameInfo.ref_frame_map)); // TODO: move to another place
 }
 
 mfxStatus VideoDECODEVP9_HW::DecodeHeader(VideoCORE* core, mfxBitstream* bs, mfxVideoParam* par)
@@ -1186,7 +1186,7 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameHeader(mfxBitstream *in, VP9DecoderFrame
 
         // setup_tile_info()
         {
-            const mfxI32 alignedWidth = ALIGN_POWER_OF_TWO(info.width, MI_SIZE_LOG2);
+            const mfxI32 alignedWidth = AlignPowerOfTwo(info.width, MI_SIZE_LOG2);
             int minLog2TileColumns, maxLog2TileColumns, maxOnes;
             mfxU32 miCols = alignedWidth >> MI_SIZE_LOG2;
             GetTileNBits(miCols, minLog2TileColumns, maxLog2TileColumns);

--- a/_studio/shared/umc/codec/vp9_dec/include/umc_vp9_utils.h
+++ b/_studio/shared/umc/codec/vp9_dec/include/umc_vp9_utils.h
@@ -28,12 +28,15 @@
 #ifndef __UMC_VP9_UTILS_H_
 #define __UMC_VP9_UTILS_H_
 
-#define ALIGN_POWER_OF_TWO(value, n) \
-    (((value) + ((1 << (n)) - 1)) & ~((1 << (n)) - 1))
-
 namespace UMC_VP9_DECODER
 {
+    constexpr auto VP9_INVALID_REF_FRAME = -1;
     class VP9DecoderFrame;
+
+    inline mfxU32 AlignPowerOfTwo(mfxU32 value, mfxU32 n)
+    {
+        return (((value) + ((1 << (n)) - 1)) & ~((1 << (n)) - 1));
+    }
 
     inline
     int32_t clamp(int32_t value, int32_t low, int32_t high)

--- a/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_utils.cpp
+++ b/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_utils.cpp
@@ -382,7 +382,7 @@ namespace UMC_VP9_DECODER
 
     void GetTileNBits(const int32_t miCols, int32_t & minLog2TileCols, int32_t & maxLog2TileCols)
     {
-        const int32_t sbCols = ALIGN_POWER_OF_TWO(miCols, MI_BLOCK_SIZE_LOG2) >> MI_BLOCK_SIZE_LOG2;
+        const int32_t sbCols = AlignPowerOfTwo(miCols, MI_BLOCK_SIZE_LOG2) >> MI_BLOCK_SIZE_LOG2;
         int32_t minLog2 = 0, maxLog2 = 0;
 
         while ((sbCols >> maxLog2) >= MIN_TILE_WIDTH_B64)

--- a/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_va_packer.cpp
+++ b/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_va_packer.cpp
@@ -126,7 +126,16 @@ void PackerVA::PackPicParams(VADecPictureParameterBufferVP9* picParam, VP9Decode
     else
     {
         for (mfxU8 ref = 0; ref < NUM_REF_FRAMES; ++ref)
-            picParam->reference_frames[ref] = m_va->GetSurfaceID(info->ref_frame_map[ref]);
+        {
+            if (info->ref_frame_map[ref] != VP9_INVALID_REF_FRAME)
+            {
+                picParam->reference_frames[ref] = m_va->GetSurfaceID(info->ref_frame_map[ref]);
+            }
+            else
+            {
+                picParam->reference_frames[ref] = VA_INVALID_SURFACE;
+            }
+        }
     }
 
     picParam->pic_fields.bits.subsampling_x = info->subsamplingX;


### PR DESCRIPTION
A VP9 stream starting w/ inter frame has it intra-coded without
references. Prior code led to error since the auxiliary ref frame array
was filled with VA_INVALID_SURFACE ids, which cannot be passed
to the GetSurfaceID functions.