### PR TITLE
CORE: Release Scheduler before Core

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_session.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_session.cpp
@@ -612,10 +612,14 @@ void _mfxSession::Cleanup(void)
     m_pVPP.reset();
     m_pDECODE.reset();
     m_pENCODE.reset();
-    m_pCORE.reset();
 
     // release m_pScheduler and m_pSchedulerAllocated
     ReleaseScheduler();
+
+    // release core
+    // should be released at the end, becaude m_pCORE may be used during destroy of
+    // components and scheduler
+    m_pCORE.reset();
 
     //delete m_coreInt.ExternalSurfaceAllocator;
     Clear();


### PR DESCRIPTION
-Fix possible issue: during destroy instance of scheduler may be used m_pCore,
 so need release m_pCore only after scheduler