### PR TITLE
scheduler: create threads per-component requests

### DIFF
--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -21,6 +21,8 @@
 #if !defined(__MFX_SCHEDULER_CORE_H)
 #define __MFX_SCHEDULER_CORE_H
 
+#include <list>
+
 #include <mfx_interface_scheduler.h>
 
 #include <mfx_scheduler_core_thread.h>
@@ -223,9 +225,6 @@ protected:
     // Release the object
     void Close(void);
 
-    // Wait until the scheduler got more work
-    void Wait(const mfxU32 curThreadNum, std::unique_lock<std::mutex>& mutex);
-
     // Get high performance counter value. This counter is used to calculate
     // tasks duration and priority management.
     mfxU64 GetHighPerformanceCounter(void);
@@ -309,10 +308,6 @@ protected:
     // Assign socket affinity for every thread
     void SetThreadsAffinityToSockets(void);
 
-    inline MFX_SCHEDULER_THREAD_CONTEXT* GetThreadCtx(mfxU32 thread_id)
-    { return &m_pThreadCtx[thread_id]; }
-
-
     // Scheduler's initialization parameters
     MFX_SCHEDULER_PARAM2 m_param;
     // Reference counters
@@ -346,9 +341,7 @@ protected:
     bool m_bQuitWakeUpThread;
     
     // Threads contexts
-    MFX_SCHEDULER_THREAD_CONTEXT *m_pThreadCtx;
-
-
+    std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> m_pThreads;
 
     // Event to wait free task objects
     UMC::Semaphore m_freeTasks;
@@ -409,7 +402,6 @@ protected:
     mfxU32 m_jobCounter;
 
     mfxU32 m_timer_hw_event;
-
 
 private:
     // declare a assignment operator to avoid warnings

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -22,6 +22,7 @@
 #define __MFX_SCHEDULER_CORE_H
 
 #include <list>
+#include <map>
 
 #include <mfx_interface_scheduler.h>
 
@@ -125,7 +126,7 @@ enum eWakeUpReason
 };
 
 
-class mfxSchedulerCore : public MFXIScheduler2
+class mfxSchedulerCore : public MFXIScheduler3
 {
 public:
     // Default constructor
@@ -182,6 +183,9 @@ public:
     virtual
     mfxStatus AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoint,
                       const char *pFileName, int lineNumber);
+
+    virtual
+    mfxStatus SetThreadNum(const void *pComponent, mfxU32 threadNum);
 
     //
     // MFXIUnknown interface
@@ -342,6 +346,10 @@ protected:
     
     // Threads contexts
     std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> m_pThreads;
+    // Number of threads required for each component to be functional
+    std::map<const void*, mfxU32> m_pThreadsMap;
+    // Mutex to guard threads add/remove operations
+    std::mutex m_pThreadsMapMutex;
 
     // Event to wait free task objects
     UMC::Semaphore m_freeTasks;

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -342,9 +342,6 @@ protected:
     // Stop and terminate the wake up thread
     mfxStatus StopWakeUpThread(void);
 
-    // 'quit' flag for threads
-    volatile
-    bool m_bQuit;
     volatile
     bool m_bQuitWakeUpThread;
     

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core_thread.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core_thread.h
@@ -41,8 +41,9 @@ struct MFX_SCHEDULER_THREAD_CONTEXT
     {}
 
     enum State {
-        Waiting, // thread is waiting for incoming tasks
-        Running  // thread is executing a task
+        Waiting,  // thread is waiting for incoming tasks
+        Running,  // thread is executing a task
+        Stopping, // thread is going to stop
     };
 
     State state;                       // thread state, waiting or running

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
@@ -44,7 +44,6 @@ mfxSchedulerCore::mfxSchedulerCore(void)
     memset(m_workingTime, 0, sizeof(m_workingTime));
     m_timeIdx = 0;
 
-    m_pThreadCtx = NULL;
     m_vmtick_msec_frequency = vm_time_get_frequency()/1000;
     vm_event_set_invalid(&m_hwTaskDone);
 
@@ -104,22 +103,12 @@ void mfxSchedulerCore::Close(void)
     StopWakeUpThread();
 
     // stop threads
