### PR TITLE
[mpeg2d] improve pipeline robustness

### DIFF
--- a/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
+++ b/_studio/mfx_lib/decode/mpeg2/include/mfx_mpeg2_decode.h
@@ -101,7 +101,7 @@ typedef struct _MParam
     mfxFrameSurface1 *surface_work;
     mfx_UMC_FrameAllocator *m_FrameAllocator;
     mfxVideoParam m_vPar;
-    int32_t *mid;
+    UMC::FrameMemID *mid;
     mfxBitstream *m_frame;
     bool *m_frame_in_use;
 

--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -2254,15 +2254,14 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
             if (false == m_first_SH && (surface_work->Info.CropW <  CropW || surface_work->Info.CropH < CropH))
             {
                 m_resizing = true;
-
-                return MFX_WRN_VIDEO_PARAM_CHANGED;
+                //return MFX_WRN_VIDEO_PARAM_CHANGED; // don't go to error path if smaller
             }
 
             if (false == m_first_SH)
                 if (m_InitW >  Width || m_InitH > Height)
                 {
                     m_resizing = true;
-                    return MFX_WRN_VIDEO_PARAM_CHANGED;
+                    // return MFX_WRN_VIDEO_PARAM_CHANGED; // don't go to error path if smaller
                 }
 
             m_first_SH = false;
@@ -2436,6 +2435,7 @@ mfxStatus VideoDECODEMPEG2InternalBase::ConstructFrameImpl(mfxBitstream *in, mfx
 
             MoveBitstreamData(*in, (mfxU32)(curr - head));
 
+            if (!m_found_SH) // have to pass sequence header, even with error frame
             if (m_fcState.picHeader == FcState::FRAME && !VerifyPictureBits(out, curr, tail))
                 return MFX_ERR_NOT_ENOUGH_BUFFER; // to start again with next picture
 
@@ -2638,9 +2638,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
     {
         m_implUmcHW->SaveDecoderState();
         umcRes = m_implUmc->GetPictureHeader(&m_in[m_task_num], m_task_num, m_prev_task_num);
-        // Shouldn't restore decoder state if GetPictureHeader returned error
-        // because buffers were not changed
-        // also now (m_IsFrameSkipped = false) == (umcRes == UMC::UMC_OK)
+        // now (m_IsFrameSkipped = false) == (umcRes == UMC::UMC_OK)
 
         // second field for frame picture, forget it (restore decoder)
         if (m_task_num >= DPB && UMC::UMC_OK == umcRes && m_implUmc->IsFramePictureStructure(m_task_num))
@@ -2655,9 +2653,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
 
         if (UMC::UMC_OK != umcRes)
         {
-            // we trying not to modify buffers on error, so no need to restore
-            //MFX_CHECK_STS(RestoreDecoder(m_frame_curr, NO_SURFACE_TO_UNLOCK, NO_TASK_TO_UNLOCK, NO_END_FRAME, REMOVE_LAST_FRAME, 0))
-            m_frame_in_use[m_frame_curr] = false;
+            MFX_CHECK_STS(RestoreDecoder(m_frame_curr, NO_SURFACE_TO_UNLOCK, NO_TASK_TO_UNLOCK, NO_END_FRAME, REMOVE_LAST_FRAME, 0))
 
             bool IsSkipped = m_implUmc->IsFrameSkipped();
 
@@ -2852,7 +2848,7 @@ mfxStatus VideoDECODEMPEG2Internal_HW::DecodeFrameCheck(mfxBitstream *bs,
             UMC::UMC_ERR_NOT_ENOUGH_DATA != umcRes &&
             UMC::UMC_ERR_SYNC != umcRes))
         {
-            MFX_CHECK_STS(RestoreDecoder(m_frame_curr, mid[curr_index], m_task_num, END_FRAME, REMOVE_LAST_FRAME, IsField?1:2))
+            MFX_CHECK_STS(RestoreDecoder(m_frame_curr, mid[curr_index], m_task_num, NO_END_FRAME, REMOVE_LAST_FRAME, IsField?1:2))
             return MFX_ERR_MORE_DATA;
         }
 

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_pic.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_dec_pic.cpp
@@ -316,7 +316,8 @@ Status MPEG2VideoDecoderBase::DecodeSequenceHeader(VideoContext* video, int task
         m_signalInfo.TransferCharacteristics = 1;
         m_signalInfo.MatrixCoefficients = 1;
 
-        VideoStreamType newtype = MPEG1_VIDEO;
+        // if not first sequence ext is missed, try without it
+        VideoStreamType newtype = sequenceHeader.is_decoded ? MPEG2_VIDEO : MPEG1_VIDEO;
 
         if (!constrained_parameters_flag)
         {


### PR DESCRIPTION
Improve robustness and recovery for very corrupted content.
No error on size < init.size; accept broken SequenceHeaderExtension
in between, accept SH if next frame is invalid, returned
RestoreDecoder after early caught errors.