### PR TITLE
Resolve "unused variable" warnings for MFX traces

### DIFF
--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -446,6 +446,7 @@ void mfxSchedulerCore::call_pRoutine(MFX_CALL_INFO& call)
         "MFX Async Task";
     mfxU64 start;
 
+    (void)pRoutineName;
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_SCHED, pRoutineName);
     MFX_LTRACE_1(MFX_TRACE_LEVEL_SCHED, "^Child^of", "%d", call.pTask->nParentId);
 

--- a/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
+++ b/_studio/mfx_lib/scheduler/src/mfx_scheduler_core_thread.cpp
@@ -116,6 +116,7 @@ void mfxSchedulerCore::WakeupThreadProc()
 {
     {
         const char thread_name[30] = "ThreadName=MSDKHWL#0";
+        (void)thread_name;
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_SCHED, thread_name);
     }
 

--- a/_studio/mfx_lib/shared/src/libmfxsw.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw.cpp
@@ -87,6 +87,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 #else
     _mfxSession * pSession = 0;
 #endif
+    (void)g_hModule;
     mfxStatus mfxRes;
     int adapterNum = 0;
     mfxIMPL impl = par.Implementation & (MFX_IMPL_VIA_ANY - 1);

--- a/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_vpp.cpp
@@ -453,6 +453,8 @@ mfxStatus MFXVideoVPP_RunFrameVPPAsync(mfxSession session, mfxFrameSurface1 *in,
 mfxStatus MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp)
 {
 #if !defined(MFX_ENABLE_USER_VPP)
+    (void)in;
+    (void)surface_work;
     (void)surface_out;
 #endif
 


### PR DESCRIPTION
Some variables and parameters are created only for using
within MFX_AUTO_LTRACE, MFX_LTRACE_P, MFX_LTRACE_S and other macros.
If MFX_TRACE_ENABLE is not defined, such variables are marked
by compiler as "unused variable" and if the warnings are treated
as errors the build is failed.

The patch is one of the options how to resolve this issue.

Signed-off-by: Dmitry Brazhkin <dmitry.brazhkin@intel.com>