### PR TITLE
[MJPEGd/UMC]Avoid using address of local variable as member of CBitSt…

### DIFF
--- a/_studio/shared/umc/codec/jpeg_dec/include/jpegdec_base.h
+++ b/_studio/shared/umc/codec/jpeg_dec/include/jpegdec_base.h
@@ -27,6 +27,7 @@
 #include "decqtbl.h"
 #include "dechtbl.h"
 #include "colorcomp.h"
+#include "membuffin.h"
 #include "bitstreamin.h"
 
 class CJPEGDecoderBase
@@ -38,8 +39,8 @@ public:
 
   virtual void Reset(void);
 
-  JERRCODE SetSource(
-    CBaseStreamInput* pStreamIn);
+  JERRCODE SetSource(const uint8_t* pBuf, size_t buflen);
+  JERRCODE Seek(long offset, int origin);
 
   virtual JERRCODE ReadHeader(
     int*     width,
@@ -115,6 +116,7 @@ public:
   int      m_al;
   int      m_ah;
   JMARKER  m_marker;
+  CMemBuffInput m_stream_in;
 
   int      m_nblock;
 

--- a/_studio/shared/umc/codec/jpeg_dec/include/umc_mjpeg_mfx_decode_hw.h
+++ b/_studio/shared/umc/codec/jpeg_dec/include/umc_mjpeg_mfx_decode_hw.h
@@ -97,7 +97,7 @@ protected:
 
     Status _DecodeField();
 
-    Status _DecodeHeader(CBaseStreamInput* in, int32_t* nUsedBytes);
+    Status _DecodeHeader(int32_t* nUsedBytes);
 
     virtual Status _DecodeField(MediaDataEx* in);
 

--- a/_studio/shared/umc/codec/jpeg_dec/src/jpegdec_base.cpp
+++ b/_studio/shared/umc/codec/jpeg_dec/src/jpegdec_base.cpp
@@ -110,6 +110,8 @@ void CJPEGDecoderBase::Reset(void)
   m_marker                 = JM_NONE;
 
   m_nblock                 = 0;
+
+  m_stream_in.Close();
   return;
 } // CJPEGDecoderBase::Reset(void)
 
@@ -157,17 +159,23 @@ JERRCODE CJPEGDecoderBase::Clean(void)
 
 #define BS_BUFLEN 16384
 
-JERRCODE CJPEGDecoderBase::SetSource(
-  CBaseStreamInput* pInStream)
+JERRCODE CJPEGDecoderBase::SetSource(const uint8_t* pBuf, size_t buflen)
 {
-  JERRCODE jerr;
+  JERRCODE jerr = m_stream_in.Open(pBuf, buflen);
+  if(JPEG_OK != jerr)
+    return jerr;
 
-  jerr = m_BitStreamIn.Attach(pInStream);
+  jerr = m_BitStreamIn.Attach(&m_stream_in);
   if(JPEG_OK != jerr)
     return jerr;
 
   return m_BitStreamIn.Init(BS_BUFLEN);
 } // CJPEGDecoderBase::SetSource()
+
+JERRCODE CJPEGDecoderBase::Seek(long offset, int origin)
+{
+  return m_stream_in.Seek(offset, origin);
+}// CJPEGDecoderBase::Seek
 
 JERRCODE CJPEGDecoderBase::DetectSampling(void)
 {

--- a/_studio/shared/umc/codec/jpeg_dec/src/umc_mjpeg_mfx_decode_base.cpp
+++ b/_studio/shared/umc/codec/jpeg_dec/src/umc_mjpeg_mfx_decode_base.cpp
@@ -324,15 +324,12 @@ Status MJPEGVideoDecoderBaseMFX::_GetFrameInfo(const uint8_t* pBitStream, size_t
     int32_t   precision;
     JSS      sampling;
     JCOLOR   color;
-    CMemBuffInput in;
     JERRCODE jerr;
 
     if (!m_IsInit)
         return UMC_ERR_NOT_INITIALIZED;
 
-    in.Open(pBitStream,nSize);
-
-    jerr = m_decBase->SetSource(&in);
+    jerr = m_decBase->SetSource(pBitStream,nSize);
     if(JPEG_OK != jerr)
         return UMC_ERR_FAILED;
 
@@ -370,15 +367,12 @@ void MJPEGVideoDecoderBaseMFX::SetFrameAllocator(FrameAllocator * frameAllocator
 
 Status MJPEGVideoDecoderBaseMFX::FindStartOfImage(MediaData * in)
 {
-    CMemBuffInput source;
     JERRCODE jerr;
 
     if (!m_IsInit)
         return UMC_ERR_NOT_INITIALIZED;
 
-    source.Open((uint8_t*) in->GetDataPointer(), in->GetDataSize());
-
-    jerr = m_decBase->SetSource(&source);
+    jerr = m_decBase->SetSource((uint8_t*) in->GetDataPointer(), in->GetDataSize());
     if(JPEG_OK != jerr)
         return UMC_ERR_FAILED;
 


### PR DESCRIPTION
…reamInput

-Time live of instance CBitStreamInput longer then local variable
 so move responsibility for memory management CBaseStreamInput* m_in
 to class  CBitStreamInput