### PR TITLE
[avc fei] Fixed PWT in FEI single field mode

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -8999,7 +8999,9 @@ void WritePredWeightTable(
     mfxU32              chromaArrayType)
 {
     // Transform field parity to field number before buffer request (PWT attached according to field order, not parity)
-    const mfxExtPredWeightTable* pPWT = GetExtBuffer(task.m_ctrl, task.m_fid[fieldId]);
+    // However in case of FEI single field mode, only one buffer is attached.
+    mfxU32 fieldNum = task.m_singleFieldMode ? 0 : task.m_fid[fieldId];
+    const mfxExtPredWeightTable* pPWT = GetExtBuffer(task.m_ctrl, fieldNum);
 
     if (!pPWT)
         pPWT = &task.m_pwt[fieldId];


### PR DESCRIPTION
In case of FEI single field mode, only one ext buffer is attached.

Issue: MDP-48131

Signed-off-by: ZhiZhen Tang <zhizhen.tang@intel.com>
(cherry picked from commit 698734459ab24372a560ea8a53f63360f6915b8b)