### PR TITLE
Remove QueryInputTiling functionality

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -562,21 +562,6 @@ mfxStatus ImplementationAvc::Query(
             return MFX_ERR_UNSUPPORTED;
         }
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
-        mfxU32 inputTiling = 0;
-        mfxU32 Width  = in->mfx.FrameInfo.Width == 0 ? 1920: in->mfx.FrameInfo.Width;
-        mfxU32 Height = in->mfx.FrameInfo.Height == 0 ? 1088: in->mfx.FrameInfo.Height;
-        // query input tiling support from the driver
-        sts = QueryInputTilingSupport(core, *in, inputTiling, MSDK_Private_Guid_Encode_AVC_Query, Width, Height);
-        if (sts != MFX_ERR_NONE)
-        {
-            extCaps->InputMemoryTiling = 0;
-            if (sts == MFX_ERR_UNSUPPORTED)
-                return sts; // driver don't support reporting of MB processing rate
-
-            return MFX_WRN_PARTIAL_ACCELERATION; // any other HW problem
-        }
-#endif
         return MFX_ERR_NONE;
     }
     else if (5 == queryMode)

--- a/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
@@ -684,14 +684,6 @@ namespace MfxHwH264Encode
         mfxU32 (&mbPerSec)[16],
         const mfxVideoParam * in);
 
-    mfxStatus QueryInputTilingSupport(
-        VideoCORE* core,
-        mfxVideoParam const & par,
-        mfxU32 &inputTiling,
-        GUID guid,
-        mfxU32 width = 1920,
-        mfxU32 height = 1088);
-
     mfxStatus QueryGuid(
         VideoCORE* core,
         GUID guid);

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_interface.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_interface.h
@@ -140,11 +140,6 @@ namespace MfxHwH264Encode
             mfxU32              (&mbPerSec)[16]) = 0;
 
         virtual
-        mfxStatus QueryInputTilingSupport(
-            mfxVideoParam const & /*par*/,
-            mfxU32               & inputTiling) { inputTiling = 0; return MFX_ERR_NONE; };
-
-        virtual
         mfxStatus QueryStatus(
             DdiTask & task,
             mfxU32    fieldId) = 0;

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
@@ -48,8 +48,6 @@ do {                                               \
     }                                              \
 } while (0)
 
