### PR TITLE
AVC FEI: fixed pointer check logic

### DIFF
--- a/samples/sample_fei/src/fei_encode.cpp
+++ b/samples/sample_fei/src/fei_encode.cpp
@@ -689,10 +689,12 @@ mfxStatus FEI_EncodeInterface::EncodeOneFrame(iTask* eTask)
 {
     MFX_ITT_TASK("EncodeOneFrame");
 
+    MSDK_CHECK_POINTER(eTask, MFX_ERR_NULL_PTR);
+
     mfxStatus sts = MFX_ERR_NONE;
 
     // ENC_in.InSurface always holds full-res surface
-    mfxFrameSurface1* encodeSurface = eTask ? eTask->ENC_in.InSurface : NULL;
+    mfxFrameSurface1* encodeSurface = eTask->ENC_in.InSurface;
     if (encodeSurface) // no need to do this for buffered frames
     {
         sts = InitFrameParams(eTask);


### PR DESCRIPTION
eTask pointer is never NULL anymore. Removed logic is a leftover from times when Encode in Encoded Order didn't use eTask