### PR TITLE
[JPEG] Turning on hardware decoding with YCbCr&&YUV444 color format

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1051,7 +1051,8 @@ bool MFX_JPEG_Utility::IsNeedPartialAcceleration(VideoCORE * core, mfxVideoParam
                     if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
                             (par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV420  ||
                              par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV422H ||
-                             par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV422V))
+                             par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV422V ||
+                             par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444 ))
                         return false;
                     else
                         return true;


### PR DESCRIPTION
JPEG with CHROMAFORMAT_YUV444 and COLORFORMAT_YCbCr is being decoded by APL hardware.

Test: MDP-51112
