### PR TITLE
[vp9d] Make DecodeHeader static function

### DIFF
--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
@@ -55,7 +55,7 @@ public:
     virtual mfxStatus GetVideoParam(mfxVideoParam *pPar);
     virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat);
 
-    virtual mfxStatus DecodeHeader(VideoCORE * core, mfxBitstream *bs, mfxVideoParam *params);
+    static mfxStatus DecodeHeader(VideoCORE * core, mfxBitstream *bs, mfxVideoParam *params);
     virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 **ppSurfaceOut, MFX_ENTRY_POINT *pEntryPoint);
 
     virtual mfxStatus GetUserData(mfxU8 *pUserData, mfxU32 *pSize, mfxU64 *pTimeStamp);

--- a/_studio/mfx_lib/shared/src/libmfxsw_decode.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_decode.cpp
@@ -391,7 +391,7 @@ mfxStatus MFXVideoDECODE_DecodeHeader(mfxSession session, mfxBitstream *bs, mfxV
 
 #if defined (MFX_ENABLE_VP9_VIDEO_DECODE_HW)
         case MFX_CODEC_VP9:
-            mfxRes = MFX_VP9_Utility::DecodeHeader(session->m_pCORE.get(), bs, par);
+            mfxRes = VideoDECODEVP9_HW::DecodeHeader(session->m_pCORE.get(), bs, par);
             break;
 #endif
 


### PR DESCRIPTION
MFXVideoDECODE_DecodeHeader should call VP9 specific
DecodeHeader function, to do so the function must be
static, like it was done for other decoders H264, H265.

Issue: vsmgwl-10697
Test: vp9d_*_format_change./*