### PR TITLE
[VPP] Fix of background color normalization

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -1352,7 +1352,7 @@ mfxStatus TaskManager::AssignTask(
         // m_MCTFSurfacesInQueue means number of frames including the current;
         // in case of 2 refs or 4 refs, its enough to have 2 or 3 to output.
         // Effectively, it is used to count number of forward refs + current;
-        // Semantic can be changed to track how many frames are in queue (it 
+        // Semantic can be changed to track how many frames are in queue (it
         // cannot be greater than 3 for 2 refs, or 5 for 4 refs.
         switch (mctf->MCTF_GetReferenceNumber())
         {
@@ -1361,7 +1361,7 @@ mfxStatus TaskManager::AssignTask(
             m_MCTFSurfacesInQueue = 1;
             break;
         case TWO_REFERENCES:
-            if (m_MCTFSurfacesInQueue < 2) 
+            if (m_MCTFSurfacesInQueue < 2)
             {
                 // MCTF cannot work with FRC if it uses 2-refs
                 if (MFX_ERR_MORE_SURFACE == intSts)
@@ -1487,7 +1487,7 @@ void TaskManager::FillTask_Mode30i60p(
 #endif
     )
 {
-    m_resMngr.FillTaskForMode30i60p(pTask, 
+    m_resMngr.FillTaskForMode30i60p(pTask,
                                     pInSurface,
                                     pOutSurface
 #ifdef MFX_ENABLE_MCTF
@@ -2988,7 +2988,7 @@ mfxStatus VideoVPPHW::VppFrameCheck(
         if (input && !m_MctfIsFlushing)
         {
             MFX_SAFE_CALL(m_pMCTFilter->MCTF_GetEmptySurface(&pWorkOutSurf));
-            if (!pWorkOutSurf) 
+            if (!pWorkOutSurf)
             {
                 guard.Unlock();
                 mfxU32 iters(0);
@@ -3042,7 +3042,7 @@ mfxStatus VideoVPPHW::VppFrameCheck(
         // AssignTask will also clear bForcedInternalAlloc
         sts = m_taskMngr.AssignTask(input,pWorkOutSurf, output, aux, pTask, intSts);
 
-        if (MFX_WRN_DEVICE_BUSY != sts) 
+        if (MFX_WRN_DEVICE_BUSY != sts)
         {
             if (!pTask)
                 return MFX_ERR_UNDEFINED_BEHAVIOR;
@@ -3946,11 +3946,11 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
         // this is correct that outputForApp is used:
         // provided that MCTF is not used, and system memory is an output,
         // PostWorkOutSurfaceCopy will copy from an internal buffer to real
-        // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be 
-        // called but in QueryFromMCTF; for D3D output surface no specific 
+        // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be
+        // called but in QueryFromMCTF; for D3D output surface no specific
         // processing is need: if MCTF is not used, outputForApp must be
         // the same as output; if MCTF is used, "copy" to an output surface is done
-        // by MCTF when it makes filtration (no copy, just result of filtering 
+        // by MCTF when it makes filtration (no copy, just result of filtering
         // is placed in to the output suface)
         // NB: if MCTF is not used, and system memory is an output surface,
         // its important ot have bForcedInternalAlloc == false,
@@ -3992,11 +3992,11 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
         // this is correct that outputForApp is used:
         // provided that MCTF is not used, and system memory is an output,
         // PostWorkOutSurfaceCopy will copy from an internal buffer to real
-        // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be 
-        // called but in QueryFromMCTF; for D3D output surface no specific 
+        // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be
+        // called but in QueryFromMCTF; for D3D output surface no specific
         // processing is need: if MCTF is not used, outputForApp must be
         // the same as output; if MCTF is used, "copy" to an output surface is done
-        // by MCTF when it makes filtration (no copy, just result of filtering 
+        // by MCTF when it makes filtration (no copy, just result of filtering
         // is placed in to the output suface)
         // NB: if MCTF is not used, and system memory is an output surface,
         // its important ot have bForcedInternalAlloc == false,
@@ -4100,7 +4100,7 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
             // input fields to SCD detection engine are field 2N + 2 and 2N + 3
 
             // SCD needs field input in display order
-            // SCD detects if input field is the first field of a new Scene 
+            // SCD detects if input field is the first field of a new Scene
             // based on current and previous stream statistics
             sts = m_SCD.PutFrameInterlaced(frameHandle);
             MFX_CHECK_STS(sts);
@@ -4307,11 +4307,11 @@ mfxStatus VideoVPPHW::SyncTaskSubmission(DdiTask* pTask)
     // this is correct that outputForApp is used:
     // provided that MCTF is not used, and system memory is an output,
     // PostWorkOutSurfaceCopy will copy from an internal buffer to real
-    // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be 
-    // called but in QueryFromMCTF; for D3D output surface no specific 
+    // output surface; if MCTF is used, PostWorkOutSurfaceCopy will be
+    // called but in QueryFromMCTF; for D3D output surface no specific
     // processing is need: if MCTF is not used, outputForApp must be
     // the same as output; if MCTF is used, "copy" to an output surface is done
-    // by MCTF when it makes filtration (no copy, just result of filtering 
+    // by MCTF when it makes filtration (no copy, just result of filtering
     // is placed in to the output suface)
     // NB: if MCTF is not used, and system memory is an output surface,
     // its important ot have bForcedInternalAlloc == false,
@@ -4505,7 +4505,7 @@ mfxStatus VideoVPPHW::SubmitToMctf(void *pState, void *pParam, bool* bMctfReadyT
                     }
                 }
             }
-            
+
             mfxFrameSurface1* pSurf = pTask->output.pSurf;
             bool bInForcedInternalAlloc = pTask->output.bForcedInternalAlloc;
             // take control out of input surface:
@@ -4514,7 +4514,7 @@ mfxStatus VideoVPPHW::SubmitToMctf(void *pState, void *pParam, bool* bMctfReadyT
             // be taken & CmSurface2D will be created (or found from the pool)
 
 
-  
+
             mfxHDLPair handle;
             CmSurface2D* pSurfCm(nullptr), *pSurfOutCm(nullptr);
             SurfaceIndex* pSurfIdxCm(nullptr), *pSurfOutIdxCm(nullptr);
@@ -4522,19 +4522,19 @@ mfxStatus VideoVPPHW::SubmitToMctf(void *pState, void *pParam, bool* bMctfReadyT
             MFX_SAFE_CALL(pHwVpp->GetFrameHandle(pSurf, handle, bInForcedInternalAlloc));
             MFX_SAFE_CALL(pHwVpp->CreateCmSurface2D(reinterpret_cast<AbstractSurfaceHandle>(handle.first), pSurfCm, pSurfIdxCm));
 
-            if (pd3dSurf) 
+            if (pd3dSurf)
             {
                 MFX_SAFE_CALL(pHwVpp->GetFrameHandle(pd3dSurf, handle, bOutForcedInternalAlloc));
                 MFX_SAFE_CALL(pHwVpp->CreateCmSurface2D(reinterpret_cast<AbstractSurfaceHandle>(handle.first), pSurfOutCm, pSurfOutIdxCm));
             }
-            
+
             //sts = pHwVpp->m_pMCTFilter->MCTF_PUT_FRAME(MctfData, pSurf, pd3dSurf, bInForcedInternalAlloc, bOutForcedInternalAlloc);
 
             sts = pHwVpp->m_pMCTFilter->MCTF_PUT_FRAME(MctfData, pSurfCm, pSurfOutCm);
 
             // --- access to the internal MCTF queue to increase buffer_count: no need to protect by mutex, as 1 writer & 1 reader
             MFX_SAFE_CALL(pHwVpp->m_pMCTFilter->MCTF_UpdateBufferCount());
-            
+
             // filtering itself
             MFX_SAFE_CALL(pHwVpp->m_pMCTFilter->MCTF_DO_FILTERING());
 
@@ -4573,7 +4573,7 @@ mfxStatus VideoVPPHW::QueryFromMctf(void *pState, void *pParam, bool bMctfReadyT
             //bForcedInternalAlloc = true; // this is true in case of *_TO_SYS ioMode
             // borrowed from  postworkoutput
 
-            if (NO_INDEX != pTask->outputForApp.resIdx) 
+            if (NO_INDEX != pTask->outputForApp.resIdx)
             {
                 d3dSurf.Info = pTask->outputForApp.pSurf->Info;
                 d3dSurf.Data.MemId = pHwVpp->m_internalVidSurf[VPP_OUT].mids[pTask->outputForApp.resIdx];
@@ -5081,10 +5081,10 @@ mfxU64 make_back_color_yuv(mfxU16 bit_depth, mfxU16 Y, mfxU16 U, mfxU16 V)
     mfxU64 const max_val = 256 << shift;
 
     return
-        ((mfxU64)                                 (max_val - 1) << 48) |
-        ((mfxU64)VPP_RANGE_CLIP(Y, (16 << shift), (235 << shift))     << 32) |
-        ((mfxU64)VPP_RANGE_CLIP(U, (16 << shift), (240 << shift))     << 16) |
-        ((mfxU64)VPP_RANGE_CLIP(V, (16 << shift), (240 << shift))     <<  0)
+        ((mfxU64)             (max_val - 1)  << 48)  |
+        ((mfxU64)VPP_RANGE_CLIP(Y, 16, 235)  << 32)  |
+        ((mfxU64)VPP_RANGE_CLIP(U, 16, 240)  << 16)  |
+        ((mfxU64)VPP_RANGE_CLIP(V, 16, 240)  <<  0)
         ;
 };
 
@@ -5873,7 +5873,7 @@ mfxStatus ConfigureExecuteParams(
                     if (videoParam.ExtParam[i]->BufferId == MFX_EXTBUFF_VPP_MCTF)
                     {
                         mfxExtVppMctf *extMCTF = (mfxExtVppMctf*)videoParam.ExtParam[i];
-                        //  if number of min requred frames for MCTF is 2, but async-depth == 1, 
+                        //  if number of min requred frames for MCTF is 2, but async-depth == 1,
                         // should we increase number of input / output surfaces to prevent hangs?
                         executeParams.MctfFilterStrength = extMCTF->FilterStrength;
                         //switch below must work in case MFX_ENABLE_MCTF_EXT is not defined;


### PR DESCRIPTION
The make_back_color_yuv function takes 8-bit background color values as input
and checks them for color ranges of 10-bit/16-bit formats, which is incorrect,
because these values will later be converted to the required format and may be
out of range.