### PR TITLE
[vp9d] Clear mfx.Shift for packed format

### DIFF
--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode.h
@@ -36,7 +36,7 @@
 namespace MFX_VP9_Utility
 {
     mfxStatus DecodeHeader(VideoCORE * /*core*/, mfxBitstream *bs, mfxVideoParam *params);
-    mfxStatus FillVideoParam(VideoCORE* /*core*/, UMC_VP9_DECODER::VP9DecoderFrame const&, mfxVideoParam* params);
+    void FillVideoParam(eMFXPlatform platform, UMC_VP9_DECODER::VP9DecoderFrame const& frame, mfxVideoParam &params);
 };
 
 #endif // #if defined(MFX_ENABLE_VP9_VIDEO_DECODE) || defined(MFX_ENABLE_VP9_VIDEO_DECODE_HW)

--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
@@ -75,8 +75,6 @@ protected:
     mfxStatus DecodeFrameHeader(mfxBitstream *in, UMC_VP9_DECODER::VP9DecoderFrame & info);
     mfxStatus PackHeaders(mfxBitstream *bs, UMC_VP9_DECODER::VP9DecoderFrame const & info);
 
-    void UpdateVideoParam(mfxVideoParam *par, UMC_VP9_DECODER::VP9DecoderFrame const & frameInfo);
-
     mfxFrameSurface1 * GetOriginalSurface(mfxFrameSurface1 *);
     mfxStatus GetOutputSurface(mfxFrameSurface1 **, mfxFrameSurface1 *, UMC::FrameMemID);
 

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode.cpp
@@ -45,7 +45,7 @@ mfxStatus DecodeHeader(VideoCORE* core, mfxBitstream* bs, mfxVideoParam* params)
 {
     mfxStatus sts = MFX_ERR_NONE;
 
-    MFX_CHECK_NULL_PTR2(bs, params);
+    MFX_CHECK_NULL_PTR3(core, bs, params);
 
     sts = CheckBitstream(bs);
     MFX_CHECK_STS(sts);
@@ -185,78 +185,77 @@ mfxStatus DecodeHeader(VideoCORE* core, mfxBitstream* bs, mfxVideoParam* params)
         return MFX_ERR_MORE_DATA;
     }
 
-    FillVideoParam(core, frame, params);
+    FillVideoParam(core->GetPlatformType(), frame, *params);
 
     return MFX_ERR_NONE;
 }
 