-    if (m_pThreadCtx)
+    if (!m_pThreads.empty())
     {
-        for (mfxU32 i = 0; i < m_param.numberOfThreads; ++i)
-        {
-            {
-                std::lock_guard<std::mutex> guard(m_guard);
-                m_pThreadCtx[i].state = MFX_SCHEDULER_THREAD_CONTEXT::Stopping;
-                m_pThreadCtx[i].taskAdded.notify_one();
-            }
-            // wait for particular thread
-            if (m_pThreadCtx[i].threadHandle.joinable())
-                m_pThreadCtx[i].threadHandle.join();
-        }
-
-        delete[] m_pThreadCtx;
+        std::lock_guard<std::mutex> lock(m_guard);
+        for (auto& thread: m_pThreads) thread->Stop(lock);
     }
+    m_pThreads.clear();
 
     // run over the task lists and abort the existing tasks
     for (priority = MFX_PRIORITY_HIGH;
@@ -153,8 +142,6 @@ void mfxSchedulerCore::Close(void)
     memset(m_workingTime, 0, sizeof(m_workingTime));
     m_timeIdx = 0;
 
-    // reset variables
-    m_pThreadCtx = NULL;
     // reset task variables
     memset(m_pTasks, 0, sizeof(m_pTasks));
     memset(m_numAssignedTasks, 0, sizeof(m_numAssignedTasks));
@@ -178,31 +165,15 @@ void mfxSchedulerCore::WakeUpThreads(mfxU32 num_dedicated_threads, mfxU32 num_re
     if (m_param.flags == MFX_SINGLE_THREAD)
         return;
 
-    MFX_SCHEDULER_THREAD_CONTEXT* thctx;
+    for (auto& ctx: m_pThreads) {
+      if (!num_dedicated_threads && !num_regular_threads)
+        break;
 
-    if (num_dedicated_threads) {
-        // we have single dedicated thread, thus no loop here
-        thctx = GetThreadCtx(0);
-        if (thctx->state == MFX_SCHEDULER_THREAD_CONTEXT::Waiting) {
-            thctx->taskAdded.notify_one();
-        }
-    }
-    // if we have woken up dedicated thread, we exclude it from the loop below
-    for (mfxU32 i = (num_dedicated_threads)? 1: 0; (i < m_param.numberOfThreads) && num_regular_threads; ++i) {
-        thctx = GetThreadCtx(i);
-        if (thctx->state == MFX_SCHEDULER_THREAD_CONTEXT::Waiting) {
-            thctx->taskAdded.notify_one();
-            --num_regular_threads;
-        }
-    }
-}
-
-void mfxSchedulerCore::Wait(const mfxU32 curThreadNum, std::unique_lock<std::mutex>& mutex)
-{
-    MFX_SCHEDULER_THREAD_CONTEXT* thctx = GetThreadCtx(curThreadNum);
-
-    if (thctx) {
-        thctx->taskAdded.wait(mutex);
+      if (ctx->state == MFX_SCHEDULER_THREAD_CONTEXT::Waiting) {
+          ctx->taskAdded.notify_one();
+      }
+      if (num_dedicated_threads) --num_dedicated_threads;
+      else --num_regular_threads;
     }
 }
 

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
@@ -44,8 +44,6 @@ mfxSchedulerCore::mfxSchedulerCore(void)
     memset(m_workingTime, 0, sizeof(m_workingTime));
     m_timeIdx = 0;
 
-    m_bQuit = false;
-
     m_pThreadCtx = NULL;
     m_vmtick_msec_frequency = vm_time_get_frequency()/1000;
     vm_event_set_invalid(&m_hwTaskDone);
@@ -108,19 +106,13 @@ void mfxSchedulerCore::Close(void)
     // stop threads
     if (m_pThreadCtx)
     {
-        mfxU32 i;
-
-        // set the 'quit' flag for threads
-        m_bQuit = true;
-
+        for (mfxU32 i = 0; i < m_param.numberOfThreads; ++i)
         {
-            // set the events to wake up sleeping threads
-            std::lock_guard<std::mutex> guard(m_guard);
-            WakeUpThreads();
-        }
-
-        for (i = 0; i < m_param.numberOfThreads; i += 1)
-        {
+            {
+                std::lock_guard<std::mutex> guard(m_guard);
+                m_pThreadCtx[i].state = MFX_SCHEDULER_THREAD_CONTEXT::Stopping;
+                m_pThreadCtx[i].taskAdded.notify_one();
+            }
             // wait for particular thread
             if (m_pThreadCtx[i].threadHandle.joinable())
                 m_pThreadCtx[i].threadHandle.join();
@@ -162,7 +154,6 @@ void mfxSchedulerCore::Close(void)
     m_timeIdx = 0;
 
     // reset variables
-    m_bQuit = false;
     m_pThreadCtx = NULL;
     // reset task variables
     memset(m_pTasks, 0, sizeof(m_pTasks));

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
@@ -25,9 +25,6 @@
 #include <mfx_trace.h>
 
 #include <vm_time.h>
-#include <vm_sys_info.h>
-
-
 
 mfxSchedulerCore::mfxSchedulerCore(void)
     :  m_currentTimeStamp(0)

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
@@ -92,7 +92,6 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
             return MFX_ERR_UNSUPPORTED;
         }
 
-
         try
         {
             // allocate 'free task' event
@@ -113,14 +112,13 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
                 }
                 m_pThreads.emplace_back(std::move(thread));
             }
+
+            SetThreadsAffinityToSockets();
         }
         catch (...)
         {
             return MFX_ERR_MEMORY_ALLOC;
         }
-
-
-        SetThreadsAffinityToSockets();
     }
     else
     {
@@ -129,8 +127,7 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
     }
 
     return MFX_ERR_NONE;
