### PR TITLE
[h264d] Re-worked recent fix for frame gap handling

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -125,6 +125,7 @@ class H264DecoderFrame
     bool             m_isInterViewRef[2];
 
     bool             m_bIDRFlag;
+    bool             m_bIFlag;
 
     bool IsFullFrame() const;
     void SetFullFrame(bool isFull);

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -597,7 +597,6 @@ protected:
     virtual void OnFullFrame(H264DecoderFrame * pFrame);
     virtual bool ProcessNonPairedField(H264DecoderFrame * pFrame) = 0;
 
-    void DPBSanitize(H264DecoderFrame * pDPBHead, const H264DecoderFrame * pFrame);
     void DBPUpdate(H264DecoderFrame * pFrame, int32_t field);
 
     virtual void AddFakeReferenceFrame(H264Slice * pSlice);

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_frame.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_frame.cpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2017 Intel Corporation
-// 
+// Copyright (c) 2018 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -85,6 +85,7 @@ H264DecoderFrame::H264DecoderFrame(MemoryAllocator *pMemoryAllocator, H264_Heap_
     m_LongTermPicNum[0] = m_PicNum[1] = -1;
     m_PicOrderCnt[0] = m_PicOrderCnt[1] = 0;
     m_bIDRFlag = false;
+    m_bIFlag   = false;
 
     // set memory managment tools
     m_pMemoryAllocator = pMemoryAllocator;
@@ -160,6 +161,7 @@ void H264DecoderFrame::Reset()
 
     post_procces_complete = false;
     m_bIDRFlag = false;
+    m_bIFlag   = false;
 
     m_RefPicListResetCount[0] = m_RefPicListResetCount[1] = 0;
     m_PicNum[0] = m_PicNum[1] = -1;

--- a/_studio/shared/umc/core/umc/include/umc_structures.h
+++ b/_studio/shared/umc/core/umc/include/umc_structures.h
@@ -1,15 +1,15 @@
 // Copyright (c) 2018 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -681,6 +681,7 @@ namespace UMC
         ERROR_FRAME_RECOVERY                = 0x00000010,  // major artifacts at recovery point
         ERROR_FRAME_TOP_FIELD_ABSENT        = 0x00000020,
         ERROR_FRAME_BOTTOM_FIELD_ABSENT     = 0x00000040,
+        ERROR_FRAME_SHORT_TERM_STUCK        = 0x00000100,  // used to mark ST which potentially can get stuck in DPB due to frame gaps
         ERROR_FRAME_DEVICE_FAILURE          = 0x80000000   //if this bit is set, this means the error is [UMC::Status] code
     };
 


### PR DESCRIPTION
Some streams have incorrect log2_max_frame_num value.
So we can't remove _at once_ ST when a gap is detected.
Instead, remove them at a next I frame(as a potential recovery point)
or at SEI recovery point.

Issue: MDP-46557

Signed-off-by: ZhiZhen Tang <zhizhen.tang@intel.com>
(cherry picked from commit 5fec4d2d3bd58d19e89e7e9cadf23b14c5be3cfe)