-mfxStatus FillVideoParam(VideoCORE* core, UMC_VP9_DECODER::VP9DecoderFrame const& frame, mfxVideoParam* params)
+void FillVideoParam(eMFXPlatform platform, UMC_VP9_DECODER::VP9DecoderFrame const& frame, mfxVideoParam &params)
 {
-    MFX_CHECK_NULL_PTR2(core, params);
+    params.mfx.CodecProfile = mfxU16(frame.profile + 1);
 
-    params->mfx.CodecProfile = mfxU16(frame.profile + 1);
+    params.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
+    params.mfx.FrameInfo.AspectRatioW = 1;
+    params.mfx.FrameInfo.AspectRatioH = 1;
 
-    params->mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
-    params->mfx.FrameInfo.AspectRatioW = 1;
-    params->mfx.FrameInfo.AspectRatioH = 1;
+    params.mfx.FrameInfo.CropX = 0;
+    params.mfx.FrameInfo.CropY = 0;
+    params.mfx.FrameInfo.CropW = static_cast<mfxU16>(frame.width);
+    params.mfx.FrameInfo.CropH = static_cast<mfxU16>(frame.height);
 
-    params->mfx.FrameInfo.CropX = 0;
-    params->mfx.FrameInfo.CropY = 0;
-    params->mfx.FrameInfo.CropW = static_cast<mfxU16>(frame.width);
-    params->mfx.FrameInfo.CropH = static_cast<mfxU16>(frame.height);
-
-    params->mfx.FrameInfo.Width  = UMC::align_value<mfxU16>(params->mfx.FrameInfo.CropW, 16);
-    params->mfx.FrameInfo.Height = UMC::align_value<mfxU16>(params->mfx.FrameInfo.CropH, 16);
+    params.mfx.FrameInfo.Width  = UMC::align_value<mfxU16>(params.mfx.FrameInfo.CropW, 16);
+    params.mfx.FrameInfo.Height = UMC::align_value<mfxU16>(params.mfx.FrameInfo.CropH, 16);
 
     if (!frame.subsamplingX && !frame.subsamplingY)
-        params->mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV444;
+        params.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV444;
     //else if (!subsampling_x && subsampling_y)
-    //    params->mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV440;
+    //    params.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV440;
     else if (frame.subsamplingX && !frame.subsamplingY)
-        params->mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV422;
+        params.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV422;
     else if (frame.subsamplingX && frame.subsamplingY)
-        params->mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV420;
+        params.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV420;
 
     switch (frame.bit_depth)
     {
         case  8:
-            params->mfx.FrameInfo.FourCC = MFX_FOURCC_NV12;
-            if (MFX_CHROMAFORMAT_YUV444 == params->mfx.FrameInfo.ChromaFormat)
-                params->mfx.FrameInfo.FourCC = MFX_FOURCC_AYUV;
-            else if (MFX_CHROMAFORMAT_YUV422 == params->mfx.FrameInfo.ChromaFormat)
-                params->mfx.FrameInfo.FourCC = MFX_FOURCC_YUY2;
-            params->mfx.FrameInfo.BitDepthLuma   = 8;
-            params->mfx.FrameInfo.BitDepthChroma = 8;
-            params->mfx.FrameInfo.Shift = 0;
+            params.mfx.FrameInfo.FourCC = MFX_FOURCC_NV12;
+            if (MFX_CHROMAFORMAT_YUV444 == params.mfx.FrameInfo.ChromaFormat)
+                params.mfx.FrameInfo.FourCC = MFX_FOURCC_AYUV;
+            else if (MFX_CHROMAFORMAT_YUV422 == params.mfx.FrameInfo.ChromaFormat)
+                params.mfx.FrameInfo.FourCC = MFX_FOURCC_YUY2;
+            params.mfx.FrameInfo.BitDepthLuma   = 8;
+            params.mfx.FrameInfo.BitDepthChroma = 8;
+            params.mfx.FrameInfo.Shift = 0;
             break;
 
         case 10:
-            params->mfx.FrameInfo.FourCC = MFX_FOURCC_P010;
+            params.mfx.FrameInfo.FourCC = MFX_FOURCC_P010;
 #if (MFX_VERSION >= 1027)
-            if (MFX_CHROMAFORMAT_YUV444 == params->mfx.FrameInfo.ChromaFormat)
-                params->mfx.FrameInfo.FourCC = MFX_FOURCC_Y410;
-            else if (MFX_CHROMAFORMAT_YUV422 == params->mfx.FrameInfo.ChromaFormat)
-                params->mfx.FrameInfo.FourCC = MFX_FOURCC_Y210;
+            if (MFX_CHROMAFORMAT_YUV444 == params.mfx.FrameInfo.ChromaFormat)
+                params.mfx.FrameInfo.FourCC = MFX_FOURCC_Y410;
+            else if (MFX_CHROMAFORMAT_YUV422 == params.mfx.FrameInfo.ChromaFormat)
+                params.mfx.FrameInfo.FourCC = MFX_FOURCC_Y210;
 #endif
-            params->mfx.FrameInfo.BitDepthLuma   = 10;
-            params->mfx.FrameInfo.BitDepthChroma = 10;
+            params.mfx.FrameInfo.BitDepthLuma   = 10;
+            params.mfx.FrameInfo.BitDepthChroma = 10;
             break;
 
         case 12:
-            params->mfx.FrameInfo.FourCC = 0;
-            params->mfx.FrameInfo.BitDepthLuma   = 12;
-            params->mfx.FrameInfo.BitDepthChroma = 12;
+            params.mfx.FrameInfo.FourCC = 0;
+            params.mfx.FrameInfo.BitDepthLuma   = 12;
+            params.mfx.FrameInfo.BitDepthChroma = 12;
             break;
     }
 
-    if (core->GetPlatformType() == MFX_PLATFORM_HARDWARE)
+    if (platform == MFX_PLATFORM_HARDWARE)
     {
-        if (   params->mfx.FrameInfo.FourCC == MFX_FOURCC_P010
-        )
-            params->mfx.FrameInfo.Shift = 1;
-    }
+        params.mfx.FrameInfo.Shift = 0;
 
-    return MFX_ERR_NONE;
+        if (params.mfx.FrameInfo.FourCC == MFX_FOURCC_P010)
+        {
+            params.mfx.FrameInfo.Shift = 1;
+        }
+    }
 }
 
 } //MFX_VP9_Utility

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -574,9 +574,6 @@ mfxStatus VideoDECODEVP9_HW::DecodeHeader(VideoCORE* core, mfxBitstream* bs, mfx
     mfxStatus sts = MFX_VP9_Utility::DecodeHeader(core, bs, par);
     MFX_CHECK_STS(sts);
 
-    if (par->mfx.FrameInfo.FourCC == MFX_FOURCC_P010)
-        par->mfx.FrameInfo.Shift = 1;
-
     return sts;
 }
 
@@ -747,16 +744,6 @@ mfxStatus VideoDECODEVP9_HW::GetVideoParam(mfxVideoParam *par)
     par->mfx.FrameInfo.AspectRatioW = m_vInitPar.mfx.FrameInfo.AspectRatioW;
 
     return MFX_ERR_NONE;
-}
-
-void VideoDECODEVP9_HW::UpdateVideoParam(mfxVideoParam *par, VP9DecoderFrame const & frameInfo)
-{
-    VM_ASSERT(par);
-
-    MFX_VP9_Utility::FillVideoParam(m_core, frameInfo, par);
-
-    if (par->mfx.FrameInfo.FourCC == MFX_FOURCC_P010)
-        par->mfx.FrameInfo.Shift = 1;
 }
 
 mfxStatus VideoDECODEVP9_HW::GetDecodeStat(mfxDecodeStat *pStat)
@@ -1075,7 +1062,7 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1
     sts = DecodeFrameHeader(bs, frameInfo);
     MFX_CHECK_STS(sts);
 
-    UpdateVideoParam(&m_vPar, frameInfo);
+    MFX_VP9_Utility::FillVideoParam(m_core->GetPlatformType(), frameInfo, m_vPar);
 
     // check resize
     if (m_vPar.mfx.FrameInfo.Width > surface_work->Info.Width || m_vPar.mfx.FrameInfo.Height > surface_work->Info.Height)


### PR DESCRIPTION
DecodeHeader and UpdateVideoParam functions
set Shift to one for planar formats
but didn't clear it for packed formats (like Y410).

Issue: vsmgwl-10697
Test: vp9d_*_format_change./*