### PR TITLE
[build] Remove RUN_TESTS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ cmake_dependent_option(BUILD_SAMPLES "Build samples?" ON "BUILD_DISPATCHER" OFF 
 cmake_dependent_option(BUILD_TOOLS "Build tools?" "${BUILD_ALL}" "BUILD_SAMPLES" OFF)
 option(BUILD_TESTS "Build tests?" "${BUILD_ALL}")
 
-cmake_dependent_option(RUN_TESTS "Run tests during build?" OFF "BUILD_TESTS" OFF )
-
 include( ${BUILDER_ROOT}/FindOpenCL.cmake )
 include( ${BUILDER_ROOT}/FindFunctions.cmake )
 include( ${BUILDER_ROOT}/FindGlobals.cmake )
@@ -110,11 +108,8 @@ if (BUILD_RUNTIME)
   add_subdirectory(${CMAKE_HOME_DIRECTORY}/_studio)
 endif()
 
-if(RUN_TESTS)
-    enable_testing()
-endif()
-
-if (BUILD_TESTS AND GTEST_FOUND)
+if (BUILD_TESTS)
+  enable_testing()
   add_subdirectory(tests)
 endif()
 
@@ -179,6 +174,4 @@ message("  BUILD_DISPATCHER                        : ${BUILD_DISPATCHER}")
 message("  BUILD_SAMPLES                           : ${BUILD_SAMPLES}")
 message("  BUILD_TESTS                             : ${BUILD_TESTS}")
 message("  BUILD_TOOLS                             : ${BUILD_TOOLS}")
-message("Test:")
-message("  RUN_TESTS                               : ${RUN_TESTS}")
 message("*****************************************************************************")

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Media SDK depends on a number of packages which are identified and checked for t
 | BUILD_SAMPLES | ON\|OFF | Build samples (default: ON) |
 | BUILD_TESTS | ON\|OFF | Build unit tests (default: OFF) |
 | BUILD_TOOLS | ON\|OFF | Build tools (default: OFF) |
-| RUN_TESTS | ON\|OFF | Run unit tests as part of build - requires BUILD_TESTS=ON (default: OFF) |
 
 The following cmake settings can be used to adjust search path locations for some components Media SDK build may depend on:
 


### PR DESCRIPTION
The option was deemed redundant - BUILD_TESTS does the job already.