### PR TITLE
mctf: fixed static analysis issue

### DIFF
--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -482,7 +482,7 @@ mfxStatus CMC::MCTF_SetMemory(
     else
     {
         auto inp_iter = mfxSurfPool.begin();
-        for (auto it = QfIn.begin(); it != QfIn.end(); ++it, ++inp_iter)
+        for (auto it = QfIn.begin(); it != QfIn.end() && inp_iter != mfxSurfPool.end(); ++it, ++inp_iter)
             it->mfxFrame = *inp_iter;
         res = IM_SURF_SET();
         MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);


### PR DESCRIPTION
Added check to make sure that iterator is inside mfxSurfPool