### PR TITLE
scheduler: implement GetThreadNum in components

### DIFF
--- a/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
+++ b/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
@@ -65,6 +65,7 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
     virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);

--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -644,6 +644,13 @@ mfxTaskThreadingPolicy VideoDECODEH264::GetThreadingPolicy(void)
     return MFX_TASK_THREADING_SHARED;
 }
 
+mfxStatus VideoDECODEH264::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_isInit, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_vPar.mfx.NumThread;
+    return MFX_ERR_NONE;
+}
+
 mfxStatus VideoDECODEH264::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *out)
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_API, "VideoDECODEH264::Query");

--- a/_studio/mfx_lib/decode/h265/include/mfx_h265_dec_decode.h
+++ b/_studio/mfx_lib/decode/h265/include/mfx_h265_dec_decode.h
@@ -77,6 +77,7 @@ public:
     virtual mfxStatus Close(void);
     // Returns decoder threading mode
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
     // MediaSDK DECODE_GetVideoParam API function
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);

--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -469,6 +469,13 @@ mfxTaskThreadingPolicy VideoDECODEH265::GetThreadingPolicy(void)
     return MFX_TASK_THREADING_SHARED;
 }
 
+mfxStatus VideoDECODEH265::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_isInit, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_vPar.mfx.NumThread;
+    return MFX_ERR_NONE;
+}
+
 // MediaSDK DECODE_Query API function
 mfxStatus VideoDECODEH265::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *out)
 {

--- a/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
+++ b/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
@@ -146,6 +146,7 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
     virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);

--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -341,6 +341,13 @@ mfxTaskThreadingPolicy VideoDECODEMJPEG::GetThreadingPolicy(void)
     return MFX_TASK_THREADING_INTER;
 }
 
+mfxStatus VideoDECODEMJPEG::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_isInit, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_vPar.mfx.NumThread;
+    return MFX_ERR_NONE;
+}
+
 mfxStatus VideoDECODEMJPEG::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *out)
 {
     MFX_CHECK_NULL_PTR1(out);

--- a/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
+++ b/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
@@ -319,6 +319,12 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close();
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) { return MFX_TASK_THREADING_INTRA; }
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        MFX_CHECK(m_isInitialized, MFX_ERR_NOT_INITIALIZED);
+        threadNum = internalImpl->m_vdPar.numThreads;
+        return MFX_ERR_NONE;
+    }
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
 

--- a/_studio/mfx_lib/decode/vc1/include/mfx_vc1_decode.h
+++ b/_studio/mfx_lib/decode/vc1/include/mfx_vc1_decode.h
@@ -74,6 +74,7 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
 

--- a/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
+++ b/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
@@ -531,6 +531,13 @@ mfxTaskThreadingPolicy MFXVideoDECODEVC1::GetThreadingPolicy(void)
     }
 }
 
+mfxStatus MFXVideoDECODEVC1::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_bIsDecInit, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_par.mfx.NumThread;
+    return MFX_ERR_NONE;
+}
+
 mfxStatus MFXVideoDECODEVC1::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *out)
 {
     mfxStatus       MFXSts = MFX_ERR_NONE;

--- a/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
@@ -181,6 +181,7 @@ public:
     virtual mfxStatus Close();
 
     virtual mfxTaskThreadingPolicy GetThreadingPolicy();
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
     virtual mfxStatus GetVideoParam(mfxVideoParam *pPar);
     virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat);
 
@@ -231,6 +232,7 @@ private:
         UMC::FrameMemID memId;
     };
 
+    const mfxU32            m_thread_num = 1;
     bool                    m_is_initialized;
     bool                    m_is_opaque_memory;
     VideoCORE*              m_p_core;

--- a/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
@@ -818,7 +818,7 @@ mfxStatus VideoDECODEVP8_HW::DecodeFrameCheck(mfxBitstream *p_bs, mfxFrameSurfac
     routineData->surface_work = p_surface_work;
 
     p_entry_point->pState = routineData;
-    p_entry_point->requiredNumThreads = 1;
+    p_entry_point->requiredNumThreads = m_thread_num;
 
     return show_frame ? MFX_ERR_NONE : MFX_ERR_MORE_DATA;
 
@@ -1301,6 +1301,13 @@ mfxStatus VideoDECODEVP8_HW::GetFrame(MediaData* /*in*/, FrameData** /*out*/)
 mfxTaskThreadingPolicy VideoDECODEVP8_HW::GetThreadingPolicy()
 {
     return MFX_TASK_THREADING_INTRA;
+}
+
+mfxStatus VideoDECODEVP8_HW::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_is_initialized, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_thread_num;
+    return MFX_ERR_NONE;
 }
 
 mfxStatus VideoDECODEVP8_HW::GetVideoParam(mfxVideoParam *pPar)

--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
@@ -54,6 +54,7 @@ public:
     virtual mfxStatus Close();
 
     virtual mfxTaskThreadingPolicy GetThreadingPolicy();
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
     virtual mfxStatus GetVideoParam(mfxVideoParam *pPar);
     virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat);
 
@@ -80,6 +81,7 @@ protected:
     mfxStatus GetOutputSurface(mfxFrameSurface1 **, mfxFrameSurface1 *, UMC::FrameMemID);
 
 private:
+    const mfxU32            m_thread_num = 1;
     bool                    m_isInit;
     bool                    m_is_opaque_memory;
     VideoCORE*              m_core;

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -451,6 +451,13 @@ mfxTaskThreadingPolicy VideoDECODEVP9_HW::GetThreadingPolicy()
     return MFX_TASK_THREADING_SHARED;
 }
 
