### PR TITLE
[vp9d,vp8d,av1d] Fix aspect ratio checks

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -212,25 +212,16 @@ namespace MFX_VPX_Utility
                 p_out->mfx.FrameInfo.FrameRateExtD = p_in->mfx.FrameInfo.FrameRateExtD;
             }
 
-            if ((p_in->mfx.FrameInfo.AspectRatioW || p_in->mfx.FrameInfo.AspectRatioH) &&
-                (!p_in->mfx.FrameInfo.AspectRatioW || !p_in->mfx.FrameInfo.AspectRatioH))
+            if ((p_in->mfx.FrameInfo.AspectRatioW == 0 && p_in->mfx.FrameInfo.AspectRatioH == 0) ||
+                (p_in->mfx.FrameInfo.AspectRatioW != 0 && p_in->mfx.FrameInfo.AspectRatioH != 0))
             {
-                sts = MFX_ERR_UNSUPPORTED;
+                p_out->mfx.FrameInfo.AspectRatioW = p_in->mfx.FrameInfo.AspectRatioW;
+                p_out->mfx.FrameInfo.AspectRatioH = p_in->mfx.FrameInfo.AspectRatioH;
             }
             else
             {
-                if ((p_in->mfx.FrameInfo.AspectRatioW && p_in->mfx.FrameInfo.AspectRatioW != 1) ||
-                    (p_in->mfx.FrameInfo.AspectRatioH && p_in->mfx.FrameInfo.AspectRatioH != 1))
-                {
-                    sts = MFX_ERR_UNSUPPORTED;
-                }
-                else
-                {
-                    p_out->mfx.FrameInfo.AspectRatioW = p_in->mfx.FrameInfo.AspectRatioW;
-                    p_out->mfx.FrameInfo.AspectRatioH = p_in->mfx.FrameInfo.AspectRatioH;
-                }
+                sts = MFX_ERR_UNSUPPORTED;
             }
-
 
             if (p_in->mfx.ExtendedPicStruct)
                 sts = MFX_ERR_UNSUPPORTED;


### PR DESCRIPTION
If the aspect ratio is not set by the user (contains zero values)
then treat it as (1,1).
If the user set the aspect ratio
then check it is valid (AspectRatioW != 0 and AspectRatioH != 0)

Issue: vsmgwl-10915, vsmgwl-10735
Test: manual, vp9d_10b_420_p010_reset./26