### PR TITLE
h264e: change the quality factor range to [1, 51] for QVBR

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3862,7 +3862,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR)
     {
-        if (!CheckRange(extOpt3->QVBRQuality, 0, 51)) changed = true;
+        if (!CheckRange(extOpt3->QVBRQuality, 1, 51)) changed = true;
     }
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)


### PR DESCRIPTION
Although there is no explicit declaration in VAAPI
for the range of "quality_factor",
for AVC, the range should be [1, 51],
like "ICQ_quality_factor" in VAAPI.

Change-Id: Idd5877d45bf7185ff8d189c9af2cbcc7c1ab5d73