+mfxStatus VideoDECODEVP9_HW::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_isInit, MFX_ERR_NOT_INITIALIZED);
+    threadNum = m_thread_num;
+    return MFX_ERR_NONE;
+}
+
 mfxStatus VideoDECODEVP9_HW::Query(VideoCORE *p_core, mfxVideoParam *p_in, mfxVideoParam *p_out)
 {
     MFX_CHECK_NULL_PTR1(p_out);
@@ -888,7 +895,7 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1
     routineData->showFrame = m_frameInfo.showFrame;
 
     p_entry_point->pState = routineData;
-    p_entry_point->requiredNumThreads = 1;
+    p_entry_point->requiredNumThreads = m_thread_num;
 
     if (m_frameInfo.showFrame)
     {

--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw.h
@@ -55,6 +55,13 @@ public:
         return MFX_TASK_THREADING_INTRA;
     }
 
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        return m_impl.get()
+            ? m_impl->GetThreadNum(threadNum)
+            : MFX_ERR_NOT_INITIALIZED;
+    }
+
     virtual mfxStatus Reset(mfxVideoParam *par)
     {
         return m_impl.get()

--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -1886,6 +1886,12 @@ namespace MfxHwH264Encode
 
         virtual mfxStatus Reset(mfxVideoParam * par);
 
+        virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+        {
+            threadNum = m_thread_num;
+            return MFX_ERR_NONE;
+        }
+
         virtual mfxStatus GetVideoParam(mfxVideoParam * par);
 
         virtual mfxStatus GetFrameParam(mfxFrameParam * par);
@@ -2029,6 +2035,7 @@ namespace MfxHwH264Encode
 
         void DestroyDanglingCmResources();
 
+        static const mfxU32 m_thread_num = 1;
         VideoCORE *         m_core;
         CmDevicePtr         m_cmDevice;
         MfxVideoParam       m_video;

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -284,7 +284,7 @@ mfxStatus ImplementationAvc::Query(
         out->mfx.MaxKbps           = 1;
         out->mfx.NumSlice          = 1;
         out->mfx.NumRefFrame       = 1;
-        out->mfx.NumThread         = 1;
+        out->mfx.NumThread         = m_thread_num;
         out->mfx.EncodedOrder      = 1;
 
         out->mfx.FrameInfo.FourCC        = 1;
@@ -3144,7 +3144,7 @@ mfxStatus ImplementationAvc::EncodeFrameCheck(
             entryPoints[0].pCompleteProc        = 0;
             entryPoints[0].pGetSubTaskProc      = 0;
             entryPoints[0].pCompleteSubTaskProc = 0;
-            entryPoints[0].requiredNumThreads   = 1;
+            entryPoints[0].requiredNumThreads   = m_thread_num;
             entryPoints[0].pRoutineName         = "AsyncRoutine";
             entryPoints[0].pRoutine             = AsyncRoutineHelper;
             numEntryPoints = 1;
@@ -3186,7 +3186,7 @@ mfxStatus ImplementationAvc::EncodeFrameCheckNormalWay(
         entryPoints[0].pCompleteProc        = 0;
         entryPoints[0].pGetSubTaskProc      = 0;
         entryPoints[0].pCompleteSubTaskProc = 0;
-        entryPoints[0].requiredNumThreads   = 1;
+        entryPoints[0].requiredNumThreads   = m_thread_num;
         entryPoints[0].pRoutineName         = "AsyncRoutine";
         entryPoints[0].pRoutine             = AsyncRoutineHelper;
         numEntryPoints = 1;
@@ -3268,7 +3268,7 @@ mfxStatus ImplementationAvc::EncodeFrameCheckNormalWay(
     entryPoints[0].pCompleteProc        = 0;
     entryPoints[0].pGetSubTaskProc      = 0;
     entryPoints[0].pCompleteSubTaskProc = 0;
-    entryPoints[0].requiredNumThreads   = 1;
+    entryPoints[0].requiredNumThreads   = m_thread_num;
     entryPoints[0].pRoutineName         = "AsyncRoutine";
     entryPoints[0].pRoutine             = AsyncRoutineHelper;
     numEntryPoints = 1;

--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
@@ -58,6 +58,13 @@ public:
         Close();
     }
 
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        MFX_CHECK(m_bInit, MFX_ERR_NOT_INITIALIZED);
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
+
     static mfxStatus QueryIOSurf(VideoCORE *core, mfxVideoParam *par, mfxFrameAllocRequest *request);
 
     static mfxStatus Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *out);
@@ -95,7 +102,7 @@ public:
             pEntryPoint->pState             = this;
             pEntryPoint->pRoutine           = Execute;
             pEntryPoint->pCompleteProc      = FreeResources;
-            pEntryPoint->requiredNumThreads = 1;
+            pEntryPoint->requiredNumThreads = m_thread_num;
             pEntryPoint->pParam             = userParam;
         }
 
@@ -177,6 +184,7 @@ protected:
     mfxStatus FreeTask(Task& task);
     mfxStatus WaitForQueringTask(Task& task);
 
+    static const mfxU32             m_thread_num = 1;
     std::unique_ptr<DriverEncoder>  m_ddi;
     VideoCORE                      *m_core;
     MfxVideoParam                   m_vpar;

--- a/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_hw.h
@@ -70,6 +70,13 @@ public:
     virtual mfxStatus GetFrameParam(mfxFrameParam *par);
     virtual mfxStatus GetEncodeStat(mfxEncodeStat *stat);
 
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        MFX_CHECK(m_bInitialized, MFX_ERR_NOT_INITIALIZED);
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
+
     virtual
     mfxStatus EncodeFrameCheck(mfxEncodeCtrl *ctrl,
                                mfxFrameSurface1 *surface,
@@ -124,6 +131,8 @@ protected:
     mfxStatus CheckEncodeFrameParam(mfxFrameSurface1    * surface,
                                     mfxBitstream        * bs,
                                     bool                  isExternalFrameAllocator);
+
+    static const mfxU32 m_thread_num = 1;
 
     // pointer to video core - class for memory/frames management and allocation
     VideoCORE*          m_pCore;

--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
@@ -207,7 +207,7 @@ mfxStatus MFXVideoENCODEMJPEG_HW::Query(VideoCORE * core, mfxVideoParam *in, mfx
         out->mfx.CodecId                 = MFX_CODEC_JPEG;
         out->mfx.CodecLevel              = 0;
         out->mfx.CodecProfile            = MFX_PROFILE_JPEG_BASELINE;
-        out->mfx.NumThread               = 1;
+        out->mfx.NumThread               = m_thread_num;
         out->mfx.Interleaved             = MFX_SCANTYPE_INTERLEAVED;
         out->mfx.Quality                 = 1;
         out->mfx.RestartInterval         = 0;
@@ -987,7 +987,7 @@ mfxStatus MFXVideoENCODEMJPEG_HW::EncodeFrameCheck(
     pEntryPoints[0].pGetSubTaskProc      = 0;
     pEntryPoints[0].pCompleteSubTaskProc = 0;
 
-    pEntryPoints[0].requiredNumThreads   = 1;
+    pEntryPoints[0].requiredNumThreads   = m_thread_num;
     pEntryPoints[1] = pEntryPoints[0];
     pEntryPoints[0].pRoutineName = (char *)"Encode Submit";
     pEntryPoints[1].pRoutineName = (char *)"Encode Query";

--- a/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_full_hw.h
+++ b/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_full_hw.h
@@ -362,7 +362,12 @@ public:
         virtual
         mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_INTRA;}
      
-
+        virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+        {
+            MFX_CHECK(is_initialized(), MFX_ERR_NOT_INITIALIZED);
+            threadNum = m_thread_num;
+            return MFX_ERR_NONE;
+        }
 
     protected:
         inline bool is_initialized() {return m_pController!=0;}
@@ -392,6 +397,7 @@ public:
 
 
     private:
+        static const mfxU32              m_thread_num = 1;
         UMC::Mutex                       m_guard;
 
         VideoCORE *                      m_pCore;

--- a/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_hw.h
@@ -176,8 +176,11 @@ public:
         }
         return pEncoder->GetThreadingPolicy();
     }
-protected:
-
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        MFX_CHECK(pEncoder, MFX_ERR_NOT_INITIALIZED);
+        return pEncoder->GetThreadNum(threadNum);
+    }
 
 private:
     VideoCORE*                      m_pCore;

--- a/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_utils_hw.h
+++ b/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_utils_hw.h
@@ -92,7 +92,8 @@ namespace MPEG2EncoderHW
             mfxStatus CancelFrame(mfxEncodeCtrl *ctrl, mfxEncodeInternalParams *pInternalParams, mfxFrameSurface1 *surface, mfxBitstream *bs) = 0;
         virtual
             mfxTaskThreadingPolicy GetThreadingPolicy(void) = 0;
-
+        virtual
+            mfxStatus GetThreadNum(mfxU32& threadNum) = 0;
     };
     class FramesSet
     {

--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw.h
@@ -78,6 +78,12 @@ public:
     virtual mfxStatus Close();
 
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) { return MFX_TASK_THREADING_INTRA; }
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        MFX_CHECK(m_initialized, MFX_ERR_NOT_INITIALIZED);
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
 
     virtual mfxStatus GetVideoParam(mfxVideoParam *par);
 
