### PR TITLE
AVBR: enable support for AVC in core library and sample_encode

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
@@ -1926,7 +1926,8 @@ void Hrd::Setup(MfxVideoParam const & par)
 {
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
         || par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ
-        || par.mfx.RateControlMethod == MFX_RATECONTROL_LA_ICQ)
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_LA_ICQ
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
     {
         // hrd control isn't required for BRC methods above
         m_bIsHrdRequired = false;

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
@@ -305,7 +305,8 @@ typedef struct tagENCODE_CAPS
             UINT    LLCStreamingBufferSupport     : 1;
             UINT    DDRStreamingBufferSupport     : 1;
             UINT    LowDelayBRCSupport            : 1; // eFrameSizeTolerance_ExtremelyLow (Low delay) supported
-            UINT                            : 12;
+            UINT    AVBRBRCSupport                : 1;
+            UINT                            : 11;
         };
         UINT      CodingLimits2;
     };

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -2413,6 +2413,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
        par.mfx.RateControlMethod != MFX_RATECONTROL_VBR &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_QVBR &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_CQP &&
+       par.mfx.RateControlMethod != MFX_RATECONTROL_AVBR &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ &&
        !bRateControlLA(par.mfx.RateControlMethod))
     {
@@ -3843,6 +3844,13 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR &&
         hwCaps.QVBRBRCSupport == 0)
