### PR TITLE
[test_monitor] intel_gt(dev_id) function fixed

### DIFF
--- a/samples/metrics_monitor/test/cttmetrics_gtest.cpp
+++ b/samples/metrics_monitor/test/cttmetrics_gtest.cpp
@@ -79,10 +79,10 @@ void getAndCheckAvailableMetrics(unsigned int* count, cttMetric* out_metric_ids)
     EXPECT_EQ(CTT_ERR_NONE, CTTMetrics_GetMetricCount(count));
     EXPECT_EQ(CTT_ERR_NONE, CTTMetrics_GetMetricInfo(*count, out_metric_ids));
 
-    if (num_slices > 1)
+    if (num_slices > 1 && !device_info->is_broxton)
         EXPECT_EQ(*count, (unsigned int)CTT_MAX_METRIC_COUNT);
     else
-        //GT2 haven't VDBOX2
+        //GT2 systems, Broxton haven't VDBOX2
         EXPECT_EQ(*count, (unsigned int)(CTT_MAX_METRIC_COUNT - 1));
 
     CTTMetrics_Close();

--- a/samples/metrics_monitor/test/device_info.h
+++ b/samples/metrics_monitor/test/device_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Intel Corporation.  All rights reserved.
+ * Copyright (C) 2017-2019 Intel Corporation.  All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@
 
 struct intel_device_info {
     unsigned gen;
+    unsigned gt; /* 0 if unknown */
     bool is_mobile : 1;
     bool is_whitney : 1;
     bool is_almador : 1;
@@ -63,6 +64,7 @@ struct intel_device_info {
     bool is_geminilake : 1;
     bool is_coffeelake : 1;
     bool is_cannonlake : 1;
+    bool is_icelake : 1;
     const char *codename;
 };
 
@@ -72,6 +74,7 @@ const struct intel_device_info intel_generic_info = {
 
 const struct intel_device_info intel_i810_info = {
     .gen = BIT(0),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = true,
     .is_almador = false,
@@ -102,11 +105,13 @@ const struct intel_device_info intel_i810_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "solano"
 };
 
 const struct intel_device_info intel_i815_info = {
     .gen = BIT(0),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = true,
     .is_almador = false,
@@ -137,11 +142,13 @@ const struct intel_device_info intel_i815_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "whitney"
 };
 
 const struct intel_device_info intel_i830_info = {
     .gen = BIT(1),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = true,
@@ -172,11 +179,13 @@ const struct intel_device_info intel_i830_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "almador"
 };
 
 const struct intel_device_info intel_i845_info = {
     .gen = BIT(1),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -207,11 +216,13 @@ const struct intel_device_info intel_i845_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "brookdale"
 };
 
 const struct intel_device_info intel_i855_info = {
     .gen = BIT(1),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -242,11 +253,13 @@ const struct intel_device_info intel_i855_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "montara"
 };
 
 const struct intel_device_info intel_i865_info = {
     .gen = BIT(1),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -277,11 +290,13 @@ const struct intel_device_info intel_i865_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "spingdale"
 };
 
 const struct intel_device_info intel_i915_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -312,11 +327,13 @@ const struct intel_device_info intel_i915_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "grantsdale"
 };
 
 const struct intel_device_info intel_i915m_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -347,11 +364,13 @@ const struct intel_device_info intel_i915m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "alviso"
 };
 
 const struct intel_device_info intel_i945_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -382,11 +401,13 @@ const struct intel_device_info intel_i945_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "lakeport"
 };
 
 const struct intel_device_info intel_i945m_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -417,11 +438,13 @@ const struct intel_device_info intel_i945m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "calistoga"
 };
 
 const struct intel_device_info intel_g33_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -452,11 +475,13 @@ const struct intel_device_info intel_g33_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "bearlake"
 };
 
 const struct intel_device_info intel_pineview_info = {
     .gen = BIT(2),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -487,11 +512,13 @@ const struct intel_device_info intel_pineview_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "pineview"
 };
 
 const struct intel_device_info intel_i965_info = {
     .gen = BIT(3),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -522,11 +549,13 @@ const struct intel_device_info intel_i965_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "broadwater"
 };
 
 const struct intel_device_info intel_i965m_info = {
     .gen = BIT(3),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -557,11 +586,13 @@ const struct intel_device_info intel_i965m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "crestline"
 };
 
 const struct intel_device_info intel_g45_info = {
     .gen = BIT(3),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -592,11 +623,13 @@ const struct intel_device_info intel_g45_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "eaglelake"
 };
 
 const struct intel_device_info intel_gm45_info = {
     .gen = BIT(3),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -627,11 +660,13 @@ const struct intel_device_info intel_gm45_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "cantiga"
 };
 
 const struct intel_device_info intel_ironlake_info = {
     .gen = BIT(4),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -662,11 +697,13 @@ const struct intel_device_info intel_ironlake_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "ironlake" /* clarkdale? */
 };
 
 const struct intel_device_info intel_ironlake_m_info = {
     .gen = BIT(4),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -697,11 +734,13 @@ const struct intel_device_info intel_ironlake_m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "arrandale"
 };
 
 const struct intel_device_info intel_sandybridge_info = {
     .gen = BIT(5),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -732,11 +771,13 @@ const struct intel_device_info intel_sandybridge_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "sandybridge"
 };
 
 const struct intel_device_info intel_sandybridge_m_info = {
     .gen = BIT(5),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -767,11 +808,13 @@ const struct intel_device_info intel_sandybridge_m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "sandybridge"
 };
 
 const struct intel_device_info intel_ivybridge_info = {
     .gen = BIT(6),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -802,11 +845,13 @@ const struct intel_device_info intel_ivybridge_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "ivybridge"
 };
 
 const struct intel_device_info intel_ivybridge_m_info = {
     .gen = BIT(6),
+    .gt = 0,
     .is_mobile = true,
     .is_whitney = false,
     .is_almador = false,
@@ -837,11 +882,13 @@ const struct intel_device_info intel_ivybridge_m_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "ivybridge"
 };
 
 const struct intel_device_info intel_valleyview_info = {
     .gen = BIT(6),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -872,11 +919,13 @@ const struct intel_device_info intel_valleyview_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "valleyview"
 };
 
