### PR TITLE
[ASG HEVC] Replaced unsafe sscanf function

### DIFF
--- a/tools/asg-hevc/src/test_processor.cpp
+++ b/tools/asg-hevc/src/test_processor.cpp
@@ -218,7 +218,8 @@ void TestProcessor::RunRepackVerify()
         fpRepackStat.getline(repackStat, sizeof(repackStat));
         if (!fpRepackStat.good())
             throw string("ERROR: Repack stat file read failed");
-        sscanf(repackStat, "%d NumPasses\n", &activeNumPasses);
+        istringstream repackStatStream(string(repackStat, strlen(repackStat)));
+        repackStatStream >> activeNumPasses;
 
         // Check read repack data
 


### PR DESCRIPTION
Unsafe sscanf caused a build error on windows, it was replaced by using istringstream object for further parsing.