-
-} // mfxStatus mfxSchedulerCore::Initialize(mfxSchedulerFlags flags, mfxU32 numberOfThreads)
+}
 
 mfxStatus mfxSchedulerCore::AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoint)
 {
@@ -163,12 +160,6 @@ mfxStatus mfxSchedulerCore::Synchronize(mfxSyncPoint syncPoint, mfxU32 timeToWai
 
 mfxStatus mfxSchedulerCore::Synchronize(mfxTaskHandle handle, mfxU32 timeToWait)
 {
-    // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-
     // look up the task
     MFX_SCHEDULER_TASK *pTask = m_ppTaskLookUpTable.at(handle.taskID);
 
@@ -259,6 +250,8 @@ mfxStatus mfxSchedulerCore::Synchronize(mfxTaskHandle handle, mfxU32 timeToWait)
     {
         std::unique_lock<std::mutex> guard(m_guard);
 
+        MFX_CHECK(!m_pThreads.empty(), MFX_ERR_NOT_INITIALIZED);
+
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_PRIVATE, "Scheduler::Wait");
         MFX_LTRACE_1(MFX_TRACE_LEVEL_SCHED, "^Depends^on", "%d", pTask->param.task.nParentId);
         MFX_LTRACE_I(MFX_TRACE_LEVEL_SCHED, timeToWait);
@@ -292,10 +285,6 @@ mfxStatus mfxSchedulerCore::WaitForDependencyResolved(const void *pDependency)
     bool bFind = false;
 
     // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
     if (NULL == pDependency)
     {
         return MFX_ERR_NONE;
@@ -338,14 +327,7 @@ mfxStatus mfxSchedulerCore::WaitForTaskCompletion(const void *pOwner)
     mfxTaskHandle waitHandle;
 
     // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-    if (NULL == pOwner)
-    {
-        return MFX_ERR_NULL_PTR;
-    }
+    MFX_CHECK(pOwner, MFX_ERR_NULL_PTR);
 
     // make sure that threads are running
     {
@@ -429,43 +411,23 @@ mfxStatus mfxSchedulerCore::ResetWaitingStatus(const void *pOwner)
 
 mfxStatus mfxSchedulerCore::GetState(void)
 {
-    // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-
     return MFX_ERR_NONE;
-
-} // mfxStatus mfxSchedulerCore::GetState(void)
+}
 
 mfxStatus mfxSchedulerCore::GetParam(MFX_SCHEDULER_PARAM *pParam)
 {
     // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-    if (NULL == pParam)
-    {
-        return MFX_ERR_NULL_PTR;
-    }
+    MFX_CHECK(pParam, MFX_ERR_NULL_PTR);
 
     // copy the parameters
     *pParam = m_param;
 
     return MFX_ERR_NONE;
-
-} // mfxStatus mfxSchedulerCore::GetParam(MFX_SCHEDULER_PARAM *pParam)
+}
 
 mfxStatus mfxSchedulerCore::Reset(void)
 {
     // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-
     if (NULL == m_pFailedTasks)
     {
         return MFX_ERR_NONE;
@@ -486,12 +448,6 @@ mfxStatus mfxSchedulerCore::Reset(void)
 mfxStatus mfxSchedulerCore::AdjustPerformance(const mfxSchedulerMessage message)
 {
     mfxStatus mfxRes = MFX_ERR_NONE;
-
-    // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
 
     switch(message)
     {
@@ -533,15 +489,9 @@ mfxStatus mfxSchedulerCore::AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoi
 
 
     // check error(s)
-    if (0 == m_param.numberOfThreads)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
-    }
-    if ((NULL == task.entryPoint.pRoutine) ||
-        (NULL == pSyncPoint))
-    {
-        return MFX_ERR_NULL_PTR;
-    }
+    MFX_CHECK(pSyncPoint, MFX_ERR_NULL_PTR);
+    MFX_CHECK(task.entryPoint.pRoutine, MFX_ERR_NULL_PTR);
+    MFX_CHECK(!m_pThreads.empty(), MFX_ERR_NOT_INITIALIZED);
 
     // make sure that there is enough free task objects
     m_freeTasks.Wait();
@@ -606,10 +556,10 @@ mfxStatus mfxSchedulerCore::AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoi
         pAssignment->m_numRefs += 1;
 
         // saturate the number of available threads
-        uint32_t numThreads = m_pFreeTasks->param.task.entryPoint.requiredNumThreads;
-        numThreads = (0 == numThreads) ? (m_param.numberOfThreads) : (numThreads);
-        numThreads = UMC::get_min(m_param.numberOfThreads, numThreads);
-        numThreads = (uint32_t) UMC::get_min(sizeof(pAssignment->threadMask) * 8, numThreads);
+        uint32_t numThreads = (uint32_t)std::min<uint64_t>({
+            m_pFreeTasks->param.task.entryPoint.requiredNumThreads,
+            m_pThreads.size(),
+            sizeof(pAssignment->threadMask) * 8});
         m_pFreeTasks->param.task.entryPoint.requiredNumThreads = numThreads;
 
         // set the advanced task's info

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_iunknown.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_iunknown.cpp
@@ -41,6 +41,14 @@ void *mfxSchedulerCore::QueryInterface(const MFX_GUID &guid)
         return (MFXIScheduler2 *) this;
     }
 
+    if (MFXIScheduler3_GUID == guid)
+    {
+        // increment reference counter
+        vm_interlocked_inc32(&m_refCounter);
+
+        return (MFXIScheduler3 *) this;
+    }
+
     // it is unsupported interface
     return NULL;
 

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
@@ -92,22 +92,21 @@ void mfxSchedulerCore::ThreadProc(MFX_SCHEDULER_THREAD_CONTEXT *pContext)
         }
         else
         {
+            mfxU32 timeout = (threadNum)? MFX_THREAD_TIME_TO_WAIT: 1;
             mfxU64 start, stop;
-
 
             // mark beginning of sleep period
             start = GetHighPerformanceCounter();
 
             // there is no any task.
             // sleep for a while until the event is signaled.
-            Wait(threadNum, guard);
+            pContext->taskAdded.wait_for(guard, std::chrono::milliseconds(timeout));
 
             // mark end of sleep period
             stop = GetHighPerformanceCounter();
 
             // update thread statistic
             pContext->sleepTime += (stop - start);
-
         }
     }
 }

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
@@ -61,7 +61,7 @@ void mfxSchedulerCore::ThreadProc(MFX_SCHEDULER_THREAD_CONTEXT *pContext)
     }
 
     // main working cycle for threads
-    while (false == m_bQuit)
+    while (pContext->state != MFX_SCHEDULER_THREAD_CONTEXT::Stopping)
     {
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "thread_proc");
 

--- a/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
+++ b/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
@@ -37,6 +37,11 @@ static const
 MFX_GUID MFXIScheduler2_GUID =
 { 0xdc775b1c, 0x951d, 0x421f, { 0xbf, 0xd8, 0xca, 0x56, 0x2d, 0x95, 0xa4, 0x18 } };
 
+// {CA33464F-30AB-4FD1-9BA8-D936B353D8DD}
+static const
+MFX_GUID MFXIScheduler3_GUID =
+{ 0xca33464f, 0x30ab, 0x4fd1, { 0x9b, 0xa8, 0xd9, 0x36, 0xb3, 0x53, 0xd8, 0xdd } };
+
 enum mfxSchedulerFlags
 {
     // default behaviour policy
@@ -119,8 +124,6 @@ public:
     // Send a performance message to the scheduler
     virtual
     mfxStatus AdjustPerformance(const mfxSchedulerMessage message) = 0;
-
-
 };
 
 struct MFX_SCHEDULER_PARAM2: public MFX_SCHEDULER_PARAM
@@ -140,6 +143,13 @@ public:
 
     virtual
     mfxStatus GetTimeout(mfxU32 & maxTimeToRun) = 0;
+};
+
+class MFXIScheduler3 : public MFXIScheduler2
+{
+public:
+    virtual
+    mfxStatus SetThreadNum(const void *pComponent, mfxU32 threadNum) = 0;
 };
 
 #endif // __MFX_INTERFACE_SCHEDULER_H

