### PR TITLE
Pass to libdrm render node, not primary node

### DIFF
--- a/samples/sample_common/include/vaapi_device.h
+++ b/samples/sample_common/include/vaapi_device.h
@@ -84,7 +84,6 @@ public:
         m_bRenderWin=false;
 #if defined(X11_DRI3_SUPPORT)
         m_dri_fd = 0;
-        m_dpy = NULL;
         m_bufmgr = NULL;
         m_xcbconn = NULL;
 #endif
@@ -117,7 +116,6 @@ private:
     mfxU32 m_nRenderWinH;
 #if defined(X11_DRI3_SUPPORT)
     int m_dri_fd;
-    Display* m_dpy;
     drm_intel_bufmgr* m_bufmgr;
     xcb_connection_t *m_xcbconn;
 #endif

--- a/samples/sample_common/include/vaapi_utils.h
+++ b/samples/sample_common/include/vaapi_utils.h
@@ -444,19 +444,16 @@ public:
         VASurfaceID srf2);
 
     inline int getBackendType() { return m_type; }
-    VADisplay GetVADisplay(bool render = false)
-     { return (render && m_va_dpy_render)? m_va_dpy_render: m_va_dpy; }
+    VADisplay GetVADisplay() { return m_va_dpy; }
     const MfxLoader::VA_Proxy m_libva;
 
 protected:
     CLibVA(int type)
       : m_type(type)
       , m_va_dpy(NULL)
-      , m_va_dpy_render(NULL)
     {}
     int m_type;
     VADisplay m_va_dpy;
-    VADisplay m_va_dpy_render;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(CLibVA);

--- a/samples/sample_common/src/vaapi_device.cpp
+++ b/samples/sample_common/src/vaapi_device.cpp
@@ -95,7 +95,9 @@ mfxStatus CVAAPIDeviceX11::Init(mfxHDL hWindow, mfxU16 nViews, mfxU32 nAdapterNu
     }
     m_xcbconn = x11xcblib.XGetXCBConnection(m_dpy);
 