@@ -106,7 +112,7 @@ public:
             pEntryPoint->pState = this;
             pEntryPoint->pRoutine = Execute;
             pEntryPoint->pCompleteProc = FreeResources;
-            pEntryPoint->requiredNumThreads = 1;
+            pEntryPoint->requiredNumThreads = m_thread_num;
             pEntryPoint->pParam = userParam;
         }
 
@@ -154,6 +160,7 @@ public:
     }
 
 protected:
+    static const mfxU32           m_thread_num = 1;
     VP9MfxVideoParam              m_video;
     std::list<VP9MfxVideoParam>   m_videoForParamChange; // encoder keeps several versions of encoding parameters
                                                          // to allow dynamic parameter change w/o drain of all buffered tasks.

--- a/_studio/mfx_lib/fei/h264_enc/mfx_h264_enc.cpp
+++ b/_studio/mfx_lib/fei/h264_enc/mfx_h264_enc.cpp
@@ -632,7 +632,7 @@ mfxStatus VideoENC_ENC::RunFrameVmeENCCheck(
     pEntryPoints[0].pCompleteProc        = 0;
     pEntryPoints[0].pGetSubTaskProc      = 0;
     pEntryPoints[0].pCompleteSubTaskProc = 0;
-    pEntryPoints[0].requiredNumThreads   = 1;
+    pEntryPoints[0].requiredNumThreads   = m_thread_num;
     pEntryPoints[0].pRoutineName         = "AsyncRoutine";
     pEntryPoints[0].pRoutine             = AsyncRoutine;
     pEntryPoints[1] = pEntryPoints[0];

--- a/_studio/mfx_lib/fei/h264_enc/mfx_h264_enc.h
+++ b/_studio/mfx_lib/fei/h264_enc/mfx_h264_enc.h
@@ -41,6 +41,11 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_INTRA;}
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
 
     mfxStatus Submit(mfxEncodeInternalParams * iParams);
 
