### PR TITLE
[HEVCE] update PPyrInterval after NumRefFrame change

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -24,6 +24,7 @@
 #include "mfx_h265_encode_hw_ddi.h"
 #include <assert.h>
 #include <math.h>
+#include <algorithm>
 
 namespace MfxHwH265Encode
 {
@@ -2842,8 +2843,9 @@ void SetDefaults(
             }
             par.mfx.NumRefFrame = Max<mfxU16>(par.NumTL() - 1, par.mfx.NumRefFrame);
             par.mfx.NumRefFrame = Min<mfxU16>(maxDPB - 1, par.mfx.NumRefFrame);
+            par.PPyrInterval = std::min<mfxU32>(par.PPyrInterval, par.mfx.NumRefFrame);
         }
-     }
+    }
     if (par.m_ext.CO2.ExtBRC == MFX_CODINGOPTION_UNKNOWN)
         par.m_ext.CO2.ExtBRC = MFX_CODINGOPTION_OFF;
 


### PR DESCRIPTION
If NumRefFrame is not given, PPyrInterval computed with uninitialized
NumRefFrame can differ. After NumRefFrame is assigned PPyrInterval to
be updated.
PPyrInterval affects DPB control. The commit fixes RefLists in
LowPower mode.
(45453)