### PR TITLE
[VP9e] Fixed buffer creation for segmentation map

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -280,16 +280,17 @@ namespace MfxHwVP9Encode
         Zero(segPar);
 
         mfxFrameInfo const & dstFi = task.m_pSegmentMap->pSurface->Info;
-        mfxU32 dstW = dstFi.Width;
+        // driver seg map is always in 16x16 blocks because of HW limitation
+        const mfxU16 dstBlockSize = 16;
+        mfxU32 dstW = dstFi.CropW >> 4; // width should be in MBs
         mfxU32 dstH = dstFi.Height;
-        mfxU32 dstPitch = segMap.Pitch;
+        mfxU32 dstPitch = dstFi.Width;
 
         mfxFrameInfo const & srcFi = task.m_pRawFrame->pSurface->Info;
         mfxU16 srcBlockSize = MapIdToBlockSize(seg.SegmentIdBlockSize);
         mfxU32 srcW = (srcFi.Width + srcBlockSize - 1)  / srcBlockSize;
         mfxU32 srcH = (srcFi.Height + srcBlockSize - 1) / srcBlockSize;
-        // driver seg map is always in 16x16 blocks because of HW limitation
-        const mfxU16 dstBlockSize = 16;
+
         mfxU16 ratio = srcBlockSize / dstBlockSize;
 
         if (seg.NumSegmentIdAlloc < srcW * srcH || seg.SegmentId == 0 ||
@@ -928,9 +929,10 @@ mfxStatus VAAPIEncoder::QueryCompBufferInfo(D3DDDIFORMAT type, mfxFrameAllocRequ
     }
     else if (type == D3DDDIFMT_INTELENCODE_MBSEGMENTMAP)
     {
+        // driver seg map is always in 16x16 blocks because of HW limitation
         request.Info.FourCC = MFX_FOURCC_VP9_SEGMAP;
-        request.Info.Width  = AlignValue(frameWidth >> 5, 64);
-        request.Info.Height = frameHeight >> 5;//VDENC 32x32 block size ??
+        request.Info.Width  = AlignValue(frameWidth >> 4, 64);
+        request.Info.Height = frameHeight >> 4;
     }
 
     request.AllocId = m_vaContextEncode;
@@ -1078,6 +1080,15 @@ mfxStatus VAAPIEncoder::Execute(
             // 4. Segmentation map
 
             // segmentation map buffer is already allocated and filled. Need just to attach it
+            mfxU32 segCodedBuffer = task.m_pSegmentMap->idInPool;
+            if( segCodedBuffer < m_segMapQueue.size())
+            {
+                m_segMapBufferId = m_segMapQueue[segCodedBuffer].surface;
+            }
+            else
+            {
+                return MFX_ERR_UNDEFINED_BEHAVIOR;
+            }
             configBuffers.push_back(m_segMapBufferId);
 
             // 5. Per-segment parameters
@@ -1129,7 +1140,7 @@ mfxStatus VAAPIEncoder::Execute(
 
         // 8. hrd parameters
         configBuffers.push_back(m_hrdBufferId);
-        
+
         // 9. temporal layers
         if (m_video.m_numLayers)
             configBuffers.push_back(m_tempLayersBufferId);

--- a/_studio/shared/src/libmfx_allocator_vaapi.cpp
+++ b/_studio/shared/src/libmfx_allocator_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -278,12 +278,13 @@ mfxDefaultAllocatorVAAPI::AllocFramesHW(
         else
         {
             VAContextID context_id = request->AllocId;
-            mfxU32 codedbuf_size;
+            mfxU32 codedbuf_size, codedbuf_num;
             VABufferType codedbuf_type;
 
             if (fourcc == MFX_FOURCC_VP8_SEGMAP)
             {
-                codedbuf_size = request->Info.Width * request->Info.Height;
+                codedbuf_size = request->Info.Width;
+                codedbuf_num = request->Info.Height;
                 codedbuf_type = (VABufferType)VAEncMacroblockMapBufferType;
             }
             else
@@ -291,6 +292,7 @@ mfxDefaultAllocatorVAAPI::AllocFramesHW(
                 int width32 = 32 * ((request->Info.Width + 31) >> 5);
                 int height32 = 32 * ((request->Info.Height + 31) >> 5);
                 codedbuf_size = static_cast<mfxU32>((width32 * height32) * 400LL / (16 * 16));
+                codedbuf_num = 1;
 
                 codedbuf_type = VAEncCodedBufferType;
             }
@@ -303,7 +305,7 @@ mfxDefaultAllocatorVAAPI::AllocFramesHW(
                                       context_id,
                                       codedbuf_type,
                                       codedbuf_size,
-                                      1,
+                                      codedbuf_num,
                                       NULL,
                                       &coded_buf);
                 mfx_res = VA_TO_MFX_STATUS(va_res);

--- a/samples/sample_common/src/vaapi_allocator.cpp
+++ b/samples/sample_common/src/vaapi_allocator.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2018, Intel Corporation
+Copyright (c) 2005-2019, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -254,7 +254,7 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
         else
         {
             VAContextID context_id = request->AllocId;
-            int codedbuf_size;
+            int codedbuf_size, codedbuf_num;
 
             int width32 = 32 * ((request->Info.Width + 31) >> 5);
             int height32 = 32 * ((request->Info.Height + 31) >> 5);
@@ -262,12 +262,14 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
             VABufferType codedbuf_type;
             if (fourcc == MFX_FOURCC_VP8_SEGMAP)
             {
-                codedbuf_size = request->Info.Width * request->Info.Height;
+                codedbuf_size = request->Info.Width;
+                codedbuf_num = request->Info.Height;
                 codedbuf_type = (VABufferType)VAEncMacroblockMapBufferType;
             }
             else
             {
                 codedbuf_size = static_cast<int>((width32 * height32) * 400LL / (16 * 16));
+                codedbuf_num = 1;
                 codedbuf_type = VAEncCodedBufferType;
             }
 
@@ -279,7 +281,7 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
                                       context_id,
                                       codedbuf_type,
                                       codedbuf_size,
-                                      1,
+                                      codedbuf_num,
                                       NULL,
                                       &coded_buf);
                 mfx_res = va_to_mfx_status(va_res);


### PR DESCRIPTION
Buffer for segmentation map should be created as 2D buffer with picture width/
height in MB. Picture width has to be with 64 bytes alignment.