+    {
+        par.mfx.RateControlMethod = 0;
+        unsupported = true;
+    }
+
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR &&
+        hwCaps.AVBRBRCSupport == 0)
     {
         par.mfx.RateControlMethod = 0;
         unsupported = true;
@@ -5389,7 +5397,7 @@ void MfxHwH264Encode::SetDefaults(
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
     {
         if (par.mfx.Accuracy == 0)
-            par.mfx.Accuracy = AVBR_ACCURACY_MAX;
+            par.mfx.Accuracy = 100;
 
         if (par.mfx.Convergence == 0)
             par.mfx.Convergence = AVBR_CONVERGENCE_MAX;
@@ -7541,7 +7549,8 @@ void MfxVideoParam::SyncVideoToCalculableParam()
             calcParam.mvcPerViewPar.bufferSizeInKB   = calcParam.bufferSizeInKB / extMvc->NumView;
             if (mfx.RateControlMethod != MFX_RATECONTROL_CQP
                 && mfx.RateControlMethod != MFX_RATECONTROL_ICQ
-                && mfx.RateControlMethod != MFX_RATECONTROL_LA_ICQ)
+                && mfx.RateControlMethod != MFX_RATECONTROL_LA_ICQ
+                && mfx.RateControlMethod != MFX_RATECONTROL_AVBR)
             {
                 calcParam.mvcPerViewPar.initialDelayInKB = calcParam.initialDelayInKB / extMvc->NumView;
                 calcParam.mvcPerViewPar.targetKbps       = calcParam.targetKbps / extMvc->NumView;

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -60,7 +60,7 @@ uint32_t ConvertRateControlMFX2VAAPI(mfxU8 rateControl)
     {
     case MFX_RATECONTROL_CBR:  return VA_RC_CBR;
     case MFX_RATECONTROL_VBR:  return VA_RC_VBR;
-    case MFX_RATECONTROL_AVBR: return VA_RC_VBR;
+    case MFX_RATECONTROL_AVBR: return VA_RC_AVBR;
 #ifdef MFX_ENABLE_QVBR
     case MFX_RATECONTROL_QVBR: return VA_RC_QVBR;
 #endif
@@ -202,6 +202,15 @@ mfxStatus SetRateControl(
     rate_param->bits_per_second = GetMaxBitrateValue(par.calcParam.maxKbps) << (6 + SCALE_FROM_DRIVER);
     rate_param->window_size     = par.mfx.Convergence * 100;
 
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        rate_param->window_size = par.mfx.Convergence;
+    }
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        rate_param->bits_per_second = ((1000 * par.calcParam.targetKbps) >> (6 + SCALE_FROM_DRIVER)) << (6 + SCALE_FROM_DRIVER);
+    }
+
     rate_param->min_qp = minQP;
     rate_param->max_qp = maxQP;
 
@@ -214,6 +223,11 @@ mfxStatus SetRateControl(
 
     if(par.calcParam.maxKbps)
         rate_param->target_percentage = (unsigned int)(100.0 * (mfxF64)par.calcParam.targetKbps / (mfxF64)par.calcParam.maxKbps);
+
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        rate_param->target_percentage = par.mfx.Accuracy;
+    }
 
     // Activate frame tolerance sliding window mode
     if (extOpt3.WinBRCSize && caps.FrameSizeToleranceSupport)
@@ -1409,6 +1423,8 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     m_caps.QVBRBRCSupport =
         (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_QVBR) ? 1 : 0;
 #endif
+    m_caps.AVBRBRCSupport =
+        (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_AVBR) ? 1 : 0;
     m_caps.TrelisQuantization =
         (attrs[idx_map[VAConfigAttribEncQuantization]].value & (~VA_ATTRIB_NOT_SUPPORTED)) ? 1 : 0;
     m_caps.vaTrellisQuantization =

--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -163,6 +163,8 @@ struct sInputParams
 
     mfxU16 ICQQuality;
     mfxU16 QVBRQuality;
+    mfxU16 Convergence;
+    mfxU16 Accuracy;
     mfxU16 LowDelayBRC;
     mfxU16 ExtBrcAdaptiveLTR;
 

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -422,6 +422,12 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
     {
         m_mfxEncParams.mfx.ICQQuality = pInParams->ICQQuality;
     }
+    else if (m_mfxEncParams.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        m_mfxEncParams.mfx.Accuracy    = pInParams->Accuracy;
+        m_mfxEncParams.mfx.TargetKbps  = pInParams->nBitRate;
+        m_mfxEncParams.mfx.Convergence = pInParams->Convergence;
+    }
     else
     {
         m_mfxEncParams.mfx.TargetKbps = pInParams->nBitRate; // in Kbps

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -98,6 +98,9 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-cbr]                   - constant bitrate control\n"));
     msdk_printf(MSDK_STRING("   [-qvbr quality]          - variable bitrate control algorithm with constant quality. Quality in range [1,51]. 1 is the best quality.\n"));
     msdk_printf(MSDK_STRING("   [-icq quality]           - Intelligent Constant Quality (ICQ) bitrate control method. In range [1,51]. 1 is the best quality.\n"));
+    msdk_printf(MSDK_STRING("   [-avbr]                  - average variable bitrate control algorithm \n"));
+    msdk_printf(MSDK_STRING("   [-convergence]           - bitrate convergence period for avbr, in the unit of frame \n"));
+    msdk_printf(MSDK_STRING("   [-accuracy]              - bitrate accuracy for avbr, in the range of [1, 100] \n"));
     msdk_printf(MSDK_STRING("   [-cqp]                   - constant quantization parameter (CQP BRC) bitrate control method\n"));
     msdk_printf(MSDK_STRING("                              (by default constant bitrate control method is used), should be used along with -qpi, -qpp, -qpb.\n"));
     msdk_printf(MSDK_STRING("   [-qpi]                   - constant quantizer for I frames (if bitrace control method is CQP). In range [1,51]. 0 by default, i.e.no limitations on QP.\n"));
@@ -393,6 +396,28 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
             if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->QVBRQuality))
             {
                 PrintHelp(strInput[0], MSDK_STRING("QVBRQuality param is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-avbr")))
+        {
+            pParams->nRateControlMethod = MFX_RATECONTROL_AVBR;
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-convergence")))
+        {
+            VAL_CHECK(i+1 >= nArgNum, i, strInput[i]);
+            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->Convergence))
+            {
+                PrintHelp(strInput[0], MSDK_STRING("convergence is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-accuracy")))
+        {
+            VAL_CHECK(i+1 >= nArgNum, i, strInput[i]);
+            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->Accuracy))
+            {
+                PrintHelp(strInput[0], MSDK_STRING("accuracy is invalid"));
                 return MFX_ERR_UNSUPPORTED;
             }
         }
@@ -1117,6 +1142,15 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
     {
         PrintHelp(strInput[0], MSDK_STRING("Look ahead BRC is supported only with -hw option!"));
         return MFX_ERR_UNSUPPORTED;
+    }
+
+    if (pParams->nRateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        if (pParams->Accuracy > 100)
+        {
+            msdk_printf(MSDK_STRING("For AVBR BRC, the assigned accuracy exceeds 100, now set it to 100\n"));
+            pParams->Accuracy = 100;
+        }
     }
 
     if ((pParams->nMaxSliceSize) && (!pParams->bUseHWLib))


### PR DESCRIPTION
./sample_encode h264 -i xxx.yuv -o xxx.h264 .....-avbr -b TargetBitrate
-convergence Convergence -accuracy Accuracy
Convergence is in the unit of frame
Accuracy should be in [1, 100]

Change-Id: Ic57cf2c213a9345328d2b91d9bf455bec3283360