-const struct intel_device_info intel_haswell_info = {
+const struct intel_device_info intel_haswell_gt1_info = {
     .gen = BIT(6),
+    .gt = 1,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -907,11 +956,87 @@ const struct intel_device_info intel_haswell_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "haswell"
 };
 
-const struct intel_device_info intel_broadwell_info = {
+const struct intel_device_info intel_haswell_gt2_info = {
+    .gen = BIT(6),
+    .gt = 2,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = true,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "haswell"
+};
+
+const struct intel_device_info intel_haswell_gt3_info = {
+    .gen = BIT(6),
+    .gt = 3,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = true,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "haswell"
+};
+
+const struct intel_device_info intel_broadwell_gt1_info = {
     .gen = BIT(7),
+    .gt = 1,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -942,11 +1067,124 @@ const struct intel_device_info intel_broadwell_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "broadwell"
+};
+
+const struct intel_device_info intel_broadwell_gt2_info = {
+    .gen = BIT(7),
+    .gt = 2,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = true,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "broadwell"
+};
+
+const struct intel_device_info intel_broadwell_gt3_info = {
+    .gen = BIT(7),
+    .gt = 3,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = true,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "broadwell"
+};
+
+const struct intel_device_info intel_broadwell_unknown_info = {
+    .gen = BIT(7),
+    .gt = 0,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = true,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "broadwell"
 };
 
 const struct intel_device_info intel_cherryview_info = {
     .gen = BIT(7),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -977,11 +1215,13 @@ const struct intel_device_info intel_cherryview_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "cherryview"
 };
 
-const struct intel_device_info intel_skylake_info = {
+const struct intel_device_info intel_skylake_gt1_info = {
     .gen = BIT(8),
+    .gt = 1,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1012,11 +1252,124 @@ const struct intel_device_info intel_skylake_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "skylake"
+};
+
+const struct intel_device_info intel_skylake_gt2_info = {
+    .gen = BIT(8),
+    .gt = 2,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = true,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "skylake"
+};
+
+const struct intel_device_info intel_skylake_gt3_info = {
+    .gen = BIT(8),
+    .gt = 3,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = true,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "skylake"
+};
+
+const struct intel_device_info intel_skylake_gt4_info = {
+    .gen = BIT(8),
+    .gt = 4,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = true,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "skylake"
 };
 
 const struct intel_device_info intel_broxton_info = {
     .gen = BIT(8),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1047,11 +1400,13 @@ const struct intel_device_info intel_broxton_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "broxton"
 };
 
-const struct intel_device_info intel_kabylake_info = {
+const struct intel_device_info intel_kabylake_gt1_info = {
     .gen = BIT(8),
+    .gt = 1,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1082,11 +1437,124 @@ const struct intel_device_info intel_kabylake_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "kabylake"
+};
+
+const struct intel_device_info intel_kabylake_gt2_info = {
+    .gen = BIT(8),
+    .gt = 2,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = true,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "kabylake"
+};
+
+const struct intel_device_info intel_kabylake_gt3_info = {
+    .gen = BIT(8),
+    .gt = 3,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = true,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "kabylake"
+};
+
+const struct intel_device_info intel_kabylake_gt4_info = {
+    .gen = BIT(8),
+    .gt = 4,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = true,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "kabylake"
 };
 
 const struct intel_device_info intel_geminilake_info = {
     .gen = BIT(8),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1117,11 +1585,13 @@ const struct intel_device_info intel_geminilake_info = {
     .is_geminilake = true,
     .is_coffeelake = false,
     .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "geminilake"
 };
 
-const struct intel_device_info intel_coffeelake_info = {
+const struct intel_device_info intel_coffeelake_gt1_info = {
     .gen = BIT(8),
+    .gt = 1,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1152,11 +1622,87 @@ const struct intel_device_info intel_coffeelake_info = {
     .is_geminilake = false,
     .is_coffeelake = true,
     .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "coffeelake"
+};
+
+const struct intel_device_info intel_coffeelake_gt2_info = {
+    .gen = BIT(8),
+    .gt = 2,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = true,
+    .is_cannonlake = false,
+    .is_icelake = false,
+    .codename = "coffeelake"
+};
+
+const struct intel_device_info intel_coffeelake_gt3_info = {
+    .gen = BIT(8),
+    .gt = 3,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = true,
+    .is_cannonlake = false,
+    .is_icelake = false,
     .codename = "coffeelake"
 };
 
 const struct intel_device_info intel_cannonlake_info = {
     .gen = BIT(9),
+    .gt = 0,
     .is_mobile = false,
     .is_whitney = false,
     .is_almador = false,
@@ -1187,7 +1733,45 @@ const struct intel_device_info intel_cannonlake_info = {
     .is_geminilake = false,
     .is_coffeelake = false,
     .is_cannonlake = true,
+    .is_icelake = false,
     .codename = "cannonlake"
+};
+
+const struct intel_device_info intel_icelake_info = {
+    .gen = BIT(10),
+    .gt = 0,
+    .is_mobile = false,
+    .is_whitney = false,
+    .is_almador = false,
+    .is_brookdale = false,
+    .is_montara = false,
+    .is_springdale = false,
+    .is_grantsdale = false,
+    .is_alviso = false,
+    .is_lakeport = false,
+    .is_calistoga = false,
+    .is_bearlake = false,
+    .is_pineview = false,
+    .is_broadwater = false,
+    .is_crestline = false,
+    .is_eaglelake = false,
+    .is_cantiga = false,
+    .is_ironlake = false,
+    .is_arrandale = false,
+    .is_sandybridge = false,
+    .is_ivybridge = false,
+    .is_valleyview = false,
+    .is_haswell = false,
+    .is_broadwell = false,
+    .is_cherryview = false,
+    .is_skylake = false,
+    .is_broxton = false,
+    .is_kabylake = false,
+    .is_geminilake = false,
+    .is_coffeelake = false,
+    .is_cannonlake = false,
+    .is_icelake = true,
+    .codename = "icelake"
 };
 
 const struct pci_id_match intel_device_match [] = {
@@ -1222,25 +1806,47 @@ const struct pci_id_match intel_device_match [] = {
     INTEL_IVB_D_IDS(&intel_ivybridge_info),
     INTEL_IVB_M_IDS(&intel_ivybridge_m_info),
 
-    INTEL_HSW_IDS(&intel_haswell_info),
+    INTEL_HSW_GT1_IDS(&intel_haswell_gt1_info),
+    INTEL_HSW_GT2_IDS(&intel_haswell_gt2_info),
+    INTEL_HSW_GT3_IDS(&intel_haswell_gt3_info),
 
     INTEL_VLV_IDS(&intel_valleyview_info),
 
-    INTEL_BDW_IDS(&intel_broadwell_info),
+    INTEL_BDW_GT1_IDS(&intel_broadwell_gt1_info),
+    INTEL_BDW_GT2_IDS(&intel_broadwell_gt2_info),
+    INTEL_BDW_GT3_IDS(&intel_broadwell_gt3_info),
+    INTEL_BDW_RSVD_IDS(&intel_broadwell_unknown_info),
 
     INTEL_CHV_IDS(&intel_cherryview_info),
 
-    INTEL_SKL_IDS(&intel_skylake_info),
+    INTEL_SKL_GT1_IDS(&intel_skylake_gt1_info),
+    INTEL_SKL_GT2_IDS(&intel_skylake_gt2_info),
+    INTEL_SKL_GT3_IDS(&intel_skylake_gt3_info),
+    INTEL_SKL_GT4_IDS(&intel_skylake_gt4_info),
 
     INTEL_BXT_IDS(&intel_broxton_info),
 
-    INTEL_KBL_IDS(&intel_kabylake_info),
+    INTEL_KBL_GT1_IDS(&intel_kabylake_gt1_info),
+    INTEL_KBL_GT2_IDS(&intel_kabylake_gt2_info),
+    INTEL_KBL_GT3_IDS(&intel_kabylake_gt3_info),
+    INTEL_KBL_GT4_IDS(&intel_kabylake_gt4_info),
+    INTEL_AML_KBL_GT2_IDS(&intel_kabylake_gt2_info),
 
     INTEL_GLK_IDS(&intel_geminilake_info),
 
-    INTEL_CFL_IDS(&intel_coffeelake_info),
+    INTEL_CFL_S_GT1_IDS(&intel_coffeelake_gt1_info),
+    INTEL_CFL_S_GT2_IDS(&intel_coffeelake_gt2_info),
+    INTEL_CFL_H_GT2_IDS(&intel_coffeelake_gt2_info),
+    INTEL_CFL_U_GT2_IDS(&intel_coffeelake_gt2_info),
+    INTEL_CFL_U_GT3_IDS(&intel_coffeelake_gt3_info),
+    INTEL_WHL_U_GT1_IDS(&intel_coffeelake_gt1_info),
+    INTEL_WHL_U_GT2_IDS(&intel_coffeelake_gt2_info),
+    INTEL_WHL_U_GT3_IDS(&intel_coffeelake_gt3_info),
+    INTEL_AML_CFL_GT2_IDS(&intel_coffeelake_gt2_info),
 
     INTEL_CNL_IDS(&intel_cannonlake_info),
+
+    INTEL_ICL_11_IDS(&intel_icelake_info),
 
     INTEL_VGA_DEVICE(PCI_MATCH_ANY, &intel_generic_info),
 };

--- a/samples/metrics_monitor/test/i915_pciids.h
+++ b/samples/metrics_monitor/test/i915_pciids.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Intel Corporation.  All rights reserved.
+ * Copyright (C) 2017-2019 Intel Corporation.  All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -122,91 +122,124 @@
 #define INTEL_IRONLAKE_M_IDS(info) \
     INTEL_VGA_DEVICE(0x0046, info)
 
-#define INTEL_SNB_D_IDS(info) \
+#define INTEL_SNB_D_GT1_IDS(info) \
     INTEL_VGA_DEVICE(0x0102, info), \
-    INTEL_VGA_DEVICE(0x0112, info), \
-    INTEL_VGA_DEVICE(0x0122, info), \
     INTEL_VGA_DEVICE(0x010A, info)
 
-#define INTEL_SNB_M_IDS(info) \
-    INTEL_VGA_DEVICE(0x0106, info), \
+#define INTEL_SNB_D_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x0112, info), \
+    INTEL_VGA_DEVICE(0x0122, info)
+
+#define INTEL_SNB_D_IDS(info) \
+    INTEL_SNB_D_GT1_IDS(info), \
+    INTEL_SNB_D_GT2_IDS(info)
+
+#define INTEL_SNB_M_GT1_IDS(info) \
+    INTEL_VGA_DEVICE(0x0106, info)
+
+#define INTEL_SNB_M_GT2_IDS(info) \
     INTEL_VGA_DEVICE(0x0116, info), \
     INTEL_VGA_DEVICE(0x0126, info)
 
+#define INTEL_SNB_M_IDS(info) \
+    INTEL_SNB_M_GT1_IDS(info), \
+    INTEL_SNB_M_GT2_IDS(info)
+
+#define INTEL_IVB_M_GT1_IDS(info) \
+    INTEL_VGA_DEVICE(0x0156, info) /* GT1 mobile */
+
+#define INTEL_IVB_M_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x0166, info) /* GT2 mobile */
+
 #define INTEL_IVB_M_IDS(info) \
-    INTEL_VGA_DEVICE(0x0156, info), /* GT1 mobile */ \
-    INTEL_VGA_DEVICE(0x0166, info)  /* GT2 mobile */
+    INTEL_IVB_M_GT1_IDS(info), \
+    INTEL_IVB_M_GT2_IDS(info)
+
+#define INTEL_IVB_D_GT1_IDS(info) \
+    INTEL_VGA_DEVICE(0x0152, info), /* GT1 desktop */ \
+    INTEL_VGA_DEVICE(0x015a, info)  /* GT1 server */
+
+#define INTEL_IVB_D_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x0162, info), /* GT2 desktop */ \
+    INTEL_VGA_DEVICE(0x016a, info)  /* GT2 server */
 
 #define INTEL_IVB_D_IDS(info) \
-    INTEL_VGA_DEVICE(0x0152, info), /* GT1 desktop */ \
-    INTEL_VGA_DEVICE(0x0162, info), /* GT2 desktop */ \
-    INTEL_VGA_DEVICE(0x015a, info), /* GT1 server */ \
-    INTEL_VGA_DEVICE(0x016a, info)  /* GT2 server */
+    INTEL_IVB_D_GT1_IDS(info), \
+    INTEL_IVB_D_GT2_IDS(info)
 
 #define INTEL_IVB_Q_IDS(info) \
     INTEL_QUANTA_VGA_DEVICE(info) /* Quanta transcode */
 
-#define INTEL_HSW_IDS(info) \
+#define INTEL_HSW_GT1_IDS(info) \
     INTEL_VGA_DEVICE(0x0402, info), /* GT1 desktop */ \
-    INTEL_VGA_DEVICE(0x0412, info), /* GT2 desktop */ \
-    INTEL_VGA_DEVICE(0x0422, info), /* GT3 desktop */ \
     INTEL_VGA_DEVICE(0x040a, info), /* GT1 server */ \
-    INTEL_VGA_DEVICE(0x041a, info), /* GT2 server */ \
-    INTEL_VGA_DEVICE(0x042a, info), /* GT3 server */ \
     INTEL_VGA_DEVICE(0x040B, info), /* GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x041B, info), /* GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x042B, info), /* GT3 reserved */ \
     INTEL_VGA_DEVICE(0x040E, info), /* GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x041E, info), /* GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x042E, info), /* GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0C02, info), /* SDV GT1 desktop */ \
-    INTEL_VGA_DEVICE(0x0C12, info), /* SDV GT2 desktop */ \
-    INTEL_VGA_DEVICE(0x0C22, info), /* SDV GT3 desktop */ \
     INTEL_VGA_DEVICE(0x0C0A, info), /* SDV GT1 server */ \
-    INTEL_VGA_DEVICE(0x0C1A, info), /* SDV GT2 server */ \
-    INTEL_VGA_DEVICE(0x0C2A, info), /* SDV GT3 server */ \
     INTEL_VGA_DEVICE(0x0C0B, info), /* SDV GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x0C1B, info), /* SDV GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x0C2B, info), /* SDV GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0C0E, info), /* SDV GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x0C1E, info), /* SDV GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x0C2E, info), /* SDV GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0A02, info), /* ULT GT1 desktop */ \
-    INTEL_VGA_DEVICE(0x0A12, info), /* ULT GT2 desktop */ \
-    INTEL_VGA_DEVICE(0x0A22, info), /* ULT GT3 desktop */ \
     INTEL_VGA_DEVICE(0x0A0A, info), /* ULT GT1 server */ \
-    INTEL_VGA_DEVICE(0x0A1A, info), /* ULT GT2 server */ \
-    INTEL_VGA_DEVICE(0x0A2A, info), /* ULT GT3 server */ \
     INTEL_VGA_DEVICE(0x0A0B, info), /* ULT GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x0A1B, info), /* ULT GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x0A2B, info), /* ULT GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0D02, info), /* CRW GT1 desktop */ \
-    INTEL_VGA_DEVICE(0x0D12, info), /* CRW GT2 desktop */ \
-    INTEL_VGA_DEVICE(0x0D22, info), /* CRW GT3 desktop */ \
     INTEL_VGA_DEVICE(0x0D0A, info), /* CRW GT1 server */ \
-    INTEL_VGA_DEVICE(0x0D1A, info), /* CRW GT2 server */ \
-    INTEL_VGA_DEVICE(0x0D2A, info), /* CRW GT3 server */ \
     INTEL_VGA_DEVICE(0x0D0B, info), /* CRW GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x0D1B, info), /* CRW GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x0D2B, info), /* CRW GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0D0E, info), /* CRW GT1 reserved */ \
-    INTEL_VGA_DEVICE(0x0D1E, info), /* CRW GT2 reserved */ \
-    INTEL_VGA_DEVICE(0x0D2E, info),  /* CRW GT3 reserved */ \
     INTEL_VGA_DEVICE(0x0406, info), /* GT1 mobile */ \
+    INTEL_VGA_DEVICE(0x0C06, info), /* SDV GT1 mobile */ \
+    INTEL_VGA_DEVICE(0x0A06, info), /* ULT GT1 mobile */ \
+    INTEL_VGA_DEVICE(0x0A0E, info), /* ULX GT1 mobile */ \
+    INTEL_VGA_DEVICE(0x0D06, info)  /* CRW GT1 mobile */
+
+#define INTEL_HSW_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x0412, info), /* GT2 desktop */ \
+    INTEL_VGA_DEVICE(0x041a, info), /* GT2 server */ \
+    INTEL_VGA_DEVICE(0x041B, info), /* GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x041E, info), /* GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x0C12, info), /* SDV GT2 desktop */ \
+    INTEL_VGA_DEVICE(0x0C1A, info), /* SDV GT2 server */ \
+    INTEL_VGA_DEVICE(0x0C1B, info), /* SDV GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x0C1E, info), /* SDV GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x0A12, info), /* ULT GT2 desktop */ \
+    INTEL_VGA_DEVICE(0x0A1A, info), /* ULT GT2 server */ \
+    INTEL_VGA_DEVICE(0x0A1B, info), /* ULT GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x0D12, info), /* CRW GT2 desktop */ \
+    INTEL_VGA_DEVICE(0x0D1A, info), /* CRW GT2 server */ \
+    INTEL_VGA_DEVICE(0x0D1B, info), /* CRW GT2 reserved */ \
+    INTEL_VGA_DEVICE(0x0D1E, info), /* CRW GT2 reserved */ \
     INTEL_VGA_DEVICE(0x0416, info), /* GT2 mobile */ \
     INTEL_VGA_DEVICE(0x0426, info), /* GT2 mobile */ \
-    INTEL_VGA_DEVICE(0x0C06, info), /* SDV GT1 mobile */ \
     INTEL_VGA_DEVICE(0x0C16, info), /* SDV GT2 mobile */ \
-    INTEL_VGA_DEVICE(0x0C26, info), /* SDV GT3 mobile */ \
-    INTEL_VGA_DEVICE(0x0A06, info), /* ULT GT1 mobile */ \
     INTEL_VGA_DEVICE(0x0A16, info), /* ULT GT2 mobile */ \
-    INTEL_VGA_DEVICE(0x0A26, info), /* ULT GT3 mobile */ \
-    INTEL_VGA_DEVICE(0x0A0E, info), /* ULX GT1 mobile */ \
     INTEL_VGA_DEVICE(0x0A1E, info), /* ULX GT2 mobile */ \
+    INTEL_VGA_DEVICE(0x0D16, info)  /* CRW GT2 mobile */
+
+#define INTEL_HSW_GT3_IDS(info) \
+    INTEL_VGA_DEVICE(0x0422, info), /* GT3 desktop */ \
+    INTEL_VGA_DEVICE(0x042a, info), /* GT3 server */ \
+    INTEL_VGA_DEVICE(0x042B, info), /* GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x042E, info), /* GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0C22, info), /* SDV GT3 desktop */ \
+    INTEL_VGA_DEVICE(0x0C2A, info), /* SDV GT3 server */ \
+    INTEL_VGA_DEVICE(0x0C2B, info), /* SDV GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0C2E, info), /* SDV GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0A22, info), /* ULT GT3 desktop */ \
+    INTEL_VGA_DEVICE(0x0A2A, info), /* ULT GT3 server */ \
+    INTEL_VGA_DEVICE(0x0A2B, info), /* ULT GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0D22, info), /* CRW GT3 desktop */ \
+    INTEL_VGA_DEVICE(0x0D2A, info), /* CRW GT3 server */ \
+    INTEL_VGA_DEVICE(0x0D2B, info), /* CRW GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0D2E, info), /* CRW GT3 reserved */ \
+    INTEL_VGA_DEVICE(0x0C26, info), /* SDV GT3 mobile */ \
+    INTEL_VGA_DEVICE(0x0A26, info), /* ULT GT3 mobile */ \
     INTEL_VGA_DEVICE(0x0A2E, info), /* ULT GT3 reserved */ \
-    INTEL_VGA_DEVICE(0x0D06, info), /* CRW GT1 mobile */ \
-    INTEL_VGA_DEVICE(0x0D16, info), /* CRW GT2 mobile */ \
     INTEL_VGA_DEVICE(0x0D26, info)  /* CRW GT3 mobile */
+
+#define INTEL_HSW_IDS(info) \
+    INTEL_HSW_GT1_IDS(info), \
+    INTEL_HSW_GT2_IDS(info), \
+    INTEL_HSW_GT3_IDS(info)
 
 #define INTEL_VLV_IDS(info) \
     INTEL_VGA_DEVICE(0x0f30, info), \
@@ -216,17 +249,19 @@
     INTEL_VGA_DEVICE(0x0157, info), \
     INTEL_VGA_DEVICE(0x0155, info)
 
-#define INTEL_BDW_GT12_IDS(info)  \
+#define INTEL_BDW_GT1_IDS(info)  \
     INTEL_VGA_DEVICE(0x1602, info), /* GT1 ULT */ \
     INTEL_VGA_DEVICE(0x1606, info), /* GT1 ULT */ \
     INTEL_VGA_DEVICE(0x160B, info), /* GT1 Iris */ \
     INTEL_VGA_DEVICE(0x160E, info), /* GT1 ULX */ \
-    INTEL_VGA_DEVICE(0x1612, info), /* GT2 Halo */ \
+    INTEL_VGA_DEVICE(0x160A, info), /* GT1 Server */ \
+    INTEL_VGA_DEVICE(0x160D, info)  /* GT1 Workstation */
+
+#define INTEL_BDW_GT2_IDS(info)  \
+    INTEL_VGA_DEVICE(0x1612, info), /* GT2 Halo */	\
     INTEL_VGA_DEVICE(0x1616, info), /* GT2 ULT */ \
     INTEL_VGA_DEVICE(0x161B, info), /* GT2 ULT */ \
-    INTEL_VGA_DEVICE(0x161E, info),  /* GT2 ULX */ \
-    INTEL_VGA_DEVICE(0x160A, info), /* GT1 Server */ \
-    INTEL_VGA_DEVICE(0x160D, info), /* GT1 Workstation */ \
+    INTEL_VGA_DEVICE(0x161E, info), /* GT2 ULX */ \
     INTEL_VGA_DEVICE(0x161A, info), /* GT2 Server */ \
     INTEL_VGA_DEVICE(0x161D, info)  /* GT2 Workstation */
 
@@ -247,7 +282,8 @@
     INTEL_VGA_DEVICE(0x163D, info)  /* Workstation */
 
 #define INTEL_BDW_IDS(info) \
-    INTEL_BDW_GT12_IDS(info), \
+    INTEL_BDW_GT1_IDS(info), \
+    INTEL_BDW_GT2_IDS(info), \
     INTEL_BDW_GT3_IDS(info), \
     INTEL_BDW_RSVD_IDS(info)
 
@@ -316,7 +352,7 @@
 
 #define INTEL_KBL_GT2_IDS(info)	\
     INTEL_VGA_DEVICE(0x5916, info), /* ULT GT2 */ \
-    INTEL_VGA_DEVICE(0x5917, info), /* Mobile  GT2 */ \
+    INTEL_VGA_DEVICE(0x5917, info), /* Mobile GT2 */ \
     INTEL_VGA_DEVICE(0x5921, info), /* ULT GT2F */ \
     INTEL_VGA_DEVICE(0x591E, info), /* ULX GT2 */ \
     INTEL_VGA_DEVICE(0x5912, info), /* DT  GT2 */ \
@@ -332,54 +368,103 @@
 #define INTEL_KBL_GT4_IDS(info) \
     INTEL_VGA_DEVICE(0x593B, info) /* Halo GT4 */
 
+/* AML/KBL Y GT2 */
+#define INTEL_AML_KBL_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x591C, info),  /* ULX GT2 */ \
+    INTEL_VGA_DEVICE(0x87C0, info) /* ULX GT2 */
+
+/* AML/CFL Y GT2 */
+#define INTEL_AML_CFL_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x87CA, info)
+
 #define INTEL_KBL_IDS(info) \
     INTEL_KBL_GT1_IDS(info), \
     INTEL_KBL_GT2_IDS(info), \
     INTEL_KBL_GT3_IDS(info), \
-    INTEL_KBL_GT4_IDS(info)
+    INTEL_KBL_GT4_IDS(info), \
+    INTEL_AML_KBL_GT2_IDS(info)
 
-#define INTEL_CFL_S_IDS(info) \
+/* CFL S */
+#define INTEL_CFL_S_GT1_IDS(info) \
     INTEL_VGA_DEVICE(0x3E90, info), /* SRV GT1 */ \
     INTEL_VGA_DEVICE(0x3E93, info), /* SRV GT1 */ \
+    INTEL_VGA_DEVICE(0x3E99, info)  /* SRV GT1 */
+
+#define INTEL_CFL_S_GT2_IDS(info) \
     INTEL_VGA_DEVICE(0x3E91, info), /* SRV GT2 */ \
     INTEL_VGA_DEVICE(0x3E92, info), /* SRV GT2 */ \
-    INTEL_VGA_DEVICE(0x3E96, info) /* SRV GT2 */
+    INTEL_VGA_DEVICE(0x3E96, info), /* SRV GT2 */ \
+    INTEL_VGA_DEVICE(0x3E98, info), /* SRV GT2 */ \
+    INTEL_VGA_DEVICE(0x3E9A, info)  /* SRV GT2 */
 
-#define INTEL_CFL_H_IDS(info) \
+/* CFL H */
+#define INTEL_CFL_H_GT2_IDS(info) \
     INTEL_VGA_DEVICE(0x3E9B, info), /* Halo GT2 */ \
-    INTEL_VGA_DEVICE(0x3E94, info) /* Halo GT2 */
+    INTEL_VGA_DEVICE(0x3E94, info)  /* Halo GT2 */
 
-#define INTEL_CFL_U_IDS(info) \
+/* CFL U GT2 */
+#define INTEL_CFL_U_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x3EA9, info)
+
+/* CFL U GT3 */
+#define INTEL_CFL_U_GT3_IDS(info) \
     INTEL_VGA_DEVICE(0x3EA5, info), /* ULT GT3 */ \
     INTEL_VGA_DEVICE(0x3EA6, info), /* ULT GT3 */ \
     INTEL_VGA_DEVICE(0x3EA7, info), /* ULT GT3 */ \
-    INTEL_VGA_DEVICE(0x3EA8, info) /* ULT GT3 */
+    INTEL_VGA_DEVICE(0x3EA8, info)  /* ULT GT3 */
 
-#define INTEL_WHL_U_IDS(info) \
-    INTEL_VGA_DEVICE(0x3EA0, info) /* ULT GT2 */
+/* WHL/CFL U GT1 */
+#define INTEL_WHL_U_GT1_IDS(info) \
+    INTEL_VGA_DEVICE(0x3EA1, info), \
+    INTEL_VGA_DEVICE(0x3EA4, info)
 
-#define INTEL_CFL_IDS(info) \
-    INTEL_CFL_S_IDS(info), \
-    INTEL_CFL_H_IDS(info), \
-    INTEL_CFL_U_IDS(info), \
-    INTEL_WHL_U_IDS(info)
+/* WHL/CFL U GT2 */
+#define INTEL_WHL_U_GT2_IDS(info) \
+    INTEL_VGA_DEVICE(0x3EA0, info), \
+    INTEL_VGA_DEVICE(0x3EA3, info)
 
-#define INTEL_CNL_U_GT2_IDS(info) \
-    INTEL_VGA_DEVICE(0x5A52, info),	\
-    INTEL_VGA_DEVICE(0x5A5A, info), \
-    INTEL_VGA_DEVICE(0x5A42, info), \
-    INTEL_VGA_DEVICE(0x5A4A, info)
+/* WHL/CFL U GT3 */
+#define INTEL_WHL_U_GT3_IDS(info) \
+    INTEL_VGA_DEVICE(0x3EA2, info)
 
-#define INTEL_CNL_Y_GT2_IDS(info) \
-    INTEL_VGA_DEVICE(0x5A51, info),	\
+#define INTEL_CFL_IDS(info)	   \
+    INTEL_CFL_S_GT1_IDS(info), \
+    INTEL_CFL_S_GT2_IDS(info), \
+    INTEL_CFL_H_GT2_IDS(info), \
+    INTEL_CFL_U_GT2_IDS(info), \
+    INTEL_CFL_U_GT3_IDS(info), \
+    INTEL_WHL_U_GT1_IDS(info), \
+    INTEL_WHL_U_GT2_IDS(info), \
+    INTEL_WHL_U_GT3_IDS(info), \
+    INTEL_AML_CFL_GT2_IDS(info)
+
+/* CNL */
+#define INTEL_CNL_IDS(info) \
+    INTEL_VGA_DEVICE(0x5A51, info), \
     INTEL_VGA_DEVICE(0x5A59, info), \
     INTEL_VGA_DEVICE(0x5A41, info), \
     INTEL_VGA_DEVICE(0x5A49, info), \
-    INTEL_VGA_DEVICE(0x5A71, info), \
-    INTEL_VGA_DEVICE(0x5A79, info)
+    INTEL_VGA_DEVICE(0x5A52, info), \
+    INTEL_VGA_DEVICE(0x5A5A, info), \
+    INTEL_VGA_DEVICE(0x5A42, info), \
+    INTEL_VGA_DEVICE(0x5A4A, info), \
+    INTEL_VGA_DEVICE(0x5A50, info), \
+    INTEL_VGA_DEVICE(0x5A40, info), \
+    INTEL_VGA_DEVICE(0x5A54, info), \
+    INTEL_VGA_DEVICE(0x5A5C, info), \
+    INTEL_VGA_DEVICE(0x5A44, info), \
+    INTEL_VGA_DEVICE(0x5A4C, info)
 
-#define INTEL_CNL_IDS(info) \
-    INTEL_CNL_U_GT2_IDS(info), \
-    INTEL_CNL_Y_GT2_IDS(info)
+/* ICL */
+#define INTEL_ICL_11_IDS(info) \
+    INTEL_VGA_DEVICE(0x8A50, info), \
+    INTEL_VGA_DEVICE(0x8A51, info), \
+    INTEL_VGA_DEVICE(0x8A5C, info), \
+    INTEL_VGA_DEVICE(0x8A5D, info), \
+    INTEL_VGA_DEVICE(0x8A52, info), \
+    INTEL_VGA_DEVICE(0x8A5A, info), \
+    INTEL_VGA_DEVICE(0x8A5B, info), \
+    INTEL_VGA_DEVICE(0x8A71, info), \
+    INTEL_VGA_DEVICE(0x8A70, info)
 
 #endif /* _I915_PCIIDS_H */

--- a/samples/metrics_monitor/test/igt_load.cpp
+++ b/samples/metrics_monitor/test/igt_load.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Intel Corporation.  All rights reserved.
+ * Copyright (C) 2017-2019 Intel Corporation.  All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -174,6 +174,17 @@ unsigned intel_gen(uint16_t devid)
 
 unsigned intel_gt(uint16_t devid)
 {
+    const struct intel_device_info *devinfo = intel_get_device_info(devid);
+
+    /* If in the database, just use that information. */
+    if (devinfo->gt != 0)
+        return devinfo->gt - 1;
+
+    /*
+     * This scheme doesn't work on Coffeelake, we should probably
+     * not rely on this anymore.
+    */
+
     unsigned mask = intel_gen(devid);
 
     if (mask >= 8)


### PR DESCRIPTION
Earlier scheme of decoding device id to get GT size
doesn't work on some platforms anymore,
so they are were determined in platform tables.

Issue: MDP-51279