### PR TITLE
h265d: cleanup VA packers

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
@@ -250,7 +250,7 @@ public:
     }
 
     // Return bitstream array base address and size
-    void GetOrg(uint32_t **pbs, uint32_t *size);
+    void GetOrg(uint32_t **pbs, uint32_t *size) const;
     // Return current bitstream address and bit offset
     void GetState(uint32_t **pbs, uint32_t *bitOffset);
     // Set current bitstream address and bit offset

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_slice_decoding.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_slice_decoding.h
@@ -151,7 +151,10 @@ public:  // DEBUG !!!! should remove dependence
     H265HeadersBitstream m_BitStream;                                  // (H265Bitstream) slice bit stream
 
     // Obtain bit stream object
-    H265HeadersBitstream *GetBitStream(){return &m_BitStream;}
+    H265HeadersBitstream* GetBitStream()
+    { return &m_BitStream; }
+    H265HeadersBitstream const* GetBitStream() const
+    { return &m_BitStream; }
 
 protected:
     const H265PicParamSet* m_pPicParamSet;                      // (H265PicParamSet *) pointer to array of picture parameters sets

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
@@ -65,7 +65,7 @@ void H265BaseBitstream::Reset(uint8_t * const pb, int32_t offset, const uint32_t
 } // void Reset(uint8_t * const pb, int32_t offset, const uint32_t maxsize)
 
 // Return bitstream array base address and size
-void H265BaseBitstream::GetOrg(uint32_t **pbs, uint32_t *size)
+void H265BaseBitstream::GetOrg(uint32_t **pbs, uint32_t *size) const
 {
     *pbs       = m_pbsBase;
     *size      = m_maxBsSize;


### PR DESCRIPTION
Cleanup packer interface, remove redundant method args,
use unsigned types & const whenever it's possible

Issue: MDP-52201
Test: hevcd_conf, hevcd_sbe, hevcd_conf_allegro, hevcd_afl_broken