### PR TITLE
dispatcher: open plugins.cfg with O_CLOEXEC modifier

### DIFF
--- a/api/mfx_dispatch/linux/mfxparser.cpp
+++ b/api/mfx_dispatch/linux/mfxparser.cpp
@@ -127,10 +127,15 @@ static inline char* skip(char* s)
 
 void parse(const char* file_name, std::list<PluginInfo>& plugins)
 {
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 7)
+  const char* mode = "re";
+#else
+  const char* mode = "r";
+#endif
   char line[PATH_MAX];
   PluginInfo plg;
 
-  FILE* file = fopen(file_name, "r");
+  FILE* file = fopen(file_name, mode);
   if (!file)
     return;
 


### PR DESCRIPTION
Fixes: #793

For multithreaded applications it is desirable to open files with
O_CLOEXEC specifier to avoid leaking them on the fork().

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>