### PR TITLE
[vp9e] Fix std::copy applications

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_ddi.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_ddi.h
@@ -197,7 +197,7 @@ typedef struct tagENCODE_CAPS_VP9
         if (bufferSize < sizeof(ivf_file_header))
             return MFX_ERR_MORE_DATA;
 
-        std::copy(std::begin(ivf_file_header),std::end(ivf_file_header), pBitstream);
+        std::copy(std::begin(ivf_file_header),std::end(ivf_file_header), reinterpret_cast<mfxU32*>(pBitstream));
 
         return MFX_ERR_NONE;
     };

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
@@ -925,7 +925,7 @@ inline mfxStatus UpdatePictureHeader(mfxU32 frameLen, mfxU32 frameNum, mfxU8* pP
     if (bufferSize < sizeof(ivf_frame_header))
         return MFX_ERR_MORE_DATA;
 
-    std::copy(std::begin(ivf_frame_header),std::end(ivf_frame_header), pPictureHeader);
+    std::copy(std::begin(ivf_frame_header),std::end(ivf_frame_header), reinterpret_cast<mfxU32*>(pPictureHeader));
 
     return MFX_ERR_NONE;
 };


### PR DESCRIPTION
The source and destination static arrays must have the same type