### PR TITLE
[RFC] Expand minTargetKbps for lower bit rate.

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3394,7 +3394,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
             {
                 mfxF64 rawDataBitrate = 12.0 * par.mfx.FrameInfo.Width * par.mfx.FrameInfo.Height *
                     par.mfx.FrameInfo.FrameRateExtN / par.mfx.FrameInfo.FrameRateExtD;
-                mfxU32 minTargetKbps = mfxU32(MFX_MIN(0xffffffff, rawDataBitrate / 1000 / 700));
+                mfxU32 minTargetKbps = mfxU32(MFX_MIN(0xffffffff, rawDataBitrate / 1000 / 800));
 
                 if (par.calcParam.targetKbps < minTargetKbps)
                 {


### PR DESCRIPTION
Current formula may be based on experience.
It could be expanded for lower bit rate when debugging the following
issues:
https://github.com/intel/media-driver/issues/325

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>