--- a/_studio/mfx_lib/shared/include/mfx_user_plugin.h
+++ b/_studio/mfx_lib/shared/include/mfx_user_plugin.h
@@ -43,6 +43,7 @@ public:
     mfxStatus PluginClose(void);
     // Get the plugin's threading policy
     mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    mfxStatus GetThreadNum(mfxU32& threadNum);
 
     // Check the parameters to start a new tasl
     mfxStatus Check(const mfxHDL *in, mfxU32 in_num,
@@ -102,6 +103,10 @@ protected:
         mfxTaskThreadingPolicy GetThreadingPolicy(void) {
             return m_plg->GetThreadingPolicy();
         }
+        mfxStatus GetThreadNum(mfxU32& threadNum) {
+            return m_plg->GetThreadNum(threadNum);
+        }
+
         mfxStatus GetVideoParam(mfxVideoParam *par) {
             return m_plg->GetVideoParam(par);
         }

--- a/_studio/mfx_lib/shared/src/libmfxsw_encode.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_encode.cpp
@@ -705,6 +705,22 @@ mfxStatus MFXVideoENCODE_Init(mfxSession session, mfxVideoParam *par)
         }
 
         mfxRes = session->m_pENCODE->Init(par);
+
+        if (mfxRes >= MFX_ERR_NONE) {
+            MFXIScheduler3* pScheduler3 = (MFXIScheduler3*)session->m_pScheduler->QueryInterface(MFXIScheduler3_GUID);
+
+            if (pScheduler3) {
+                mfxU32 threadNum = 0;
+                mfxStatus sts = session->m_pENCODE->GetThreadNum(threadNum);
+
+                if (MFX_ERR_NONE == sts)
+                    sts = pScheduler3->SetThreadNum(session->m_pENCODE.get(), threadNum);
+                if (MFX_ERR_NONE != sts)
+                    mfxRes = sts;
+
+                pScheduler3->Release();
+            }
+        }
     }
     // handle error(s)
     catch(...)
