### PR TITLE
[sample] Enable print of encoding fps by default

### DIFF
--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -1557,10 +1557,9 @@ void CEncodingPipeline::Close()
     if (m_FileWriters.first)
     {
         msdk_printf(MSDK_STRING("Frame number: %u\r\n"), m_FileWriters.first->m_nProcessedFramesNum);
-#ifdef TIME_STATS
+
         mfxF64 ProcDeltaTime = m_statOverall.GetDeltaTime() - m_statFile.GetDeltaTime() - m_TaskPool.GetFileStatistics().GetDeltaTime();
         msdk_printf(MSDK_STRING("Encoding fps: %.0f\n"), m_FileWriters.first->m_nProcessedFramesNum / ProcDeltaTime);
-#endif
     }
 
     if (m_UserDataUnregSEI.size() > 0)


### PR DESCRIPTION
Enable print of encoding fps by default.

Signed-off-by: Wong, Vee Khee <vee.khee.wong@intel.com>