### PR TITLE
[dispatcher_test] Adjusted test cases of loading plugin

### DIFF
--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
@@ -35,11 +35,11 @@ TEST_F(DispatcherLibsTest, ShouldSucceedForSeeminglyGoodMockLibrary)
     ver = {{MFX_VERSION_MINOR, MFX_VERSION_MAJOR}};
     mock.emulated_api_version = ver;
 
-    EXPECT_CALL(mock, dlopen).Times(AtLeast(1)).WillRepeatedly(Return(MOCK_DLOPEN_HANDLE));
+    EXPECT_CALL(mock, dlopen).Times(1).WillRepeatedly(Return(MOCK_DLOPEN_HANDLE));
     EXPECT_CALL(mock, dlsym).Times(AtLeast(1)).WillRepeatedly(Invoke(&mock, &MockCallObj::EmulateAPI));
-    EXPECT_CALL(mock, MFXInitEx).Times(AtLeast(1)).WillRepeatedly(DoAll(SetArgPointee<1>(MOCK_SESSION_HANDLE), Return(MFX_ERR_NONE)));
-    EXPECT_CALL(mock, MFXQueryIMPL).Times(AtLeast(1)).WillRepeatedly(Return(MFX_ERR_NONE));
-    EXPECT_CALL(mock, MFXQueryVersion).Times(AtLeast(1)).WillRepeatedly(Invoke(&mock, &MockCallObj::ReturnEmulatedVersion));
+    EXPECT_CALL(mock, MFXInitEx).Times(1).WillRepeatedly(DoAll(SetArgPointee<1>(MOCK_SESSION_HANDLE), Return(MFX_ERR_NONE)));
+    EXPECT_CALL(mock, MFXQueryIMPL).Times(1).WillRepeatedly(Return(MFX_ERR_NONE));
+    EXPECT_CALL(mock, MFXQueryVersion).Times(1).WillRepeatedly(Invoke(&mock, &MockCallObj::ReturnEmulatedVersion));
 
     mfxStatus sts = MFXInit(impl, &ver, &session);
     ASSERT_EQ(sts, MFX_ERR_NONE);
@@ -111,10 +111,10 @@ TEST_P(DispatcherLibsTestParametrized, ShouldEnumerateCorrectLibNames)
 
     for (std::string lib : libs)
     {
-        EXPECT_CALL(mock, dlopen(StrEq(lib.c_str()),_));
+        EXPECT_CALL(mock, dlopen(StrEq(lib.c_str()),_)).Times(1);
     }
 
-    mfxStatus sts = MFXInit(impl, &this->ver, &this->session);
+    MFXInit(impl, &this->ver, &this->session);
 }
 
 INSTANTIATE_TEST_CASE_P(EnumeratingLibs, DispatcherLibsTestParametrized, impl_case_list);

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_cases_plugins.cpp
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_cases_plugins.cpp
@@ -34,11 +34,11 @@ TEST_F(DispatcherPluginsTest, ShouldSearchForPluginsCfgByCorrectPath)
     MockCallObj& mock = *g_call_obj_ptr;
 
     std::string path = std::string(MFX_PLUGINS_CONF_DIR) + "/plugins.cfg";
-    EXPECT_CALL(mock, fopen(StrEq(path.c_str()),_));
+    EXPECT_CALL(mock, fopen(StrEq(path.c_str()), _)).Times(1);
 
     mfxPluginUID uid{0};
     std::fill(uid.Data, uid.Data + sizeof(mfxPluginUID), MOCK_PLUGIN_UID_BYTE_BASE);
-    mfxStatus sts = MFXVideoUSER_Load(session, &uid, 0);
+    MFXVideoUSER_Load(session, &uid, 0);
 }
 
 
@@ -59,19 +59,20 @@ TEST_P(DispatcherPluginsTestParametrized, ShouldLoadFromGoodPluginsCfgCorrectly)
         // and the parsed plugin list is stored as a global variable in the
         // dispatcher lib. Therefore, the calls below will only be executed once.
         std::string path = std::string(MFX_PLUGINS_CONF_DIR) + "/plugins.cfg";
