### PR TITLE
h264e: enable QVBR rate control

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -2408,6 +2408,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
        par.mfx.RateControlMethod != 0 &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_CBR &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_VBR &&
+       par.mfx.RateControlMethod != MFX_RATECONTROL_QVBR &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_CQP &&
        par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ &&
        !bRateControlLA(par.mfx.RateControlMethod))

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -61,6 +61,9 @@ uint32_t ConvertRateControlMFX2VAAPI(mfxU8 rateControl)
     case MFX_RATECONTROL_CBR:  return VA_RC_CBR;
     case MFX_RATECONTROL_VBR:  return VA_RC_VBR;
     case MFX_RATECONTROL_AVBR: return VA_RC_VBR;
+#ifdef MFX_ENABLE_QVBR
+    case MFX_RATECONTROL_QVBR: return VA_RC_QVBR;
+#endif
     case MFX_RATECONTROL_CQP:  return VA_RC_CQP;
     case MFX_RATECONTROL_ICQ:  return VA_RC_ICQ;
     default: assert(!"Unsupported RateControl"); return 0;
@@ -174,6 +177,7 @@ mfxStatus SetRateControl(
     VAStatus vaSts;
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterRateControl *rate_param;
+    mfxExtCodingOption3 const & extOpt3 = GetExtBufferRef(par);
 
     mfxStatus mfxSts = CheckAndDestroyVAbuffer(vaDisplay, rateParamBuf_id);
     MFX_CHECK_STS(mfxSts);
@@ -203,21 +207,22 @@ mfxStatus SetRateControl(
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ)
         rate_param->ICQ_quality_factor = par.mfx.ICQQuality;
+#ifdef MFX_ENABLE_QVBR
+    else if (par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR)
+        rate_param->quality_factor = extOpt3.QVBRQuality;
+#endif
 
     if(par.calcParam.maxKbps)
         rate_param->target_percentage = (unsigned int)(100.0 * (mfxF64)par.calcParam.targetKbps / (mfxF64)par.calcParam.maxKbps);
 
     // Activate frame tolerance sliding window mode
-    mfxExtCodingOption3 const & extOpt3 = GetExtBufferRef(par);
     if (extOpt3.WinBRCSize && caps.FrameSizeToleranceSupport)
     {
         rate_param->rc_flags.bits.frame_tolerance_mode = eFrameSizeTolerance_Low;
     }
 
-/*
- * MBBRC control
- * Control VA_RC_MB 0: default, 1: enable, 2: disable, other: reserved
- */
+    //  MBBRC control
+    // Control VA_RC_MB 0: default, 1: enable, 2: disable, other: reserved
     rate_param->rc_flags.bits.mb_rate_control = mbbrc & 0xf;
     rate_param->rc_flags.bits.reset = isBrcResetRequired;
 
@@ -1402,6 +1407,10 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
         (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_VCM) ? 1 : 0; //Video conference mode
     m_caps.ICQBRCSupport =
         (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_ICQ) ? 1 : 0;
+#ifdef MFX_ENABLE_QVBR
+    m_caps.QVBRBRCSupport =
+        (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_QVBR) ? 1 : 0;
+#endif
     m_caps.TrelisQuantization =
         (attrs[idx_map[VAConfigAttribEncQuantization]].value & (~VA_ATTRIB_NOT_SUPPORTED)) ? 1 : 0;
     m_caps.vaTrellisQuantization =

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -34,13 +34,13 @@
 #define MFX_ENABLE_VPP_ROTATION
 #define MFX_ENABLE_VPP_VIDEO_SIGNAL
 
-
-
-
-#if defined(LINUX32) || defined(LINUX64)
-    #undef  MFX_VA_LINUX
-    #define MFX_VA_LINUX
-#endif // #if defined(LINUX32) || defined(LINUX64)
+#ifdef MFX_VA
+    #if defined(LINUX32) || defined(LINUX64)
+        #include <va/va_version.h>
+        #undef  MFX_VA_LINUX
+        #define MFX_VA_LINUX
+    #endif
+#endif
 
 #if !defined(LINUX_TARGET_PLATFORM) || defined(LINUX_TARGET_PLATFORM_BDW) || defined(LINUX_TARGET_PLATFORM_CFL) || defined(LINUX_TARGET_PLATFORM_BXT)
     #if !defined(ANDROID)
@@ -129,6 +129,12 @@
 // after inclusion of respective features into official API
 #if MFX_VERSION >= MFX_VERSION_NEXT
     #define MFX_ENABLE_VPP_RUNTIME_HSBC
+#endif
+
+#if defined(MFX_VA_LINUX)
+    #if VA_CHECK_VERSION(1,3,0)
+        #define MFX_ENABLE_QVBR
+    #endif
 #endif
 
 #endif // _MFX_CONFIG_H_


### PR DESCRIPTION
Requires: intel/media-driver#319
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
(cherry picked from commit 7a1a3061d5933f30413c1b2d91f5b09a76bf016f)