### PR TITLE
[mpeg2d] improve corruption check

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2634,20 +2634,18 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
 
     UMC::Status umcRes = UMC::UMC_OK;
 
-    bool IsField = false;
-    bool IsSkipped = false;
-
     if (8 < m_frame[m_frame_curr].DataLength)
     {
         m_implUmcHW->SaveDecoderState();
         umcRes = m_implUmc->GetPictureHeader(&m_in[m_task_num], m_task_num, m_prev_task_num);
+        // Shouldn't restore decoder state if GetPictureHeader returned error
+        // because buffers were not changed
+        // also now (m_IsFrameSkipped = false) == (umcRes == UMC::UMC_OK)
 
-        //VM_ASSERT( m_implUmc.PictureHeader[m_task_num].picture_coding_type != 3 || ( mid[ m_implUmc.frame_buffer.latest_next ] != -1 && mid[ m_implUmc.frame_buffer.latest_prev ] != -1 ));
-
-        IsField = !m_implUmc->IsFramePictureStructure(m_task_num); // is invalid (1) if GetPictureHeader() failed (skipped)
-        if (m_task_num >= DPB && !IsField)
+        // second field for frame picture, forget it (restore decoder)
+        if (m_task_num >= DPB && UMC::UMC_OK == umcRes && m_implUmc->IsFramePictureStructure(m_task_num))
         {
-            int decrease_dec_field_count = dec_field_count % 2 == 0 ? 0 : 1;
+            int decrease_dec_field_count = dec_field_count & 1;
             int32_t previous_field = m_task_num - DPB;
             if (previous_field > DPB)
                 return MFX_ERR_UNKNOWN;
@@ -2657,9 +2655,11 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
 
         if (UMC::UMC_OK != umcRes)
         {
-            MFX_CHECK_STS(RestoreDecoder(m_frame_curr, NO_SURFACE_TO_UNLOCK, NO_TASK_TO_UNLOCK, NO_END_FRAME, REMOVE_LAST_FRAME, 0))
+            // we trying not to modify buffers on error, so no need to restore
+            //MFX_CHECK_STS(RestoreDecoder(m_frame_curr, NO_SURFACE_TO_UNLOCK, NO_TASK_TO_UNLOCK, NO_END_FRAME, REMOVE_LAST_FRAME, 0))
+            m_frame_in_use[m_frame_curr] = false;
 
-            IsSkipped = m_implUmc->IsFrameSkipped();
+            bool IsSkipped = m_implUmc->IsFrameSkipped();
 
             if (IsSkipped && !(dec_field_count & 1))
             {
@@ -2708,7 +2708,8 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
                         display_order++;
                     }
 
-                    if (false == IsField || !(dec_field_count & 1) || IsSkipped) // not 2nd field or skipped 2nd
+                    // It comes here after error in GetPictureHeader and having frame to display. No need in condition.
+                    //if (false == IsField || !(dec_field_count & 1) || IsSkipped) // not 2nd field or skipped 2nd
                     {
                         pEntryPoint->requiredNumThreads = m_NumThreads;
                         pEntryPoint->pRoutine = &MPEG2TaskRoutine;
@@ -2755,13 +2756,14 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
             return MFX_ERR_UNKNOWN;
         }
 
-        if ((false == m_isDecodedOrder && maxNumFrameBuffered <= (uint32_t)(m_implUmc->GetRetBufferLen())) ||
-                true == m_isDecodedOrder)
+        if (true == m_isDecodedOrder || maxNumFrameBuffered <= static_cast<uint32_t>(m_implUmc->GetRetBufferLen()))
         {
             disp_index = m_implUmc->GetDisplayIndex();
         }
 
-        if (false == IsField || (true == IsField && !(dec_field_count & 1)))
+        bool IsField = !m_implUmc->IsFramePictureStructure(m_task_num);
+
+        if (false == IsField || !(dec_field_count & 1))
         {
             curr_index = m_task_num;
             next_index = m_implUmc->GetNextDecodingIndex(curr_index);
@@ -2885,7 +2887,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
                 return status;
         }
 
-        if ((true == IsField && !(dec_field_count & 1)) || false == IsField)
+        if (false == IsField || !(dec_field_count & 1))
         {
             pEntryPoint->requiredNumThreads = m_NumThreads;
             pEntryPoint->pRoutine = &MPEG2TaskRoutine;
@@ -2993,7 +2995,8 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
 
         if (0 <= disp_index)
         {
-            if (false == m_isDecodedOrder && ((true == IsField && !(dec_field_count & 1)) || false == IsField))
+            bool IsField = !m_implUmc->IsFramePictureStructure(m_task_num);
+            if (false == m_isDecodedOrder && (false == IsField || !(dec_field_count & 1)))
             {
                 mfxStatus sts = GetOutputSurface(surface_disp, surface_work, mid[disp_index]);
                 if (sts < MFX_ERR_NONE)

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec.cpp
@@ -308,7 +308,7 @@ Status MPEG2VideoDecoderBase::GetPictureHeader(MediaData* input, int task_num, i
 {
   Status umcRes = UMC_OK;
 
-  m_IsFrameSkipped = false;
+  m_IsFrameSkipped = true;
   m_IsSHDecoded = false;
 
   if(task_num >= DPB_SIZE)
@@ -353,6 +353,7 @@ Status MPEG2VideoDecoderBase::GetPictureHeader(MediaData* input, int task_num, i
         }
         m_IsLastFrameProcessed = true;
       }
+      m_IsFrameSkipped = false;
       return UMC_OK;
   }
 
@@ -390,6 +391,7 @@ Status MPEG2VideoDecoderBase::GetPictureHeader(MediaData* input, int task_num, i
     }
   } while (code != PICTURE_START_CODE);
 
+  // this call sets m_IsFrameSkipped
   umcRes = DecodeHeader(PICTURE_START_CODE, video, task_num);
   if(umcRes != UMC_OK)
       return umcRes;


### PR DESCRIPTION
Changed verification logic. During DecodePictureHeader any
error sets skip flag and keeps decoder buffers unmodified.
Also recovery logic doesn't rely on invalid parameters.
Several logic expression are simplified.
(33394)