-    m_dri_fd = open("/dev/dri/card0", O_RDWR);
+    // it's enough to pass render node, because we only request
+    // information from kernel via m_dri_fd
+    m_dri_fd = open("/dev/dri/renderD128", O_RDWR);
     if (m_dri_fd < 0) {
         msdk_printf(MSDK_STRING("Failed to open dri device\n"));
         return MFX_ERR_NOT_INITIALIZED;

--- a/samples/sample_common/src/vaapi_device.cpp
+++ b/samples/sample_common/src/vaapi_device.cpp
@@ -184,7 +184,7 @@ mfxStatus CVAAPIDeviceX11::RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllo
     if (MFX_ERR_NONE == mfx_res)
     {
         VADisplay dpy = m_X11LibVA.GetVADisplay();
-        VADisplay rnddpy = m_X11LibVA.GetVADisplay(true);
+        VADisplay rnddpy = m_X11LibVA.GetVADisplay();
         VASurfaceID rndsrf;
         void* ctx;
 

--- a/samples/sample_common/src/vaapi_device.cpp
+++ b/samples/sample_common/src/vaapi_device.cpp
@@ -88,12 +88,7 @@ mfxStatus CVAAPIDeviceX11::Init(mfxHDL hWindow, mfxU16 nViews, mfxU32 nAdapterNu
     MfxLoader::XLib_Proxy & x11lib = m_X11LibVA.GetX11();
     MfxLoader::X11_Xcb_Proxy & x11xcblib = m_X11LibVA.GetX11XcbX11();
 
-    m_dpy = x11lib.XOpenDisplay(NULL);
-    if (m_dpy == NULL){
-        msdk_printf(MSDK_STRING("Failed to open display\n"));
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-    m_xcbconn = x11xcblib.XGetXCBConnection(m_dpy);
+    m_xcbconn = x11xcblib.XGetXCBConnection(VAAPI_GET_X_DISPLAY(m_X11LibVA.GetXDisplay()));
 
     // it's enough to pass render node, because we only request
     // information from kernel via m_dri_fd
@@ -131,11 +126,6 @@ void CVAAPIDeviceX11::Close(void)
     if (m_dri_fd)
     {
         close(m_dri_fd);
-    }
-    if (m_dpy)
-    {
-        MfxLoader::XLib_Proxy & x11lib = m_X11LibVA.GetX11();
-        x11lib.XCloseDisplay(m_dpy);
     }
 #endif
 }
@@ -251,8 +241,10 @@ mfxStatus CVAAPIDeviceX11::RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllo
 
     if (MFX_ERR_NONE == mfx_res)
     {
-        x11lib.XResizeWindow(m_dpy, *window, pSurface->Info.CropW, pSurface->Info.CropH);
-        x11lib.XGetGeometry(m_dpy, *window, &root, &x, &y, &width, &height, &border, &depth);
+        x11lib.XResizeWindow(VAAPI_GET_X_DISPLAY(m_X11LibVA.GetXDisplay()),
+                             *window, pSurface->Info.CropW, pSurface->Info.CropH);
+        x11lib.XGetGeometry(VAAPI_GET_X_DISPLAY(m_X11LibVA.GetXDisplay()),
+                            *window, &root, &x, &y, &width, &height, &border, &depth);
 
         switch (depth) {
             case 8: bpp = 8; break;

--- a/samples/sample_common/src/vaapi_utils_x11.cpp
+++ b/samples/sample_common/src/vaapi_utils_x11.cpp
@@ -39,7 +39,6 @@ X11LibVA::X11LibVA(void)
     int major_version = 0, minor_version = 0;
     char* currentDisplay = getenv("DISPLAY");
 
-#if !defined(X11_DRI3_SUPPORT)
     try
     {
         if (currentDisplay)
@@ -48,23 +47,21 @@ X11LibVA::X11LibVA(void)
             m_display = m_x11lib.XOpenDisplay(VAAPI_X_DEFAULT_DISPLAY);
 
         if (NULL == m_display) sts = MFX_ERR_NOT_INITIALIZED;
+
         if (MFX_ERR_NONE == sts)
         {
             m_va_dpy = m_vax11lib.vaGetDisplay(m_display);
 
             if (!m_va_dpy)
             {
-                m_x11lib.XCloseDisplay(m_display);
                 sts = MFX_ERR_NULL_PTR;
             }
         }
+#if !defined(X11_DRI3_SUPPORT)
         if (MFX_ERR_NONE == sts)
         {
             va_res = m_libva.vaInitialize(m_va_dpy, &major_version, &minor_version);
             sts = va_to_mfx_status(va_res);
-            if (MFX_ERR_NONE != sts) {
-                m_x11lib.XCloseDisplay(m_display);
-            }
         }
         if (MFX_ERR_NONE == sts)
         {
@@ -96,37 +93,18 @@ X11LibVA::X11LibVA(void)
                                              0,
                                              &m_contextID);
         }
-    }
 #else
-    try
-    {
-        if (currentDisplay)
-            m_display = m_x11lib.XOpenDisplay(currentDisplay);
-        else
-            m_display = m_x11lib.XOpenDisplay(VAAPI_X_DEFAULT_DISPLAY);
-
-        if (NULL == m_display) sts = MFX_ERR_NOT_INITIALIZED;
-        if (MFX_ERR_NONE == sts)
-        {
-            m_va_dpy = m_vax11lib.vaGetDisplay(m_display);
-
-            if (!m_va_dpy)
-            {
-                m_x11lib.XCloseDisplay(m_display);
-                sts = MFX_ERR_NULL_PTR;
-            }
-        }
         if (MFX_ERR_NONE == sts)
         {
             va_res = m_libva.vaInitialize(m_va_dpy, &major_version, &minor_version);
             sts = va_to_mfx_status(va_res);
-            if (MFX_ERR_NONE != sts)
-            {
-                m_x11lib.XCloseDisplay(m_display);
-            }
+        }
+#endif // X11_DRI3_SUPPORT
+        if (MFX_ERR_NONE != sts)
+        {
+            m_x11lib.XCloseDisplay(m_display);
         }
     }
-#endif // X11_DRI3_SUPPORT
     catch(std::exception& )
     {
         sts = MFX_ERR_NOT_INITIALIZED;

--- a/samples/sample_common/src/vaapi_utils_x11.cpp
+++ b/samples/sample_common/src/vaapi_utils_x11.cpp
@@ -29,9 +29,6 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 
 #define VAAPI_X_DEFAULT_DISPLAY ":0.0"
 
-const char* PROCESSING_DRIVER_NAME="iHD";
-const char* RENDERING_DRIVER_NAME="iHD";
-
 X11LibVA::X11LibVA(void)
     : CLibVA(MFX_LIBVA_X11)
     , m_display(0)
@@ -54,9 +51,8 @@ X11LibVA::X11LibVA(void)
         if (MFX_ERR_NONE == sts)
         {
             m_va_dpy = m_vax11lib.vaGetDisplay(m_display);
-            m_va_dpy_render = m_vax11lib.vaGetDisplay(m_display);
 
-            if (!m_va_dpy || !m_va_dpy_render)
+            if (!m_va_dpy)
             {
                 m_x11lib.XCloseDisplay(m_display);
                 sts = MFX_ERR_NULL_PTR;
@@ -64,35 +60,26 @@ X11LibVA::X11LibVA(void)
         }
         if (MFX_ERR_NONE == sts)
         {
-            if (!setenv("LIBVA_DRIVER_NAME", PROCESSING_DRIVER_NAME, 1)) {
             va_res = m_libva.vaInitialize(m_va_dpy, &major_version, &minor_version);
             sts = va_to_mfx_status(va_res);
             if (MFX_ERR_NONE != sts) {
                 m_x11lib.XCloseDisplay(m_display);
-                }
-                unsetenv("LIBVA_DRIVER_NAME");
-            } else {
-                sts = MFX_ERR_NOT_INITIALIZED;
             }
         }
         if (MFX_ERR_NONE == sts)
         {
-        if (!msdk_strcmp(PROCESSING_DRIVER_NAME, RENDERING_DRIVER_NAME)) {
-            // same driver
             VAStatus        va_res        = VA_STATUS_SUCCESS;
             VAConfigID      vpp_config_id = VA_INVALID_ID;
             VAConfigAttrib  cfgAttrib;
 
-            m_va_dpy_render = m_va_dpy;
-
             cfgAttrib.type = VAConfigAttribRTFormat;
-            m_libva.vaGetConfigAttributes(m_va_dpy_render,
+            m_libva.vaGetConfigAttributes(m_va_dpy,
                                           VAProfileNone,
                                           VAEntrypointVideoProc,
                                           &cfgAttrib,
                                           1);
 
-            va_res = m_libva.vaCreateConfig(m_va_dpy_render,
+            va_res = m_libva.vaCreateConfig(m_va_dpy,
                                             VAProfileNone,
                                             VAEntrypointVideoProc,
                                             &cfgAttrib,
@@ -100,7 +87,7 @@ X11LibVA::X11LibVA(void)
                                             &vpp_config_id);
 
             /* Create a context for VPP pipe */
-            va_res = m_libva.vaCreateContext(m_va_dpy_render,
+            va_res = m_libva.vaCreateContext(m_va_dpy,
                                              vpp_config_id,
                                              0,
                                              0,
@@ -108,25 +95,6 @@ X11LibVA::X11LibVA(void)
                                              0,
                                              0,
                                              &m_contextID);
-        } else {
-            m_va_dpy_render = m_vax11lib.vaGetDisplay(m_display);
-            if (!m_va_dpy_render)
-            {
-                m_libva.vaTerminate(m_va_dpy);
-                m_x11lib.XCloseDisplay(m_display);
-                sts = MFX_ERR_NULL_PTR;
-            }
-            if (!setenv("LIBVA_DRIVER_NAME", RENDERING_DRIVER_NAME, 1)) {
-                va_res = m_libva.vaInitialize(m_va_dpy_render, &major_version, &minor_version);
-                sts = va_to_mfx_status(va_res);
-                if (MFX_ERR_NONE != sts)
-                {
-                    m_libva.vaTerminate(m_va_dpy);
-                    m_x11lib.XCloseDisplay(m_display);
-                }
-                unsetenv("LIBVA_DRIVER_NAME");
-            }
-            }
         }
     }
 #else
@@ -169,22 +137,13 @@ X11LibVA::X11LibVA(void)
 
 X11LibVA::~X11LibVA(void)
 {
-    if (!msdk_strcmp(PROCESSING_DRIVER_NAME, RENDERING_DRIVER_NAME))
+    //release context
+    if (m_contextID != VA_INVALID_ID)
     {
-        //release context
-        if (m_contextID != VA_INVALID_ID)
-        {
-            m_libva.vaDestroyContext(m_va_dpy_render, m_contextID);
-            m_contextID = VA_INVALID_ID;
-        }
+        m_libva.vaDestroyContext(m_va_dpy, m_contextID);
+        m_contextID = VA_INVALID_ID;
     }
 
-#if !defined(X11_DRI3_SUPPORT)
-    if (m_va_dpy_render && (m_va_dpy_render != m_va_dpy))
-    {
-        m_libva.vaTerminate(m_va_dpy_render);
-    }
-#endif
     if (m_va_dpy)
     {
         m_libva.vaTerminate(m_va_dpy);


### PR DESCRIPTION
Fix failure on CentOS 7.5: primary drm node was created for libdri,
but it lacks permissions required for ioctl(.., DRM_IOCTL_I915_GETPARAM)
to run.