### PR TITLE
h264e: change ICQ quality factor range to [1, 51].

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3854,8 +3854,11 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         changed = true;
     }
 
-    if (par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ ||
-        par.mfx.RateControlMethod == MFX_RATECONTROL_LA_ICQ)
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ)
+    {
+        if (!CheckRange(par.mfx.ICQQuality, 1, 51)) changed = true;
+    }
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_LA_ICQ)
     {
         if (!CheckRange(par.mfx.ICQQuality, 0, 51)) changed = true;
     }


### PR DESCRIPTION
Change the ICQ quality factor range to [1, 51]
which aligns with the definition in VAAPI.

Change-Id: I582753964de57d0b479c1eebee42b05700f516d1