### PR TITLE
[VP9e] Added dynamic scaling flag

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
@@ -471,6 +471,14 @@ mfxStatus MFXVideoENCODEVP9_HW::Reset(mfxVideoParam *par)
         {
             return MFX_ERR_INVALID_VIDEO_PARAM;
         }
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        if ((extParAfter.FrameWidth != extParBefore.FrameWidth ||
+            extParAfter.FrameHeight != extParBefore.FrameHeight) &&
+            extParAfter.DynamicScaling != MFX_CODINGOPTION_ON)
+        {
+            return MFX_ERR_INVALID_VIDEO_PARAM;
+        }
+#endif
     }
 
     sts = m_ddi->Reset(m_video);

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -190,6 +190,7 @@ inline void SetOrCopy(mfxExtVP9Param *pDst, mfxExtVP9Param const *pSrc = 0, bool
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
     SET_OR_COPY_PAR(NumTileRows);
     SET_OR_COPY_PAR(NumTileColumns);
+    SET_OR_COPY_PAR(DynamicScaling);
 #endif
 }
 
@@ -1530,6 +1531,22 @@ mfxStatus CheckParameters(VP9MfxVideoParam &par, ENCODE_CAPS_VP9 const &caps)
         rows = 0;
         unsupported = true;
     }
+
+    if (false == CheckTriStateOption(extPar.DynamicScaling))
+    {
+        changed = true;
+    }
+    if (!caps.DynamicScaling && extPar.DynamicScaling == MFX_CODINGOPTION_ON)
+    {
+        extPar.DynamicScaling = MFX_CODINGOPTION_OFF;
+        unsupported = true;
+    }
+    //known limitation: these 2 features don't work together
+    if (extPar.DynamicScaling && par.m_numLayers > 0)
+    {
+        extPar.DynamicScaling = MFX_CODINGOPTION_OFF;
+        unsupported = true;
+    }
 #endif // MFX_VERSION >= MFX_VERSION_NEXT
 
     return GetCheckStatus(changed, unsupported);
@@ -1726,6 +1743,7 @@ mfxStatus SetDefaults(
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
     SetDefault(extPar.NumTileColumns, (extPar.FrameWidth + MAX_TILE_WIDTH - 1) / MAX_TILE_WIDTH);
     SetDefault(extPar.NumTileRows, 1);
+    SetDefault(extPar.DynamicScaling, MFX_CODINGOPTION_OFF);
 #endif // (MFX_VERSION >= MFX_VERSION_NEXT)
 
     // ext buffers

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -728,6 +728,7 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     {
         m_caps.DynamicScaling = attrs[idx_map[VAConfigAttribEncDynamicScaling]].value;
     }
+    m_caps.DynamicScaling = 1; // TODO: remove hardcode when driver will report correct caps
 
     if (attrs[idx_map[VAConfigAttribFrameSizeToleranceSupport]].value != VA_ATTRIB_NOT_SUPPORTED)
         m_caps.UserMaxFrameSizeSupport  = attrs[idx_map[VAConfigAttribFrameSizeToleranceSupport]].value;

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -413,6 +413,13 @@ mfxStatus SetRateControl(
             rate_param->rc_flags.bits.temporal_id = tl;
         }
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        mfxExtVP9Param vp9param = GetExtBufferRef(par);
+        rate_param->rc_flags.bits.enable_dynamic_scaling = vp9param.DynamicScaling == MFX_CODINGOPTION_ON ? 1 : 0;
+#else
+        rate_param->rc_flags.bits.enable_dynamic_scaling = 1;
+#endif
+
         vaSts = vaUnmapBuffer(m_vaDisplay, rateParamBuf_ids[tl]);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
     }

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -2034,7 +2034,8 @@ typedef struct {
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
     mfxU16  NumTileRows;
     mfxU16  NumTileColumns;
-    mfxU16  reserved[110];
+    mfxU16  DynamicScaling;
+    mfxU16  reserved[109];
 #else // API 1.26
     mfxU16  reserved[112];
 #endif

--- a/api/mediasdk_structures/ts_struct_decl.h
+++ b/api/mediasdk_structures/ts_struct_decl.h
@@ -1266,6 +1266,7 @@ STRUCT(mfxExtVP9Param,
     FIELD_T(mfxI16      , QIndexDeltaChromaDC)
     FIELD_T(mfxU16      , NumTileRows)
     FIELD_T(mfxU16      , NumTileColumns)
+    FIELD_T(mfxU16      , DynamicScaling)
 )
 #elif (MFX_VERSION >= 1026)
 STRUCT(mfxExtVP9Param,


### PR DESCRIPTION
For now dynamic scaling is always ON so it leads to additional allocation on driver side to support such scenario. Was added key app should set if dynamic scaling feature is needed.