### PR TITLE
hevce: replacing macro MFX_DESTROY_VABUFFER to function CheckAndDestroyVAbuffer

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
@@ -37,6 +37,8 @@
 #include <map>
 #include <algorithm>
 
+#define MFX_CHECK_WITH_ASSERT(EXPR, ERR) { assert(EXPR); MFX_CHECK(EXPR, ERR); }
+
 #define MFX_DESTROY_VABUFFER(vaBufferId, vaDisplay)    \
 do {                                               \
     if ( vaBufferId != VA_INVALID_ID)              \
@@ -45,6 +47,19 @@ do {                                               \
         vaBufferId = VA_INVALID_ID;                \
     }                                              \
 } while (0)
+
+inline mfxStatus CheckAndDestroyVAbuffer(VADisplay display, VABufferID & buffer_id)
+{
+    if (buffer_id != VA_INVALID_ID)
+    {
+        VAStatus vaSts = vaDestroyBuffer(display, buffer_id);
+        MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
+
+        buffer_id = VA_INVALID_ID;
+    }
+
+    return MFX_ERR_NONE;
+}
 
 namespace MfxHwH265Encode
 {

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -32,7 +32,6 @@
 #include "mfx_h265_encode_hw_utils.h"
 #include <unordered_map>
 
-#define MFX_CHECK_WITH_ASSERT(EXPR, ERR) { assert(EXPR); MFX_CHECK(EXPR, ERR); }
 //#define PARALLEL_BRC_support
 
 namespace MfxHwH265Encode
@@ -91,7 +90,8 @@ static mfxStatus SetROI(
     VAEncMiscParameterBufferROI *roi_Param;
     unsigned int roi_buffer_size = sizeof(VAEncMiscParameterBufferROI);
 
-    MFX_DESTROY_VABUFFER(roiParam_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, roiParam_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
             vaContextEncode,
@@ -158,7 +158,8 @@ static mfxStatus SetRollingIntraRefresh(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterRIR    *rir_param;
 
-    MFX_DESTROY_VABUFFER(rirBuf_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, rirBuf_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -225,8 +226,12 @@ VABufferID& VABuffersHandler::VABuffersNew(mfxU32 id, mfxU32 pool, mfxU32 num)
 
     begin = it; idBegin = idIt;
 
+    mfxStatus mfxSts;
+
     for (;it != end && *idIt == id; it++, idIt++)
-        MFX_DESTROY_VABUFFER(*it, m_vaDisplay);
+    {
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, *it);
+    }
 
     end = it; idEnd = idIt;
 
@@ -260,8 +265,12 @@ VABufferID& VABuffersHandler::VABuffersNew(mfxU32 id, mfxU32 pool, mfxU32 num)
 
 void VABuffersHandler::VABuffersDestroy()
 {
+    mfxStatus mfxSts;
+
     for (size_t i = 0; i < m_buf.size(); i++)
-        MFX_DESTROY_VABUFFER(m_buf[i], m_vaDisplay);
+    {
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_buf[i]);
+    }
     m_buf.resize(0);
     m_id.resize(0);
     m_pool.resize(1, 0);
@@ -278,8 +287,11 @@ void VABuffersHandler::VABuffersDestroyPool(mfxU32 pool)
 
     std::vector<mfxU32>::iterator idBegin = m_id.begin() + std::distance(m_buf.begin(), begin);
 
+    mfxStatus mfxSts;
     for (it = begin; it != end; it++)
-        MFX_DESTROY_VABUFFER(*it, m_vaDisplay);
+    {
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, *it);
+    }
 
     m_buf.erase(begin, end);
     m_id.erase(idBegin, idBegin + poolSize);
@@ -317,7 +329,8 @@ mfxStatus SetHRD(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterHRD *hrd_param;
 
-    MFX_DESTROY_VABUFFER(hrdBuf_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, hrdBuf_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -365,7 +378,8 @@ mfxStatus SetRateControl(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterRateControl *rate_param;
 
-    MFX_DESTROY_VABUFFER(rateParamBuf_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, rateParamBuf_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -418,7 +432,8 @@ mfxStatus SetFrameRate(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterFrameRate *frameRate_param;
 
-    MFX_DESTROY_VABUFFER(frameRateBuf_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, frameRateBuf_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -451,7 +466,8 @@ mfxStatus SetMaxSliceSize(
     VAContextID  vaContextEncode,
     VABufferID & maxSliceSizeBuf_id)
 {
-    MFX_DESTROY_VABUFFER(maxSliceSizeBuf_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, maxSliceSizeBuf_id);
+    MFX_CHECK_STS(mfxSts);
 
     VAStatus vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -490,7 +506,8 @@ mfxStatus SetQualityLevelParams(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterBufferQualityLevel *quality_param;
 
-    MFX_DESTROY_VABUFFER(qualityParams_id, vaDisplay);
+    mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, qualityParams_id);
+    MFX_CHECK_STS(mfxSts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,


### PR DESCRIPTION
It is need to align code according AVC encoder.
CheckAndDestroyVAbuffer is also set invalid id to buffer id, so we need to pull this assignment out of the wrapper and do on this level (because if subsequent call to vaCreateBuffer fails, we will have valid ID for deleted buffer - unwelcome situation).