@@ -64,7 +69,7 @@ protected:
                                            mfxVideoParam const * newParIn = 0);
 
 private:
-
+    static const mfxU32                           m_thread_num = 1;
     bool                                          m_bInit;
     VideoCORE*                                    m_core;
 

--- a/_studio/mfx_lib/fei/h264_la/mfx_h264_la.cpp
+++ b/_studio/mfx_lib/fei/h264_la/mfx_h264_la.cpp
@@ -937,13 +937,13 @@ mfxStatus VideoENC_LA::RunFrameVmeENCCheck(
         /*pEntryPoints[0].pRoutine = &SubmitFrameLARoutine;
         pEntryPoints[0].pCompleteProc =0;
         pEntryPoints[0].pState = this;
-        pEntryPoints[0].requiredNumThreads = 1;
+        pEntryPoints[0].requiredNumThreads = m_thread_num;
         pEntryPoints[0].pParam = pAsyncParams;
 
         pEntryPoints[1].pRoutine = &QueryFrameLARoutine;
         pEntryPoints[1].pCompleteProc = &CompleteFrameLARoutine;
         pEntryPoints[1].pState = this;
-        pEntryPoints[1].requiredNumThreads = 1;
+        pEntryPoints[1].requiredNumThreads = m_thread_num;
         pEntryPoints[1].pParam = pAsyncParams;
 
         numEntryPoints = 2;*/
@@ -953,7 +953,7 @@ mfxStatus VideoENC_LA::RunFrameVmeENCCheck(
         pEntryPoints[0].pRoutine = &RunFrameVPPRoutine;
         pEntryPoints[0].pCompleteProc = &CompleteFrameLARoutine;
         pEntryPoints[0].pState = this;
-        pEntryPoints[0].requiredNumThreads = 1;
+        pEntryPoints[0].requiredNumThreads = m_thread_num;
         pEntryPoints[0].pParam = pAsyncParams;
 
         numEntryPoints = 1;

--- a/_studio/mfx_lib/fei/h264_la/mfx_h264_la.h
+++ b/_studio/mfx_lib/fei/h264_la/mfx_h264_la.h
@@ -228,6 +228,11 @@ public:
     mfxStatus Close(void);
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_INTRA;}
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
 
     static 
     mfxStatus Query(VideoCORE*, mfxVideoParam *in, mfxVideoParam *out);
@@ -276,7 +281,7 @@ protected:
     
 
 private:
-
+    static const mfxU32     m_thread_num = 1;
     bool                    m_bInit;
     VideoCORE*              m_core;
     mfxExtLAControl         m_LaControl;

--- a/_studio/mfx_lib/fei/h264_pak/mfx_h264_fei_pak.cpp
+++ b/_studio/mfx_lib/fei/h264_pak/mfx_h264_fei_pak.cpp
@@ -860,7 +860,7 @@ mfxStatus VideoPAK_PAK::RunFramePAKCheck(
     pEntryPoints[0].pCompleteProc        = 0;
     pEntryPoints[0].pGetSubTaskProc      = 0;
     pEntryPoints[0].pCompleteSubTaskProc = 0;
-    pEntryPoints[0].requiredNumThreads   = 1;
+    pEntryPoints[0].requiredNumThreads   = m_thread_num;
     pEntryPoints[0].pRoutineName         = "AsyncRoutine";
     pEntryPoints[0].pRoutine             = AsyncRoutine;
     pEntryPoints[1] = pEntryPoints[0];

--- a/_studio/mfx_lib/fei/h264_pak/mfx_h264_fei_pak.h
+++ b/_studio/mfx_lib/fei/h264_pak/mfx_h264_fei_pak.h
@@ -41,6 +41,11 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) { return MFX_TASK_THREADING_INTRA; }
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
 
     mfxStatus Submit(mfxEncodeInternalParams * iParams);
 
@@ -86,7 +91,7 @@ private:
                                 mfxU16 numPayload);
 
 private:
-
+    static const mfxU32                           m_thread_num = 1;
     bool                                          m_bInit;
     VideoCORE*                                    m_core;
 

--- a/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.cpp
+++ b/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.cpp
@@ -654,7 +654,7 @@ mfxStatus VideoENC_PREENC::Query(VideoCORE* core, mfxVideoParam *in, mfxVideoPar
         out->IOPattern                   = MFX_IOPATTERN_IN_VIDEO_MEMORY;
         out->AsyncDepth                  = 1;
         out->mfx.NumRefFrame             = 1;
-        out->mfx.NumThread               = 1;
+        out->mfx.NumThread               = m_thread_num;
         out->mfx.EncodedOrder            = 1;
         out->mfx.FrameInfo.FourCC        = 1;
         out->mfx.FrameInfo.Width         = 1;
@@ -1025,7 +1025,7 @@ mfxStatus VideoENC_PREENC::RunFrameVmeENCCheck(
     pEntryPoints[0].pCompleteProc        = 0;
     pEntryPoints[0].pGetSubTaskProc      = 0;
     pEntryPoints[0].pCompleteSubTaskProc = 0;
-    pEntryPoints[0].requiredNumThreads   = 1;
+    pEntryPoints[0].requiredNumThreads   = m_thread_num;
     pEntryPoints[0].pRoutineName         = "AsyncRoutine";
     pEntryPoints[0].pRoutine             = AsyncRoutine;
     pEntryPoints[1] = pEntryPoints[0];

--- a/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.h
+++ b/_studio/mfx_lib/fei/h264_preenc/mfx_h264_preenc.h
@@ -48,6 +48,11 @@ public:
     virtual mfxStatus Reset(mfxVideoParam *par);
     virtual mfxStatus Close(void);
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_INTRA;}
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum)
+    {
+        threadNum = m_thread_num;
+        return MFX_ERR_NONE;
+    }
 
     mfxStatus Submit(mfxEncodeInternalParams * iParams);
 