-        EXPECT_CALL(mock, fopen(StrEq(path.c_str()),_)).WillRepeatedly(Return(MOCK_FILE_DESCRIPTOR));
-        EXPECT_CALL(mock, fgets(_,_,MOCK_FILE_DESCRIPTOR)).WillRepeatedly(Invoke(&mock, &MockCallObj::FeedEmulatedPluginsCfgLines));
-        EXPECT_CALL(mock, fclose);
+        EXPECT_CALL(mock, fopen(StrEq(path.c_str()),_)).Times(AtLeast(1)).WillRepeatedly(Return(MOCK_FILE_DESCRIPTOR));
+        EXPECT_CALL(mock, fgets(_,_,MOCK_FILE_DESCRIPTOR)).Times(AtLeast(1)).WillRepeatedly(Invoke(&mock, &MockCallObj::FeedEmulatedPluginsCfgLines));
+        EXPECT_CALL(mock, fclose).Times(AtLeast(1)).WillRepeatedly(Return(MFX_ERR_NONE));
         successfully_parsed_at_least_once = true;
     }
 
-    EXPECT_CALL(mock, dlopen(StrEq(plugin.Path.c_str()),_));
-    EXPECT_CALL(mock, dlsym(_,StrEq("CreatePlugin"))).WillRepeatedly(Return(reinterpret_cast<void*>(CreatePluginWrap)));
-    EXPECT_CALL(mock, CreatePlugin(plugin.PluginUID,_)).WillRepeatedly(Invoke(&mock, &MockCallObj::ReturnMockPlugin));
-    EXPECT_CALL(mock, GetPluginParam(&mock.m_mock_plugin,_)).WillRepeatedly(Return(MFX_ERR_NONE));
-    EXPECT_CALL(mock, MFXVideoUSER_Register(session,plugin.Type, &mock.m_mock_plugin)).WillRepeatedly(Return(MFX_ERR_NONE));
+    EXPECT_CALL(mock, dlopen(StrEq(plugin.Path.c_str()),_)).Times(AtLeast(1)).WillRepeatedly(Return(MOCK_DLOPEN_HANDLE));
+    EXPECT_CALL(mock, dlsym(_,StrEq("CreatePlugin"))).Times(AtLeast(1)).WillRepeatedly(Return(reinterpret_cast<void*>(CreatePluginWrap)));
+    EXPECT_CALL(mock, CreatePlugin(plugin.PluginUID,_)).Times(AtLeast(1)).WillRepeatedly(Invoke(&mock, &MockCallObj::ReturnMockPlugin));
+    EXPECT_CALL(mock, GetPluginParam(mock.m_mock_plugin.pthis,_)).Times(AtLeast(1)).WillRepeatedly(DoAll(SetArgPointee<1>(plugin), Return(MFX_ERR_NONE)));
+    EXPECT_CALL(mock, MFXVideoUSER_Register(MOCK_SESSION_HANDLE,plugin.Type,_)).Times(AtLeast(1)).WillRepeatedly(Return(MFX_ERR_NONE));
 
     mfxStatus sts = MFXVideoUSER_Load(session, &plugin.PluginUID, 0);
+    ASSERT_EQ(sts, MFX_ERR_NONE);
 }
 
 INSTANTIATE_TEST_CASE_P(EnumeratingPlugins, DispatcherPluginsTestParametrized, ::testing::Range((size_t) 0, TEST_PLUGIN_COUNT));

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.cpp
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.cpp
@@ -78,6 +78,7 @@ void* MockCallObj::EmulateAPI(void *handle, const char *symbol)
     std::string mfxqueryversion_symbol("MFXQueryVersion");
     std::string mfxclose_symbol("MFXClose");
     std::string createplugin_symbol("CreatePlugin");
+    std::string mfxvideoregister_symbol("MFXVideoUSER_Register");
 
     for (int i = 0; i < eFunctionsNum; ++i)
     {
@@ -104,6 +105,10 @@ void* MockCallObj::EmulateAPI(void *handle, const char *symbol)
             else if (symbol == createplugin_symbol)
             {
                 return reinterpret_cast<void*>(CreatePluginWrap);
+            }
+            else if (symbol == mfxvideoregister_symbol)
+            {
+                return reinterpret_cast<void*>(MFXVideoUSER_RegisterWrap);
             }
             else
             {

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.h
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.h
@@ -105,7 +105,7 @@ public:
     char* FeedEmulatedPluginsCfgLines(char * str, int num, FILE * stream);
     mfxStatus ReturnMockPlugin(mfxPluginUID uid, mfxPlugin* pPlugin)
     {
-        pPlugin = &m_mock_plugin;
+        *pPlugin = m_mock_plugin;
         return MFX_ERR_NONE;
     }
     mfxPlugin m_mock_plugin;


### PR DESCRIPTION
Added return status check in and check the number of function calls in test of loading plugin. Befor the changes in ShouldLoadFromGoodPluginsCfgCorrectly case only one function (dlopen) was called and returned error. The case was considered successful, but it is wrong. Also corrected some parameters in other cases.