### PR TITLE
[VP9d] Fix AYUV FourCC and CheckVideoParam

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -196,7 +196,6 @@ mfxStatus CheckFrameInfoCodecs(mfxFrameInfo  *info, mfxU32 codecId, bool isHW)
             && info->FourCC != MFX_FOURCC_AYUV
             && info->FourCC != MFX_FOURCC_P010
 #if (MFX_VERSION >= 1027)
-            && info->FourCC != MFX_FOURCC_AYUV
             && info->FourCC != MFX_FOURCC_Y410
 #endif
 			)
@@ -214,9 +213,9 @@ mfxStatus CheckFrameInfoCodecs(mfxFrameInfo  *info, mfxU32 codecId, bool isHW)
             info->FourCC != MFX_FOURCC_YUY2 &&
             info->FourCC != MFX_FOURCC_P010 &&
             info->FourCC != MFX_FOURCC_NV16 &&
-            info->FourCC != MFX_FOURCC_P210
+            info->FourCC != MFX_FOURCC_P210 &&
+            info->FourCC != MFX_FOURCC_AYUV
 #if (MFX_VERSION >= 1027)
-            && info->FourCC != MFX_FOURCC_AYUV
             && info->FourCC != MFX_FOURCC_Y210
             && info->FourCC != MFX_FOURCC_Y410
 #endif

--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -104,9 +104,9 @@ namespace MFX_VPX_Utility
             switch (p_in->mfx.FrameInfo.FourCC)
             {
             case MFX_FOURCC_NV12:
+            case MFX_FOURCC_AYUV:
             case MFX_FOURCC_P010:
 #if (MFX_VERSION >= 1027)
-            case MFX_FOURCC_AYUV:
             case MFX_FOURCC_Y410:
 #endif
                 p_out->mfx.FrameInfo.FourCC = p_in->mfx.FrameInfo.FourCC;
@@ -132,9 +132,9 @@ namespace MFX_VPX_Utility
             if (p_in->mfx.FrameInfo.FourCC && p_in->mfx.FrameInfo.ChromaFormat)
             {
                 if ((   p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_NV12 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV420)
+                    || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_AYUV && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
                     || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_P010 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV420)
 #if (MFX_VERSION >= 1027)
-                    || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_AYUV && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
                   //|| (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_Y210 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV422)
                     || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_Y410 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
 #endif
@@ -356,20 +356,6 @@ namespace MFX_VPX_Utility
             if (p_in->mfx.CodecLevel != MFX_LEVEL_UNKNOWN)
                 return false;
         }
-        else if (codecId == MFX_CODEC_VP9)
-        {
-            if (MFX_FOURCC_NV12 != p_in->mfx.FrameInfo.FourCC &&
-                MFX_FOURCC_AYUV != p_in->mfx.FrameInfo.FourCC &&
-                MFX_FOURCC_P010 != p_in->mfx.FrameInfo.FourCC
-#if (MFX_VERSION >= 1027)
-                && !(MFX_FOURCC_Y410 == p_in->mfx.FrameInfo.FourCC && hwtype >= MFX_HW_ICL)
-#endif
-                )
-                return false;
-            if (MFX_CHROMAFORMAT_YUV420 != p_in->mfx.FrameInfo.ChromaFormat &&
-                MFX_CHROMAFORMAT_YUV444 != p_in->mfx.FrameInfo.ChromaFormat)
-                return false;
-        }
         else
         {
             /*if (platform == MFX_PLATFORM_SOFTWARE)
@@ -380,11 +366,11 @@ namespace MFX_VPX_Utility
             else*/
             {
                 if (   p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_NV12
+                    && p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_AYUV
                     && p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_P010
 #if (MFX_VERSION >= 1027)
-                    && p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_AYUV
                     //&& p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_Y210
-                    && p_in->mfx.FrameInfo.FourCC != MFX_FOURCC_Y410
+                    && !(p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_Y410 && hwtype >= MFX_HW_ICL)
 #endif
                 )
                 return false;
@@ -404,9 +390,9 @@ namespace MFX_VPX_Utility
             if (p_in->mfx.FrameInfo.ChromaFormat)
             {
                 if ((p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_NV12 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV420)
+                    || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_AYUV && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
                     || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_P010 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV420)
 #if (MFX_VERSION >= 1027)
-                    || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_AYUV && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
                     //|| (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_Y210 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV422)
                     || (p_in->mfx.FrameInfo.FourCC == MFX_FOURCC_Y410 && p_in->mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444)
 #endif


### PR DESCRIPTION
AYUV FourCC should not be guarded with MFX_VERSION >= 1027
Get rid of duplicate VP9 CheckVideoParam else branch.