@@ -66,7 +71,7 @@ public:
     virtual mfxStatus RunFrameVmeENC(mfxENCInput *in, mfxENCOutput *out);
 
 private:
-
+    static const mfxU32                           m_thread_num = 1;
     bool                                          m_bInit;
     VideoCORE*                                    m_core;
 

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -22,6 +22,7 @@
 #define __MFX_SCHEDULER_CORE_H
 
 #include <list>
+#include <map>
 
 #include <mfx_interface_scheduler.h>
 
@@ -124,7 +125,7 @@ enum eWakeUpReason
 };
 
 
-class mfxSchedulerCore : public MFXIScheduler2
+class mfxSchedulerCore : public MFXIScheduler3
 {
 public:
     // Default constructor
@@ -181,6 +182,9 @@ public:
     virtual
     mfxStatus AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoint,
                       const char *pFileName, int lineNumber);
+
+    virtual
+    mfxStatus SetThreadNum(const void *pComponent, mfxU32 threadNum);
 
     //
     // MFXIUnknown interface
@@ -341,6 +345,10 @@ protected:
     
     // Threads contexts
     std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> m_pThreads;
+    // Number of threads required for each component to be functional
+    std::map<const void*, mfxU32> m_pThreadsMap;
+    // Mutex to guard threads add/remove operations
+    std::mutex m_pThreadsMapMutex;
 
     // Event to wait free task objects
     UMC::Semaphore m_freeTasks;

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -21,6 +21,8 @@
 #if !defined(__MFX_SCHEDULER_CORE_H)
 #define __MFX_SCHEDULER_CORE_H
 
+#include <list>
+
 #include <mfx_interface_scheduler.h>
 
 #include <mfx_scheduler_core_thread.h>
@@ -222,9 +224,6 @@ protected:
     // Release the object
     void Close(void);
 
-    // Wait until the scheduler got more work
-    void Wait(const mfxU32 curThreadNum, std::unique_lock<std::mutex>& mutex);
-
     // Get high performance counter value. This counter is used to calculate
     // tasks duration and priority management.
     mfxU64 GetHighPerformanceCounter(void);
@@ -308,10 +307,6 @@ protected:
     // Assign socket affinity for every thread
     void SetThreadsAffinityToSockets(void);
 
-    inline MFX_SCHEDULER_THREAD_CONTEXT* GetThreadCtx(mfxU32 thread_id)
-    { return &m_pThreadCtx[thread_id]; }
-
-
     // Scheduler's initialization parameters
     MFX_SCHEDULER_PARAM2 m_param;
     // Reference counters
@@ -345,9 +340,7 @@ protected:
     bool m_bQuitWakeUpThread;
     
     // Threads contexts
-    MFX_SCHEDULER_THREAD_CONTEXT *m_pThreadCtx;
-
-
+    std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> m_pThreads;
 
     // Event to wait free task objects
     UMC::Semaphore m_freeTasks;
@@ -408,7 +401,6 @@ protected:
     mfxU32 m_jobCounter;
 
     mfxU32 m_timer_hw_event;
-
 
 private:
     // declare a assignment operator to avoid warnings

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -341,9 +341,6 @@ protected:
     // Stop and terminate the wake up thread
     mfxStatus StopWakeUpThread(void);
 
-    // 'quit' flag for threads
-    volatile
-    bool m_bQuit;
     volatile
     bool m_bQuitWakeUpThread;
     

--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core_thread.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core_thread.h
@@ -41,8 +41,9 @@ struct MFX_SCHEDULER_THREAD_CONTEXT
     {}
 
     enum State {
-        Waiting, // thread is waiting for incoming tasks
-        Running  // thread is executing a task
+        Waiting,  // thread is waiting for incoming tasks
+        Running,  // thread is executing a task
+        Stopping, // thread is going to stop
     };
 
     State state;                       // thread state, waiting or running

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core.cpp
@@ -26,9 +26,6 @@
 
 #include <umc_automatic_mutex.h>
 #include <vm_time.h>
-#include <vm_sys_info.h>
-
-
 
 mfxSchedulerCore::mfxSchedulerCore(void)
     :  m_currentTimeStamp(0)

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
@@ -24,7 +24,6 @@
 #include <mfx_scheduler_core_handle.h>
 
 #include <vm_time.h>
-#include <vm_sys_info.h>
 #include <umc_automatic_mutex.h>
 #include <mfx_trace.h>
 
@@ -44,11 +43,6 @@ mfxStatus mfxSchedulerCore::Initialize(const MFX_SCHEDULER_PARAM *pParam)
     if (pParam) {
         MFX_SCHEDULER_PARAM* casted_param2 = &param2;
         *casted_param2 = *pParam;
-    }
-    if (!param2.numberOfThreads) {
-        // that's just in case: core, which calls scheduler, is doing
-        // exactly the same what we are doing below
-        param2.numberOfThreads = vm_sys_info_get_cpu_num();
     }
     return Initialize2(&param2);
 }
