### PR TITLE
[VP9e][Linux] Fixed returned status for MxN tiles

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -1479,6 +1479,15 @@ mfxStatus CheckParameters(VP9MfxVideoParam &par, ENCODE_CAPS_VP9 const &caps)
         unsupported = true;
     }
 
+#if defined(MFX_VA_LINUX)
+    // TODO: For now driver on Linux doesn't support MxN tiles
+    if (rows > 1 && cols > 1)
+    {
+        rows = cols = 1;
+        unsupported = true;
+    }
+#endif
+
     if (rows && height)
     {
         mfxU16 heightInSBs = static_cast<mfxU16>(CeilDiv(height, SB_SIZE));


### PR DESCRIPTION
Fixed returned status for cases with MxN tiles what are currently unsupported
by driver on Linux.