### PR TITLE
h264d: fix async model

### DIFF
--- a/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
+++ b/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
@@ -50,6 +50,7 @@ namespace UMC
 
 typedef UMC::VATaskSupplier  MFX_AVC_Decoder;
 
+struct ThreadTaskInfo;
 class VideoDECODE;
 class VideoDECODEH264 : public VideoDECODE
 {
@@ -75,7 +76,7 @@ public:
     virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload);
     virtual mfxStatus SetSkipMode(mfxSkipMode mode);
 
-    mfxStatus RunThread(void * params, mfxU32 threadNumber);
+     mfxStatus RunThread(ThreadTaskInfo*, mfxU32 /*threadNumber*/);
 
 protected:
     static mfxStatus QueryIOSurfInternal(eMFXPlatform platform, eMFXHWType type, mfxVideoParam *par, mfxFrameAllocRequest *request);

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
@@ -3163,13 +3163,11 @@ Status TaskSupplier::AddSource(MediaData * pSource)
                 return UMC_WRN_INFO_NOT_READY;
 
             if (GetFrameToDisplayInternal(true))
-                return UMC_ERR_NOT_ENOUGH_BUFFER;
+                return UMC_ERR_NEED_FORCE_OUTPUT;
 
             PreventDPBFullness();
             return UMC_WRN_INFO_NOT_READY;
         }
-
-        return UMC_WRN_INFO_NOT_READY;
     }
 
     return umcRes;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_supplier.cpp
@@ -327,40 +327,8 @@ Status VATaskSupplier::AddSource(MediaData * pSource)
     if (!pSource)
         return MFXTaskSupplier::AddSource(pSource);
 
-    notifier0<LazyCopier> memory_leak_preventing_slice(&m_lazyCopier, &LazyCopier::CopyAll);
-
-    uint32_t const flags = pSource->GetFlags();
-    if (flags & MediaData::FLAG_VIDEO_DATA_NOT_FULL_FRAME)
-        return MFXTaskSupplier::AddSource(pSource);
-
-    if (m_currentView == INVALID_VIEW_ID)
-        return MFXTaskSupplier::AddSource(pSource);
-
-    ViewItem &view = GetView(m_currentView);
-    if (view.pCurFrame && view.pCurFrame->m_PictureStructureForDec < FRM_STRUCTURE)
-    {
-        H264Slice* pFirstFrameSlice = view.pCurFrame->GetAU(0)->GetSlice(0);
-        //we need to check only for first slice
-        if (pFirstFrameSlice)
-            return MFXTaskSupplier::AddSource(pSource);
-    }
-
-    H264DBPList* pDPB = view.GetDPBList(0);
-    VM_ASSERT(pDPB && "DPB pointer should be valid here");
-    if (!pDPB)
-        return UMC_ERR_FAILED;
-
-    //check if we have free frame
-    if (pDPB->countAllFrames() < view.maxDecFrameBuffering + m_DPBSizeEx ||
-        pDPB->IsDisposableExist())
-        return MFXTaskSupplier::AddSource(pSource);
-
-    H264DecoderFrame* completed = 0;
-    Status umcRes = CompleteDecodedFrames(&completed);
-    if (umcRes != UMC_OK)
-        return pSource || !completed ? umcRes : UMC_OK;
-
-    return UMC_WRN_INFO_NOT_READY;
+    notifier0<LazyCopier> copy_slice_data(&m_lazyCopier, &LazyCopier::CopyAll);
+    return MFXTaskSupplier::AddSource(pSource);
 }
 
 Status VATaskSupplier::AllocateFrameData(H264DecoderFrame * pFrame)


### PR DESCRIPTION
 - Decoder triggered 'global task' not only when
   it needs to force async. operation completion
   but every time it needs more work surfaces.
   When blocking sync. is used this leads to
   [SyncOperation] call may take more time than it
   really needed. In current patch we use the same
   approach as it is in h265d component.

Issue: MDP-41203
Test: full decoding & transcoding validation