### PR TITLE
hevc_parser: fixed static analysis issue

### DIFF
--- a/samples/sample_hevc_fei_abr/src/dso/hevc2_parser.cpp
+++ b/samples/sample_hevc_fei_abr/src/dso/hevc2_parser.cpp
@@ -50,7 +50,7 @@ Parser::Parser(Bs32u mode)
 
     if (m_mode & ASYNC)
     {
-        hwThreads = std::thread::hardware_concurrency();
+        hwThreads    = std::max(1u, std::thread::hardware_concurrency());
         m_asyncAUMax = hwThreads * 2;
     }
 

--- a/tools/bs_parser_hevc/src/hevc2_parser.cpp
+++ b/tools/bs_parser_hevc/src/hevc2_parser.cpp
@@ -50,7 +50,7 @@ Parser::Parser(Bs32u mode)
 
     if (m_mode & ASYNC)
     {
-        hwThreads = std::thread::hardware_concurrency();
+        hwThreads    = std::max(1u, std::thread::hardware_concurrency());
         m_asyncAUMax = hwThreads * 2;
     }
 


### PR DESCRIPTION
std::thread::hardware_concurrency may return 0 if it fails to get info from HW