@@ -93,14 +87,8 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
 
     if (MFX_SINGLE_THREAD != m_param.flags)
     {
-        if (m_param.numberOfThreads && m_param.params.NumThread) {
-            // use user-overwritten number of threads
-            m_param.numberOfThreads = m_param.params.NumThread;
-        }
-        if (!m_param.numberOfThreads) {
-            return MFX_ERR_UNSUPPORTED;
-        }
-        if (m_param.numberOfThreads == 1) {
+        // use user-overwritten number of threads
+        if (m_param.params.NumThread == 1) {
             // we need at least 2 threads to avoid dead locks
             return MFX_ERR_UNSUPPORTED;
         }
@@ -116,15 +104,17 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
 
             auto thread_proc = [this](MFX_SCHEDULER_THREAD_CONTEXT* ctx) { ThreadProc(ctx); };
             // start threads
-            for (i = 0; i < m_param.numberOfThreads; ++i)
+            for (i = 0; i < m_param.params.NumThread; ++i)
             {
-                std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT> thread(new MFX_SCHEDULER_THREAD_CONTEXT(i, thread_proc));
+                std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT> thread(new MFX_SCHEDULER_THREAD_CONTEXT(i));
 
                 if (!SetScheduling(thread->threadHandle)) {
                     return MFX_ERR_UNKNOWN;
                 }
                 m_pThreads.emplace_back(std::move(thread));
+                m_pThreads.back()->Start(thread_proc);
             }
+            m_param.numberOfThreads = m_param.params.NumThread;
 
             SetThreadsAffinityToSockets();
         }
@@ -139,6 +129,73 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
 
     }
 
+    return MFX_ERR_NONE;
+}
+
+mfxStatus mfxSchedulerCore::SetThreadNum(const void *pComponent, mfxU32 threadNum)
+{
+    MFX_CHECK(pComponent, MFX_ERR_INVALID_HANDLE);
+
+    // If user requested certain number of threads we follow his choice
+    // doing nothing in this function.
+    if (m_param.params.NumThread)
+        return MFX_ERR_NONE;
+
+    std::lock_guard<std::mutex> map_lock(m_pThreadsMapMutex);
+
+    if (threadNum)
+        m_pThreadsMap[pComponent] = threadNum;
+    else
+        m_pThreadsMap.erase(pComponent);
+
+    threadNum = 0; // reuse it now to count number of total threads
+    for (auto it: m_pThreadsMap) {
+        threadNum += it.second;
+    }
+
+    mfxU32 maxParallelism = std::thread::hardware_concurrency();
+    if (maxParallelism && (threadNum > maxParallelism)) threadNum = maxParallelism;
+
+    if (threadNum > m_pThreads.size()) {
+        // We need to create some threads.
+        std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> started;
+
+        auto thread_proc = [this](MFX_SCHEDULER_THREAD_CONTEXT* ctx) {
+            ThreadProc(ctx);
+        };
+
+        for (mfxU32 thread_id = m_pThreads.size(); thread_id < threadNum; ++thread_id) {
+            std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT> thread(
+                new MFX_SCHEDULER_THREAD_CONTEXT(thread_id));
+
+            if (!SetScheduling(thread->threadHandle)) {
+                return MFX_ERR_UNKNOWN;
+            }
+            started.emplace_back(std::move(thread));
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_guard);
+            for (auto& it: started) it->Start(thread_proc);
+            m_pThreads.splice(m_pThreads.end(), started);
+
+            SetThreadsAffinityToSockets();
+        }
+    } else if (threadNum < m_pThreads.size()) {
+        // We need to stop some threads. We will do this from the end
+        // of the threads arrray since these threads are less likely to be busy.
+        std::list<std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT>> stopped;
+
+        {
+            std::lock_guard<std::mutex> lock(m_guard);
+            do {
+                m_pThreads.front()->Stop(lock);
+                stopped.splice(stopped.end(), m_pThreads, m_pThreads.begin());
+            } while (m_pThreads.size() != threadNum);
+        }
+    }
+    // finally, let's update how many threads we have
+    m_param.numberOfThreads = m_pThreads.size();
     return MFX_ERR_NONE;
 }
 

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_ischeduler.cpp
@@ -115,23 +115,16 @@ mfxStatus mfxSchedulerCore::Initialize2(const MFX_SCHEDULER_PARAM2 *pParam)
                 return MFX_ERR_UNKNOWN;
             }
 
-            // allocate thread contexts
-            m_pThreadCtx = new MFX_SCHEDULER_THREAD_CONTEXT[m_param.numberOfThreads];
-
+            auto thread_proc = [this](MFX_SCHEDULER_THREAD_CONTEXT* ctx) { ThreadProc(ctx); };
             // start threads
-            for (i = 0; i < m_param.numberOfThreads; i += 1)
+            for (i = 0; i < m_param.numberOfThreads; ++i)
             {
-                // prepare context
-                m_pThreadCtx[i].threadNum = i;
-                m_pThreadCtx[i].pSchedulerCore = this;
+                std::unique_ptr<MFX_SCHEDULER_THREAD_CONTEXT> thread(new MFX_SCHEDULER_THREAD_CONTEXT(i, thread_proc));
 
-                // spawn a thread
-                m_pThreadCtx[i].threadHandle = std::thread(
-                    std::bind(&mfxSchedulerCore::ThreadProc, this, &m_pThreadCtx[i]));
-
-                if (!SetScheduling(m_pThreadCtx[i].threadHandle)) {
+                if (!SetScheduling(thread->threadHandle)) {
                     return MFX_ERR_UNKNOWN;
                 }
+                m_pThreads.emplace_back(std::move(thread));
             }
         }
         catch (...)

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_iunknown.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_iunknown.cpp
@@ -41,6 +41,14 @@ void *mfxSchedulerCore::QueryInterface(const MFX_GUID &guid)
         return (MFXIScheduler2 *) this;
     }
 
