### PR TITLE
[JPEGE] BGR4 in vaapi_allocator

### DIFF
--- a/samples/sample_common/src/vaapi_allocator.cpp
+++ b/samples/sample_common/src/vaapi_allocator.cpp
@@ -52,6 +52,8 @@ unsigned int ConvertMfxFourccToVAFormat(mfxU32 fourcc)
 #endif
     case MFX_FOURCC_RGB4:
         return VA_FOURCC_ARGB;
+    case MFX_FOURCC_BGR4:
+        return VA_FOURCC_ABGR;
     case MFX_FOURCC_RGBP:
         return VA_FOURCC_RGBP;
     case MFX_FOURCC_P8:
@@ -166,6 +168,7 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
                        (VA_FOURCC_R5G6B5 != va_fourcc) &&
 #endif
                        (VA_FOURCC_ARGB   != va_fourcc) &&
+                       (VA_FOURCC_ABGR   != va_fourcc) &&
                        (VA_FOURCC_RGBP   != va_fourcc) &&
                        (VA_FOURCC_P208   != va_fourcc) &&
                        (VA_FOURCC_P010   != va_fourcc)))
@@ -500,6 +503,17 @@ mfxStatus vaapiFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData *ptr)
                     ptr->G = ptr->B;
                     ptr->R = ptr->B;
                     ptr->A = ptr->B;
+                }
+                else mfx_res = MFX_ERR_LOCK_MEMORY;
+                break;
+            case VA_FOURCC_ABGR:
+                if (mfx_fourcc == MFX_FOURCC_BGR4)
+                {
+                    ptr->Pitch = (mfxU16)vaapi_mid->m_image.pitches[0];
+                    ptr->R = pBuffer + vaapi_mid->m_image.offsets[0];
+                    ptr->G = ptr->R + 1;
+                    ptr->B = ptr->R + 2;
+                    ptr->A = ptr->R + 3;
                 }
                 else mfx_res = MFX_ERR_LOCK_MEMORY;
                 break;


### PR DESCRIPTION
There are substitution
request.Info.FourCC = (m_pCore->GetVAType() == MFX_HW_VAAPI)?MFX_FOURCC_BGR4:MFX_FOURCC_RGB4;
in mfx_mjpeg_encode_hw.cpp

libmfx_allocator_vaapi.cpp (shared/src) was updated to use BGR4, but vaapi_allocator (sample_common) does not.

Issue: MDP-47046