@@ -735,6 +751,12 @@ mfxStatus MFXVideoENCODE_Close(mfxSession session)
 
         // wait until all tasks are processed
         session->m_pScheduler->WaitForTaskCompletion(session->m_pENCODE.get());
+
+        MFXIScheduler3* pScheduler3 = (MFXIScheduler3*)session->m_pScheduler->QueryInterface(MFXIScheduler3_GUID);
+        if (pScheduler3) {
+            pScheduler3->SetThreadNum(session->m_pENCODE.get(), 0);
+            pScheduler3->Release();
+        }
 
         mfxRes = session->m_pENCODE->Close();
         // delete the codec's instance if not plugin

--- a/_studio/mfx_lib/shared/src/mfx_user_plugin.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_user_plugin.cpp
@@ -215,8 +215,13 @@ mfxTaskThreadingPolicy VideoUSERPlugin::GetThreadingPolicy(void)
     }
 
     return threadingPolicy;
+}
 
-} // mfxTaskThreadingPolicy VideoUSERPlugin::GetThreadingPolicy(void)
+mfxStatus VideoUSERPlugin::GetThreadNum(mfxU32& threadNum)
+{
+    threadNum = m_param.MaxThreadNum;
+    return MFX_ERR_NONE;
+}
 
 mfxStatus VideoUSERPlugin::Check(const mfxHDL *in, mfxU32 in_num,
                                  const mfxHDL *out, mfxU32 out_num,

--- a/_studio/shared/include/mfxvideo++int.h
+++ b/_studio/shared/include/mfxvideo++int.h
@@ -21,6 +21,8 @@
 #ifndef __MFXVIDEOPLUSPLUS_INTERNAL_H
 #define __MFXVIDEOPLUSPLUS_INTERNAL_H
 
+#include <thread>
+
 #include "mfxvideo.h"
 #include "mfxstructures-int.h"
 #include <mfx_task_threading_policy.h>
@@ -276,6 +278,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -299,6 +307,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -341,6 +355,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -400,6 +420,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -435,6 +461,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -497,6 +529,12 @@ public:
     // Get the plugin's threading policy
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     // Check the parameters to start a new tasl
     virtual


### PR DESCRIPTION
This PR is not yet fully completed. Pay attention and provide comments:
1. How many threads each component needs. Pay attention on VPP, encoders and FEI - these components create 2 tasks (Submit & Query) - this part was moved away from this pr to #911.
2. Scheduler internal API altered - are we ok with that?

First 5 cleanup commits extracted to separate pr #903, please, review them there.
