### PR TITLE
[mpeg2d] Avoid null syncpoint at EOS

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2650,7 +2650,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
 
         //VM_ASSERT( m_implUmc.PictureHeader[m_task_num].picture_coding_type != 3 || ( mid[ m_implUmc.frame_buffer.latest_next ] != -1 && mid[ m_implUmc.frame_buffer.latest_prev ] != -1 ));
 
-        IsField = !m_implUmc->IsFramePictureStructure(m_task_num);
+        IsField = !m_implUmc->IsFramePictureStructure(m_task_num); // is invalid (1) if GetPictureHeader() failed (skipped)
         if (m_task_num >= DPB && !IsField)
         {
             int decrease_dec_field_count = dec_field_count % 2 == 0 ? 0 : 1;
@@ -2714,7 +2714,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
                         display_order++;
                     }
 
-                    if ((true == IsField && !(dec_field_count & 1)) || false == IsField)
+                    if (false == IsField || !(dec_field_count & 1) || IsSkipped) // not 2nd field or skipped 2nd
                     {
                         pEntryPoint->requiredNumThreads = m_NumThreads;
                         pEntryPoint->pRoutine = &MPEG2TaskRoutine;


### PR DESCRIPTION
At EOS when 2nd field has corrupted header appeared that
outSurface exists and syncPoint is unassigned. It led to
ERR_NULL_PTR error from decoder and last surface
was lost.
(48200)