### PR TITLE
hevcd: Fixed playback

### DIFF
--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -720,8 +720,8 @@ VACompBuffer* LinuxVideoAccelerator::GetCompBufferHW(int32_t type, int32_t size,
                     va_size         = sizeof(VASliceParameterBufferHEVCExtension);
                     va_num_elements = size/sizeof(VASliceParameterBufferHEVCExtension);
                 }
-                break;
 #endif
+                break;
             default:
                 va_size         = 0;
                 va_num_elements = 0;


### PR DESCRIPTION
When MFX_VERSION < 1027 va_size is set to zero and vaCreateBuffer return error

Signed-off-by: Ivan Losev <ivan.losev@intel.com>