+    if (MFXIScheduler3_GUID == guid)
+    {
+        // increment reference counter
+        vm_interlocked_inc32(&m_refCounter);
+
+        return (MFXIScheduler3 *) this;
+    }
+
     // it is unsupported interface
     return NULL;
 

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
@@ -92,22 +92,21 @@ void mfxSchedulerCore::ThreadProc(MFX_SCHEDULER_THREAD_CONTEXT *pContext)
         }
         else
         {
+            mfxU32 timeout = (threadNum)? MFX_THREAD_TIME_TO_WAIT: 1;
             mfxU64 start, stop;
-
 
             // mark beginning of sleep period
             start = GetHighPerformanceCounter();
 
             // there is no any task.
             // sleep for a while until the event is signaled.
-            Wait(threadNum, guard);
+            pContext->taskAdded.wait_for(guard, std::chrono::milliseconds(timeout));
 
             // mark end of sleep period
             stop = GetHighPerformanceCounter();
 
             // update thread statistic
             pContext->sleepTime += (stop - start);
-
         }
     }
 }

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
@@ -61,7 +61,7 @@ void mfxSchedulerCore::ThreadProc(MFX_SCHEDULER_THREAD_CONTEXT *pContext)
     }
 
     // main working cycle for threads
-    while (false == m_bQuit)
+    while (pContext->state != MFX_SCHEDULER_THREAD_CONTEXT::Stopping)
     {
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "thread_proc");
 

--- a/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
+++ b/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
@@ -37,6 +37,11 @@ static const
 MFX_GUID MFXIScheduler2_GUID =
 { 0xdc775b1c, 0x951d, 0x421f, { 0xbf, 0xd8, 0xca, 0x56, 0x2d, 0x95, 0xa4, 0x18 } };
 
+// {CA33464F-30AB-4FD1-9BA8-D936B353D8DD}
+static const
+MFX_GUID MFXIScheduler3_GUID =
+{ 0xca33464f, 0x30ab, 0x4fd1, { 0x9b, 0xa8, 0xd9, 0x36, 0xb3, 0x53, 0xd8, 0xdd } };
+
 enum mfxSchedulerFlags
 {
     // default behaviour policy
@@ -119,8 +124,6 @@ public:
     // Send a performance message to the scheduler
     virtual
     mfxStatus AdjustPerformance(const mfxSchedulerMessage message) = 0;
-
-
 };
 
 struct MFX_SCHEDULER_PARAM2: public MFX_SCHEDULER_PARAM
@@ -140,6 +143,13 @@ public:
 
     virtual
     mfxStatus GetTimeout(mfxU32 & maxTimeToRun) = 0;
+};
+
+class MFXIScheduler3 : public MFXIScheduler2
+{
+public:
+    virtual
+    mfxStatus SetThreadNum(const void *pComponent, mfxU32 threadNum) = 0;
 };
 
 #endif // __MFX_INTERFACE_SCHEDULER_H

--- a/_studio/mfx_lib/shared/include/mfx_user_plugin.h
+++ b/_studio/mfx_lib/shared/include/mfx_user_plugin.h
@@ -43,6 +43,7 @@ public:
     mfxStatus PluginClose(void);
     // Get the plugin's threading policy
     mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    mfxStatus GetThreadNum(mfxU32& threadNum);
 
     // Check the parameters to start a new tasl
     mfxStatus Check(const mfxHDL *in, mfxU32 in_num,
@@ -102,6 +103,10 @@ protected:
         mfxTaskThreadingPolicy GetThreadingPolicy(void) {
             return m_plg->GetThreadingPolicy();
         }
+        mfxStatus GetThreadNum(mfxU32& threadNum) {
+            return m_plg->GetThreadNum(threadNum);
+        }
+
         mfxStatus GetVideoParam(mfxVideoParam *par) {
             return m_plg->GetVideoParam(par);
         }

--- a/_studio/mfx_lib/shared/src/libmfxsw_encode.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_encode.cpp
@@ -463,6 +463,22 @@ mfxStatus MFXVideoENCODE_Init(mfxSession session, mfxVideoParam *par)
         }
 
         mfxRes = session->m_pENCODE->Init(par);
+
+        if (mfxRes >= MFX_ERR_NONE) {
+            MFXIScheduler3* pScheduler3 = (MFXIScheduler3*)session->m_pScheduler->QueryInterface(MFXIScheduler3_GUID);
+
+            if (pScheduler3) {
+                mfxU32 threadNum = 0;
+                mfxStatus sts = session->m_pENCODE->GetThreadNum(threadNum);
+
+                if (MFX_ERR_NONE == sts)
+                    sts = pScheduler3->SetThreadNum(session->m_pENCODE.get(), threadNum);
+                if (MFX_ERR_NONE != sts)
+                    mfxRes = sts;
+
+                pScheduler3->Release();
+            }
+        }
     }
     // handle error(s)
     catch(...)
@@ -493,6 +509,12 @@ mfxStatus MFXVideoENCODE_Close(mfxSession session)
 
         // wait until all tasks are processed
         session->m_pScheduler->WaitForTaskCompletion(session->m_pENCODE.get());
