### PR TITLE
[AVCe] Fix conversion of the slice structure from VAAPI to MFX

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1439,8 +1439,12 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
 
     if (attrs[idx_map[VAConfigAttribEncSliceStructure]].value != VA_ATTRIB_NOT_SUPPORTED)
     {
+        // Attribute for VAConfigAttribEncSliceStructure includes both (1) information about supported slice structure and
+        // (2) indication of support for max slice size feature
+        const unsigned int sliceCapabilities = attrs[idx_map[VAConfigAttribEncSliceStructure]].value;
+        const unsigned int sliceStructure = sliceCapabilities & ~VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE;
         m_caps.SliceStructure =
-            ConvertSliceStructureVAAPIToMFX(attrs[idx_map[VAConfigAttribEncSliceStructure]].value);
+            ConvertSliceStructureVAAPIToMFX(sliceStructure);
     }
     else
     {


### PR DESCRIPTION
Current commit includes removing of the
VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE from slice structure
reported by driver. It should be done for correct work of the MSDK
on Linux platform.