### PR TITLE
[dispatcher_test] Strengthening of plugin test requirements

### DIFF
--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_main.cpp
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_main.cpp
@@ -89,6 +89,10 @@ extern "C"
     {
         return g_call_obj_ptr->MFXVideoUSER_Register(session, type, par);
     }
+    mfxStatus MFXVideoUSER_UnregisterWrap(mfxSession session, mfxU32 type)
+    {
+        return g_call_obj_ptr->MFXVideoUSER_Unregister(session, type);
+    }
 
 } // extern "C"
 

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_main.h
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_main.h
@@ -55,6 +55,7 @@ extern "C"
     mfxStatus CreatePluginWrap(mfxPluginUID uid, mfxPlugin* pPlugin);
     mfxStatus GetPluginParamWrap(mfxHDL pthis, mfxPluginParam *par);
     mfxStatus MFXVideoUSER_RegisterWrap(mfxSession session, mfxU32 type, const mfxPlugin *par);
+    mfxStatus MFXVideoUSER_UnregisterWrap(mfxSession session, mfxU32 type);
 }
 
 

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.cpp
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.cpp
@@ -78,6 +78,8 @@ void* MockCallObj::EmulateAPI(void *handle, const char *symbol)
     std::string mfxqueryversion_symbol("MFXQueryVersion");
     std::string mfxclose_symbol("MFXClose");
     std::string createplugin_symbol("CreatePlugin");
+    std::string mfxvideoregister_symbol("MFXVideoUSER_Register");
+    std::string mfxvideounregister_symbol("MFXVideoUSER_Unregister");
 
     for (int i = 0; i < eFunctionsNum; ++i)
     {
@@ -104,6 +106,14 @@ void* MockCallObj::EmulateAPI(void *handle, const char *symbol)
             else if (symbol == createplugin_symbol)
             {
                 return reinterpret_cast<void*>(CreatePluginWrap);
+            }
+            else if (symbol == mfxvideoregister_symbol)
+            {
+                return reinterpret_cast<void*>(MFXVideoUSER_RegisterWrap);
+            }
+            else if (symbol == mfxvideounregister_symbol)
+            {
+                return reinterpret_cast<void*>(MFXVideoUSER_UnregisterWrap);
             }
             else
             {

--- a/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.h
+++ b/tests/mfx_dispatch/linux/mfx_dispatch_test_mocks.h
@@ -57,6 +57,7 @@ public:
     virtual mfxStatus CreatePlugin(mfxPluginUID uid, mfxPlugin* pPlugin) = 0;
     virtual mfxStatus GetPluginParam(mfxHDL pthis, mfxPluginParam *par) = 0;
     virtual mfxStatus MFXVideoUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par) = 0;
+    virtual mfxStatus MFXVideoUSER_Unregister(mfxSession session, mfxU32 type) = 0;
 };
 
 class MockCallObj : public CallObj
@@ -70,6 +71,7 @@ public:
         ON_CALL(*this, CreatePlugin(_,_)).WillByDefault(Return(MFX_ERR_UNSUPPORTED));
         ON_CALL(*this, GetPluginParam(_,_)).WillByDefault(Return(MFX_ERR_UNSUPPORTED));
         ON_CALL(*this, MFXVideoUSER_Register(_,_,_)).WillByDefault(Return(MFX_ERR_UNSUPPORTED));
+        ON_CALL(*this, MFXVideoUSER_Unregister(_,_)).WillByDefault(Return(MFX_ERR_UNSUPPORTED));
 
         m_mock_plugin.GetPluginParam = GetPluginParamWrap;
     }
@@ -86,6 +88,7 @@ public:
     MOCK_METHOD2(CreatePlugin, mfxStatus(mfxPluginUID, mfxPlugin*));
     MOCK_METHOD2(GetPluginParam, mfxStatus (mfxHDL, mfxPluginParam*));
     MOCK_METHOD3(MFXVideoUSER_Register, mfxStatus (mfxSession, mfxU32, const mfxPlugin *));
+    MOCK_METHOD2(MFXVideoUSER_Unregister, mfxStatus(mfxSession, mfxU32));
 
     mfxVersion emulated_api_version = {{0, 0}};
 
@@ -105,7 +108,9 @@ public:
     char* FeedEmulatedPluginsCfgLines(char * str, int num, FILE * stream);
     mfxStatus ReturnMockPlugin(mfxPluginUID uid, mfxPlugin* pPlugin)
     {
-        pPlugin = &m_mock_plugin;
+        if (pPlugin == nullptr)
+            return MFX_ERR_UNSUPPORTED;
+        *pPlugin = m_mock_plugin;
         return MFX_ERR_NONE;
     }
     mfxPlugin m_mock_plugin;


### PR DESCRIPTION
Added return status check and check the number of function calls in test of loading plugin. Before the changes in ShouldLoadFromGoodPluginsCfgCorrectly case only one function (dlopen) was called and returned error. The case was considered successful, but it is wrong.