### PR TITLE
[mpeg2d] Fix for missing slice

### DIFF
--- a/_studio/shared/umc/codec/mpeg2_dec/include/umc_mpeg2_decoder.h
+++ b/_studio/shared/umc/codec/mpeg2_dec/include/umc_mpeg2_decoder.h
@@ -238,6 +238,8 @@ namespace UMC_MPEG2_DECODER
         double                          m_localFrameTime;
 
         std::unique_ptr<Payload_Storage> m_messages;
+
+        std::unique_ptr<MPEG2Slice>     m_lastSlice; // slice which could't be processed
     };
 
     class Payload_Storage


### PR DESCRIPTION
In case of absent of a free frame
we need to save current slice for later processing.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>