### PR TITLE
[mpeg2d] Fix for corrupted content

### DIFF
--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_decoder.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_decoder.cpp
@@ -346,14 +346,16 @@ namespace UMC_MPEG2_DECODER
             }
             break;
             case PICTURE_HEADER:
-                DecodeHeaders(unit); // 1. Got new picture header
-                if (m_currFrame)     // 2. Complete current picture if any
+            {
+                auto sts = DecodeHeaders(unit);          // 1. Parse new picture header
+                if ((UMC::UMC_OK == sts) && m_currFrame) // 2. Complete current picture
                 {
                     bool isFullFrame = OnNewPicture();
                     if (isFullFrame)
                         return UMC::UMC_OK; // exit from the loop on full frame
                 }
-                break;
+            }
+            break;
             case EXTENSION:
             case GROUP:
                 DecodeHeaders(unit);


### PR DESCRIPTION
Check status from DecodeHeaders before completion of current frame
because a new picture header can be corrupted and therefore skipped.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>