### PR TITLE
Add new CFL device ID

### DIFF
--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -255,6 +255,7 @@ typedef struct {
     { 0x3E94, MFX_HW_CFL, MFX_GT2 },
     { 0x3E96, MFX_HW_CFL, MFX_GT2 },
     { 0x3E9B, MFX_HW_CFL, MFX_GT2 },
+    { 0x3EA5, MFX_HW_CFL, MFX_GT3 },
 
     /* CNL */
     { 0x5A51, MFX_HW_CNL, MFX_GT2 },


### PR DESCRIPTION
0x3EA5 is the Intel Iris Plus Graphics 655 processor in
the Intel Core i7-8559U.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>