### PR TITLE
vc1d: Added check after vaEndPicture

### DIFF
--- a/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
+++ b/_studio/shared/umc/codec/vc1_dec/src/umc_vc1_video_decoder_hw.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -391,7 +391,8 @@ Status VC1VideoDecoderHW::FillAndExecute(MediaData* in)
     }
     if (pPackDescriptorChild->m_pContext->m_picLayerHeader->PTYPE != VC1_SKIPPED_FRAME)
     {
-        m_va->EndFrame();
+        if (UMC_OK != m_va->EndFrame())
+            throw VC1Exceptions::vc1_exception(VC1Exceptions::internal_pipeline_error);
     }
     in->MoveDataPointer(pPackDescriptorChild->m_pContext->m_FrameSize);
 


### PR DESCRIPTION
MediaSDK return MFX_ERR_NONE in spite of vaEndPicture return error

Signed-off-by: Ivan Losev <ivan.losev@intel.com>