### PR TITLE
mfx_dispatch/linux: allow MFX_IMPL_AUTO

### DIFF
--- a/api/mfx_dispatch/linux/mfxloader.cpp
+++ b/api/mfx_dispatch/linux/mfxloader.cpp
@@ -163,10 +163,6 @@ std::shared_ptr<void> make_dlopen(const char* filename, int flags)
 
 mfxStatus LoaderCtx::Init(mfxInitParam& par)
 {
-  if (!MFX_IMPL_BASETYPE(par.Implementation) &&
-      !(par.Implementation & MFX_IMPL_VIA_VAAPI)) {
-    return MFX_ERR_UNSUPPORTED;
-  }
   if (par.Implementation & MFX_IMPL_AUDIO) {
     return MFX_ERR_UNSUPPORTED;
   }


### PR DESCRIPTION
This should fix cases when application initializes mediasdk
with 0 implementation, i.e. with MFX_IMPL_AUTO.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>