### PR TITLE
[VP9e] Fixed buffer creation for segmentation map

### DIFF
--- a/_studio/shared/src/libmfx_allocator_vaapi.cpp
+++ b/_studio/shared/src/libmfx_allocator_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -358,19 +358,21 @@ mfxDefaultAllocatorVAAPI::AllocFramesHW(
         else
         {
             VAContextID context_id = request->AllocId;
-            mfxU32 codedbuf_size;
+            mfxU32 codedbuf_size, codedbuf_num;
             VABufferType codedbuf_type;
 
             if (fourcc == MFX_FOURCC_VP8_SEGMAP)
             {
-                codedbuf_size = request->Info.Width * request->Info.Height;
-                codedbuf_type = (VABufferType)VAEncMacroblockMapBufferType;
+                codedbuf_size = request->Info.Width;
+                codedbuf_num = request->Info.Height;
+                codedbuf_type = VAEncMacroblockMapBufferType;
             }
             else
             {
                 int width32 = 32 * ((request->Info.Width + 31) >> 5);
                 int height32 = 32 * ((request->Info.Height + 31) >> 5);
                 codedbuf_size = static_cast<mfxU32>((width32 * height32) * 400LL / (16 * 16));
+                codedbuf_num = 1;
 
                 codedbuf_type = VAEncCodedBufferType;
             }
@@ -383,7 +385,7 @@ mfxDefaultAllocatorVAAPI::AllocFramesHW(
                                       context_id,
                                       codedbuf_type,
                                       codedbuf_size,
-                                      1,
+                                      codedbuf_num,
                                       NULL,
                                       &coded_buf);
                 mfx_res = VA_TO_MFX_STATUS(va_res);

--- a/samples/sample_common/src/vaapi_allocator.cpp
+++ b/samples/sample_common/src/vaapi_allocator.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2018, Intel Corporation
+Copyright (c) 2005-2019, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -254,20 +254,21 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
         else
         {
             VAContextID context_id = request->AllocId;
-            int codedbuf_size;
-
-            int width32 = 32 * ((request->Info.Width + 31) >> 5);
-            int height32 = 32 * ((request->Info.Height + 31) >> 5);
+            int codedbuf_size, codedbuf_num;
 
             VABufferType codedbuf_type;
             if (fourcc == MFX_FOURCC_VP8_SEGMAP)
             {
-                codedbuf_size = request->Info.Width * request->Info.Height;
-                codedbuf_type = (VABufferType)VAEncMacroblockMapBufferType;
+                codedbuf_size = request->Info.Width;
+                codedbuf_num = request->Info.Height;
+                codedbuf_type = VAEncMacroblockMapBufferType;
             }
             else
             {
+                int width32 = 32 * ((request->Info.Width + 31) >> 5);
+                int height32 = 32 * ((request->Info.Height + 31) >> 5);
                 codedbuf_size = static_cast<int>((width32 * height32) * 400LL / (16 * 16));
+                codedbuf_num = 1;
                 codedbuf_type = VAEncCodedBufferType;
             }
 
@@ -279,7 +280,7 @@ mfxStatus vaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrame
                                       context_id,
                                       codedbuf_type,
                                       codedbuf_size,
-                                      1,
+                                      codedbuf_num,
                                       NULL,
                                       &coded_buf);
                 mfx_res = va_to_mfx_status(va_res);


### PR DESCRIPTION
Buffer for segmentation map should be created as 2D buffer with picture width/
height in MB. Picture width has to be with 64 bytes alignment.