### PR TITLE
Replaced memcpy with std::copy / operator = in AVC components

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -3535,12 +3535,10 @@ void ImplementationAvc::FillEncodingUnitsInfo(
 
         if (encUnitsInfo->NumUnitsAlloc > encUnitsInfo->NumUnitsEncoded)
         {
-            memcpy_s(
-                encUnitsInfo->UnitInfo + encUnitsInfo->NumUnitsEncoded,
-                sizeof(mfxEncodedUnitInfo) * (encUnitsInfo->NumUnitsAlloc - encUnitsInfo->NumUnitsEncoded),
-                &task.m_headersCache[fid].front(),
-                sizeof(mfxEncodedUnitInfo) * std::min(size_t(encUnitsInfo->NumUnitsAlloc) - encUnitsInfo->NumUnitsEncoded, task.m_headersCache[fid].size())
-            );
+            size_t count = std::min<size_t>(encUnitsInfo->NumUnitsAlloc - encUnitsInfo->NumUnitsEncoded, task.m_headersCache[fid].size());
+
+            std::copy(std::begin(task.m_headersCache[fid]), std::begin(task.m_headersCache[fid]) + count,
+                        encUnitsInfo->UnitInfo + encUnitsInfo->NumUnitsEncoded);
         }
 
         if (task.m_headersCache[fid].size() > 0)

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
@@ -2227,8 +2227,9 @@ void MfxHwH264Encode::ConfigureTask(
         {
             if (extRoiRuntime)
             {
-                mfxRoiDesc task_roi = {};
-                memcpy_s(&task_roi, sizeof(mfxRoiDesc), &pRoi->ROI[i], sizeof(mfxRoiDesc));
+                mfxRoiDesc task_roi = {pRoi->ROI[i].Left,  pRoi->ROI[i].Top,
+                                       pRoi->ROI[i].Right, pRoi->ROI[i].Bottom, pRoi->ROI[i].Priority};
+
                 // check runtime ROI
 #if MFX_VERSION > 1021
                 mfxStatus sts = CheckAndFixRoiQueryLike(video, &task_roi, extRoiRuntime->ROIMode);
@@ -2236,13 +2237,14 @@ void MfxHwH264Encode::ConfigureTask(
                 mfxStatus sts = CheckAndFixRoiQueryLike(video, &task_roi, 0);
 #endif // MFX_VERSION > 1021
                 if (sts != MFX_ERR_UNSUPPORTED) {
-                    memcpy_s(&task.m_roi[task.m_numRoi], sizeof(mfxRoiDesc), &task_roi, sizeof(mfxRoiDesc));
+                    task.m_roi[task.m_numRoi] = task_roi;
                     task.m_numRoi++;
                 }
             }
             else
             {
-                memcpy_s(&task.m_roi[task.m_numRoi], sizeof(mfxRoiDesc), &pRoi->ROI[i], sizeof(mfxRoiDesc));
+                task.m_roi[task.m_numRoi] = {pRoi->ROI[i].Left,  pRoi->ROI[i].Top,
+                                             pRoi->ROI[i].Right, pRoi->ROI[i].Bottom, pRoi->ROI[i].Priority};
                 task.m_numRoi ++;
             }
         }
@@ -2258,7 +2260,9 @@ void MfxHwH264Encode::ConfigureTask(
 
         for (mfxU16 i = 0; i < numRect; i ++)
         {
-            memcpy_s(&task.m_dirtyRect[task.m_numDirtyRect], sizeof(mfxRectDesc), &pDirtyRect->Rect[i], sizeof(mfxRectDesc));
+            task.m_dirtyRect[task.m_numDirtyRect] = {pDirtyRect->Rect[i].Left,  pDirtyRect->Rect[i].Top,
+                                                     pDirtyRect->Rect[i].Right, pDirtyRect->Rect[i].Bottom};
+
             if (extDirtyRectRuntime)
             {
                 // check runtime dirty rectangle
@@ -2281,7 +2285,10 @@ void MfxHwH264Encode::ConfigureTask(
 
         for (mfxU16 i = 0; i < numRect; i ++)
         {
-            memcpy_s(&task.m_movingRect[task.m_numMovingRect], sizeof(mfxMovingRectDesc), &pMoveRect->Rect[i], sizeof(mfxMovingRectDesc));
+            task.m_movingRect[task.m_numMovingRect] = {pMoveRect->Rect[i].DestLeft,   pMoveRect->Rect[i].DestTop,
+                                                       pMoveRect->Rect[i].DestRight,  pMoveRect->Rect[i].DestBottom,
+                                                       pMoveRect->Rect[i].SourceLeft, pMoveRect->Rect[i].SourceTop};
+
             if (extMoveRectRuntime)
             {
                 // check runtime moving rectangle

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -6513,8 +6513,9 @@ mfxStatus MfxHwH264Encode::CheckRunTimeExtBuffers(
 
         for (mfxU16 i = 0; i < actualNumRoi; i++)
         {
-                mfxRoiDesc task_roi = {};
-                memcpy_s(&task_roi, sizeof(mfxRoiDesc), &extRoi->ROI[i], sizeof(mfxRoiDesc));
+                mfxRoiDesc task_roi = {extRoi->ROI[i].Left,  extRoi->ROI[i].Top,
+                                       extRoi->ROI[i].Right, extRoi->ROI[i].Bottom, extRoi->ROI[i].Priority};
+
                 // check runtime ROI
 #if MFX_VERSION > 1021
                 mfxStatus sts = CheckAndFixRoiQueryLike(video, &task_roi, extRoi->ROIMode);

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
@@ -503,7 +503,8 @@ int32_t PackerVA::PackSliceParams(H264Slice *pSlice, int32_t sliceNum, int32_t c
     VM_ASSERT (CompBuf->GetBufferSize() >= pSlice_H264->slice_data_offset + AlignedNalUnitSize);
 
     pVAAPI_BitStreamBuffer += pSlice_H264->slice_data_offset;
-    memcpy(pVAAPI_BitStreamBuffer, pNalUnit, NalUnitSize);
+
+    std::copy(pNalUnit, pNalUnit + NalUnitSize, pVAAPI_BitStreamBuffer);
     memset(pVAAPI_BitStreamBuffer + NalUnitSize, 0, AlignedNalUnitSize - NalUnitSize);
 
     if (!m_va->IsLongSliceControl())
@@ -857,13 +858,13 @@ Status PackerVA::QueryStreamOut(H264DecoderFrame* pFrame)
     if (!dst)
         return UMC_ERR_FAILED;
 
-    void const* src = buffer->GetPtr();
+    mfxU8 const* src = reinterpret_cast<mfxU8 *>(buffer->GetPtr());
     VM_ASSERT(src);
 
     int32_t const offset1 =  size * top;
     {
-        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "memcpy");
-        memcpy_s(dst + offset1, size, src, size);
+        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "std::copy");
+        std::copy(src, src + size, dst + offset1);
     }
 
     fei_va->ReleaseBuffer(buffer);
@@ -876,11 +877,11 @@ Status PackerVA::QueryStreamOut(H264DecoderFrame* pFrame)
     if (!buffer || !buffer->GetPtr())
         return UMC_ERR_FAILED;
 
-    src = buffer->GetPtr();
+    src = reinterpret_cast<mfxU8 *>(buffer->GetPtr());
     VM_ASSERT(src);
 
     int32_t const offset2 =  size * bottom;
-    memcpy_s(dst + offset2, size, src, size);
+    std::copy(src, src + size, dst + offset2);
 
     fei_va->ReleaseBuffer(buffer);
 


### PR DESCRIPTION
Replaced memcpy with std::copy / operator =