+
+        MFXIScheduler3* pScheduler3 = (MFXIScheduler3*)session->m_pScheduler->QueryInterface(MFXIScheduler3_GUID);
+        if (pScheduler3) {
+            pScheduler3->SetThreadNum(session->m_pENCODE.get(), 0);
+            pScheduler3->Release();
+        }
 
         mfxRes = session->m_pENCODE->Close();
         // delete the codec's instance if not plugin
@@ -724,6 +746,21 @@ mfxStatus MFXVideoENCODE_Reset(mfxSession session, mfxVideoParam *par)
         session->m_pScheduler->WaitForTaskCompletion(session->m_pENCODE.get());
         /* call the codec's method */
         mfxRes = session->m_pENCODE->Reset(par);
+        if (mfxRes >= MFX_ERR_NONE) {
+            MFXIScheduler3* pScheduler3 = (MFXIScheduler3*)session->m_pScheduler->QueryInterface(MFXIScheduler3_GUID);
+
+            if (pScheduler3) {
+                mfxU32 threadNum = 0;
+                mfxStatus sts = session->m_pENCODE->GetThreadNum(threadNum);
+
+                if (MFX_ERR_NONE == sts)
+                    sts = pScheduler3->SetThreadNum(session->m_pENCODE.get(), threadNum);
+                if (MFX_ERR_NONE != sts)
+                    mfxRes = sts;
+
+                pScheduler3->Release();
+            }
+        }
     }
     /* handle error(s) */
     catch(...)

--- a/_studio/mfx_lib/shared/src/mfx_user_plugin.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_user_plugin.cpp
@@ -215,8 +215,13 @@ mfxTaskThreadingPolicy VideoUSERPlugin::GetThreadingPolicy(void)
     }
 
     return threadingPolicy;
+}
 
-} // mfxTaskThreadingPolicy VideoUSERPlugin::GetThreadingPolicy(void)
+mfxStatus VideoUSERPlugin::GetThreadNum(mfxU32& threadNum)
+{
+    threadNum = m_param.MaxThreadNum;
+    return MFX_ERR_NONE;
+}
 
 mfxStatus VideoUSERPlugin::Check(const mfxHDL *in, mfxU32 in_num,
                                  const mfxHDL *out, mfxU32 out_num,

--- a/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
@@ -95,6 +95,7 @@ public:
     }
 
     virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
     // multi threading of SW_VPP functions
     mfxStatus RunVPPTask(

--- a/_studio/mfx_lib/vpp/include/mfx_vpp_mvc.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_mvc.h
@@ -83,6 +83,7 @@ namespace MfxVideoProcessing
         }
 
         virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+        virtual mfxStatus GetThreadNum(mfxU32& threadNum);
 
         // multi threading of SW_VPP functions
         mfxStatus RunVPPTask(

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_main.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_main.cpp
@@ -184,9 +184,13 @@ mfxStatus VideoVPPMain::Close( void )
 mfxTaskThreadingPolicy VideoVPPMain::GetThreadingPolicy(void)
 {
     return MFX_TASK_THREADING_INTRA;
+}
 
-} // mfxTaskThreadingPolicy VideoVPPMain::GetThreadingPolicy(void)
-
+mfxStatus VideoVPPMain::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_impl.get(), MFX_ERR_NOT_INITIALIZED);
+    return m_impl->GetThreadNum(threadNum);
+}
 
 mfxStatus VideoVPPMain::VppFrameCheck(mfxFrameSurface1 *in,
                                       mfxFrameSurface1 *out,

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_mvc.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_mvc.cpp
@@ -223,9 +223,16 @@ mfxStatus ImplementationMvc::GetVPPStat(mfxVPPStat *stat)
 mfxTaskThreadingPolicy ImplementationMvc::GetThreadingPolicy(void)
 {
     return MFX_TASK_THREADING_INTRA;
+}
 
-} // mfxTaskThreadingPolicy ImplementationMvc::GetThreadingPolicy(void)
-
+mfxStatus ImplementationMvc::GetThreadNum(mfxU32& threadNum)
+{
+    MFX_CHECK(m_bInit, MFX_ERR_NOT_INITIALIZED);
+    // TODO: std::accumulate across all MVC VPP?
+    // or return 1 for HW path and N cores for SW?
+    threadNum = 1;
+    return MFX_ERR_NONE;
+}
 
 mfxStatus ImplementationMvc::VppFrameCheck(
     mfxFrameSurface1 *in,

--- a/_studio/shared/include/mfxvideo++int.h
+++ b/_studio/shared/include/mfxvideo++int.h
@@ -21,6 +21,8 @@
 #ifndef __MFXVIDEOPLUSPLUS_INTERNAL_H
 #define __MFXVIDEOPLUSPLUS_INTERNAL_H
 
+#include <thread>
+
 #include "mfxvideo.h"
 #include "mfxstructures-int.h"
 #include <mfx_task_threading_policy.h>
@@ -276,6 +278,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -299,6 +307,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -341,6 +355,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -400,6 +420,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -435,6 +461,12 @@ public:
     mfxStatus Close(void) = 0;
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     virtual
     mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
@@ -497,6 +529,12 @@ public:
     // Get the plugin's threading policy
     virtual
     mfxTaskThreadingPolicy GetThreadingPolicy(void) {return MFX_TASK_THREADING_DEFAULT;}
+    virtual
+    mfxStatus GetThreadNum(mfxU32& threadNum) {
+        // some mediasdk components require 2 threads as a minimum
+        threadNum = std::max(std::thread::hardware_concurrency(), 2u);
+        return MFX_ERR_NONE;
+    }
 
     // Check the parameters to start a new tasl
     virtual


### PR DESCRIPTION
This PR is a final step after #885 to teach components report required number of threads to the scheduler.