### PR TITLE
[HEVCE] fix copy-paste typo

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -2760,7 +2760,7 @@ void SetDefaults(
 
         mfxU16 RefActiveP   = par.m_ext.DDI.NumActiveRefP;
         mfxU16 RefActiveBL0 = par.m_ext.DDI.NumActiveRefBL0;
-        mfxU16 RefActiveBL1 = par.m_ext.DDI.NumActiveRefBL0;
+        mfxU16 RefActiveBL1 = par.m_ext.DDI.NumActiveRefBL1;
 
         if (!RefActiveP)
             for (mfxU16 i = 0; i < 8; i++)  RefActiveP   = Max(RefActiveP, CO3.NumRefActiveP[i]);


### PR DESCRIPTION
DDI.NumActiveRefBL1 was L0.
Obvious and not affecting.