### PR TITLE
[VP9D] Reopen Lock reference frames before UpdateRefList

### DIFF
--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
@@ -37,6 +37,8 @@
 
 namespace UMC_VP9_DECODER { class Packer; }
 
+class ReferenceFrameStorage;
+
 class VideoDECODEVP9_HW : public VideoDECODE, public MfxCriticalErrorHandler
 {
 public:
@@ -98,6 +100,7 @@ private:
     std::unique_ptr<mfx_UMC_FrameAllocator> m_FrameAllocator;
 
     std::unique_ptr<UMC_VP9_DECODER::Packer>  m_Packer;
+    std::unique_ptr<ReferenceFrameStorage> m_refFramesStorage;
 
     mfxFrameAllocRequest     m_request;
     mfxFrameAllocResponse    m_response;

--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -401,6 +401,12 @@ namespace MFX_VPX_Utility
         p_request->NumFrameMin = p_params->mfx.CodecId == MFX_CODEC_VP8 ? mfxU16(4) : mfxU16(8);
 
         p_request->NumFrameMin += p_params->AsyncDepth ? p_params->AsyncDepth : MFX_AUTO_ASYNC_DEPTH_VALUE;
+
+        // Increase minimum number by one
+        // E.g., if async depth 1,then one decoded frame plus eight references total nine frames are locked
+        // add one more frame so client code will have at least one input surface to call DecodeAsync function
+        p_request->NumFrameMin += 1;
+
         p_request->NumFrameSuggested = p_request->NumFrameMin;
 
         if (p_params->IOPattern & MFX_IOPATTERN_OUT_SYSTEM_MEMORY)


### PR DESCRIPTION
Make reference frames are locked (increase reference counter)
before UpdateRefList.

UpdateRefList prepares the references for the next frame and
removes frames from the current list, when it removes it calls
DecreaseRefCount function.
If frame refCount is zero Free function is called
this function clears Locked member and the reference frame
could be used as new target frame
while still in use by HW decoder.

Issue: MDP-52110
Test: Linux/ICL