### PR TITLE
[AVCe, HEVCe] Fix for Default BufferSizeInKB calculation

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -2692,7 +2692,10 @@ void SetDefaults(
         if (!par.MaxKbps)
             par.MaxKbps = par.TargetKbps;
         if (!par.BufferSizeInKB)
+        {
             par.BufferSizeInKB = Min(maxBuf, par.MaxKbps / 4); //2 sec: the same as H264
+            par.BufferSizeInKB = Max(par.BufferSizeInKB, par.InitialDelayInKB);
+        }
         if (!par.InitialDelayInKB)
             par.InitialDelayInKB = par.BufferSizeInKB / 2;
         if (par.m_ext.CO2.MBBRC == MFX_CODINGOPTION_UNKNOWN)

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -5942,6 +5942,8 @@ void MfxHwH264Encode::SetDefaults(
                         ? GetMaxCodedFrameSizeInKB(par)
                         : bufferSizeInBits / 8000;
             }
+            par.calcParam.bufferSizeInKB = MFX_MAX(par.calcParam.bufferSizeInKB, par.calcParam.initialDelayInKB);
+
         }
 
         if (par.calcParam.mvcPerViewPar.bufferSizeInKB == 0)
@@ -5953,6 +5955,7 @@ void MfxHwH264Encode::SetDefaults(
             par.calcParam.mvcPerViewPar.bufferSizeInKB = !IsHRDBasedBRCMethod(par.mfx.RateControlMethod)
                     ? GetMaxCodedFrameSizeInKB(par)
                     : bufferSizeInBits / 8000;
+            par.calcParam.mvcPerViewPar.bufferSizeInKB = MFX_MAX(par.calcParam.mvcPerViewPar.bufferSizeInKB, par.calcParam.mvcPerViewPar.initialDelayInKB);
         }
 
         if (par.calcParam.initialDelayInKB == 0 && IsHRDBasedBRCMethod(par.mfx.RateControlMethod))


### PR DESCRIPTION
Issue: 49068
Test:  manually (beh test is needed)

If BufferSizeInKB==0 && InitialDelayInKB!=0
then BufferSizeInKB should be set >= InitialDelayInKB