-#define VAConfigAttribInputTiling  -1  // Inform the app what kind of tiling format supported by driver
-
 inline mfxStatus CheckAndDestroyVAbuffer(VADisplay display, VABufferID & buffer_id)
 {
     if (buffer_id != VA_INVALID_ID)
@@ -195,11 +193,6 @@ namespace MfxHwH264Encode
         mfxStatus QueryMbPerSec(
             mfxVideoParam const & par,
             mfxU32              (&mbPerSec)[16]);
-
-        virtual
-        mfxStatus QueryInputTilingSupport(
-            mfxVideoParam const & par,
-            mfxU32               &inputTiling);
 
         virtual
         mfxStatus QueryStatus(

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1428,24 +1428,6 @@ mfxStatus MfxHwH264Encode::QueryMbProcRate(VideoCORE* core, mfxVideoParam const 
     return pEncodeCaps->SetHWCaps<mfxU32>(guid, mbPerSec, 16);
 }
 
-mfxStatus MfxHwH264Encode::QueryInputTilingSupport(VideoCORE* core, mfxVideoParam const & par, mfxU32 &inputTiling, GUID guid, mfxU32 width,  mfxU32 height)
-{
-
-    std::unique_ptr<DriverEncoder> ddi;
-
-    ddi.reset(CreatePlatformH264Encoder(core));
-    if (ddi.get() == 0)
-        return Error(MFX_ERR_DEVICE_FAILED);
-
-    mfxStatus sts = ddi->CreateAuxilliaryDevice(core, guid, width, height, true);
-    MFX_CHECK_STS(sts);
-
-    sts = ddi->QueryInputTilingSupport(par, inputTiling);
-    MFX_CHECK_STS(sts);
-
-    return MFX_ERR_NONE;
-}
-
 mfxStatus MfxHwH264Encode::QueryGuid(VideoCORE* core, GUID guid)
 {
     std::unique_ptr<DriverEncoder> ddi;

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1915,55 +1915,6 @@ mfxStatus VAAPIEncoder::QueryMbPerSec(mfxVideoParam const & par, mfxU32 (&mbPerS
     return MFX_ERR_NONE;
 }
 
-mfxStatus VAAPIEncoder::QueryInputTilingSupport(mfxVideoParam const & par, mfxU32 & /* inputTiling */)
-{
-    VAConfigID config = VA_INVALID_ID;
-    VAEntrypoint targetEntrypoint = IsOn(par.mfx.LowPower) ? VAEntrypointEncSliceLP : VAEntrypointEncSlice;
-
-    VAConfigAttrib attrib[2];
-    attrib[0].type = VAConfigAttribRTFormat;
-    attrib[0].value = VA_RT_FORMAT_YUV420;
-    attrib[1].type = VAConfigAttribRateControl;
-    attrib[1].value = ConvertRateControlMFX2VAAPI(par.mfx.RateControlMethod);
-
-    VAStatus vaSts = vaCreateConfig(
-        m_vaDisplay,
-        ConvertProfileTypeMFX2VAAPI(par.mfx.CodecProfile),
-        targetEntrypoint,
-        attrib,
-        2,
-        &config);
-    MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-
-    VAProfile    profile;
-    VAEntrypoint entrypoint;
-    mfxI32       numAttribs, maxNumAttribs;
-    numAttribs = maxNumAttribs = vaMaxNumConfigAttributes(m_vaDisplay);
-
-    std::vector<VAConfigAttrib> attrs;
-    attrs.resize(maxNumAttribs);
-
-    vaSts = vaQueryConfigAttributes(m_vaDisplay, config, &profile, &entrypoint, Begin(attrs), &numAttribs);
-    MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-    MFX_CHECK_WITH_ASSERT((mfxU32)numAttribs < static_cast<mfxU32>(maxNumAttribs), MFX_ERR_UNDEFINED_BEHAVIOR);
-
-// VAConfigAttribInputTiling defined as -1 while attrs[i].type (type VAConfigAttribType) has values ranged from 0 to 38
-/*
-    if (entrypoint == targetEntrypoint)
-    {
-        for(mfxI32 i=0; i<numAttribs; i++)
-        {
-            if (attrs[i].type == VAConfigAttribInputTiling)
-                inputTiling = attrs[i].value;
-        }
-    }
-*/
-
-    vaDestroyConfig(m_vaDisplay, config);
-
-    return MFX_ERR_NONE;
-}
-
 mfxStatus VAAPIEncoder::QueryHWGUID(VideoCORE * /*core*/, GUID /*guid*/, bool /*isTemporal*/)
 {
     return MFX_ERR_UNSUPPORTED;

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -1283,26 +1283,11 @@ typedef struct {
     }Layer[8];
 } mfxExtAvcTemporalLayers;
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
-
-enum {
-    MFX_MEMORY_TILING_LINEAR = 0x0001,
-    MFX_MEMORY_TILING_Y      = 0x0002,
-    MFX_MEMORY_TILING_X      = 0x0004
-};
-
-#endif
-
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU32      MBPerSec;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
-    mfxU16      InputMemoryTiling;
-    mfxU16      reserved[57];
-#else
     mfxU16      reserved[58];
-#endif
 } mfxExtEncoderCapability;
 
 typedef struct {

--- a/api/mediasdk_structures/ts_struct_decl.h
+++ b/api/mediasdk_structures/ts_struct_decl.h
@@ -413,22 +413,10 @@ STRUCT(mfxExtAvcTemporalLayers,
     FIELD_S(mfxExtAvcTemporalLayers_Layer, Layer)
 )
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
-
-STRUCT(mfxExtEncoderCapability,
-    FIELD_S(mfxExtBuffer, Header)
-    FIELD_T(mfxU32, MBPerSec)
-    FIELD_T(mfxU16, InputMemoryTiling)
-)
-
-#else
-
 STRUCT(mfxExtEncoderCapability,
     FIELD_S(mfxExtBuffer, Header)
     FIELD_T(mfxU32, MBPerSec)
 )
-
-#endif
 
 STRUCT(mfxExtEncoderResetOption,
     FIELD_S(mfxExtBuffer, Header)


### PR DESCRIPTION
It was needed for Android release on legacy platforms
but master branch is targeted for BXT+ so there is no
need for this feature anymore

Signed-off-by: Dmitry Brazhkin <dmitry.brazhkin@intel.com>