### PR TITLE
Update check for support mpeg2e on BXT

### DIFF
--- a/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
@@ -948,7 +948,7 @@ namespace MPEG2EncoderHW
         CHECK_CODEC_ID(par->mfx.CodecId, MFX_CODEC_MPEG2);
         MFX_CHECK (CheckExtendedBuffers(par) == MFX_ERR_NONE, MFX_ERR_INVALID_VIDEO_PARAM);
 
-        mfxStatus sts = core->IsGuidSupported(DXVA2_Intel_Encode_MPEG2, par);
+        mfxStatus sts = core->IsGuidSupported(DXVA2_Intel_Encode_MPEG2, par, true);
         MFX_CHECK_STS(sts);
 
         mfxExtCodingOption* ext = GetExtCodingOptions(par->ExtParam, par->NumExtParam);


### PR DESCRIPTION
IsGuidSupported has third parameter isEncoder need for windows only

Issue: MDP-52519