### PR TITLE
Destroy va buffers correctly

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -36,15 +36,6 @@
 #include <vector>
 #include <map>
 #include <algorithm>
-
-#define MFX_DESTROY_VABUFFER(vaBufferId, vaDisplay)    \
-do {                                               \
-    if ( vaBufferId != VA_INVALID_ID)              \
-    {                                              \
-        vaDestroyBuffer(vaDisplay, vaBufferId);    \
-        vaBufferId = VA_INVALID_ID;                \
-    }                                              \
-} while (0)
 
 namespace MfxHwH265Encode
 {

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -90,7 +90,8 @@ static mfxStatus SetROI(
     VAEncMiscParameterBufferROI *roi_Param;
     unsigned int roi_buffer_size = sizeof(VAEncMiscParameterBufferROI);
 
-    MFX_DESTROY_VABUFFER(roiParam_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, roiParam_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
             vaContextEncode,
@@ -157,7 +158,8 @@ static mfxStatus SetRollingIntraRefresh(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterRIR    *rir_param;
 
-    MFX_DESTROY_VABUFFER(rirBuf_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, rirBuf_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -224,8 +226,12 @@ VABufferID& VABuffersHandler::VABuffersNew(mfxU32 id, mfxU32 pool, mfxU32 num)
 
     begin = it; idBegin = idIt;
 
-    for (;it != end && *idIt == id; it++, idIt++)
-        MFX_DESTROY_VABUFFER(*it, m_vaDisplay);
+    mfxStatus sts;
+    for (; it != end && *idIt == id; it++, idIt++)
+    {
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, *it);
+        std::ignore = MFX_STS_TRACE(sts);
+    }
 
     end = it; idEnd = idIt;
 
@@ -259,8 +265,12 @@ VABufferID& VABuffersHandler::VABuffersNew(mfxU32 id, mfxU32 pool, mfxU32 num)
 
 void VABuffersHandler::VABuffersDestroy()
 {
+    mfxStatus sts;
     for (size_t i = 0; i < m_buf.size(); i++)
-        MFX_DESTROY_VABUFFER(m_buf[i], m_vaDisplay);
+    {
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_buf[i]);
+        std::ignore = MFX_STS_TRACE(sts);
+    }
     m_buf.resize(0);
     m_id.resize(0);
     m_pool.resize(1, 0);
@@ -277,8 +287,12 @@ void VABuffersHandler::VABuffersDestroyPool(mfxU32 pool)
 
     std::vector<mfxU32>::iterator idBegin = m_id.begin() + std::distance(m_buf.begin(), begin);
 
+    mfxStatus sts;
     for (it = begin; it != end; it++)
-        MFX_DESTROY_VABUFFER(*it, m_vaDisplay);
+    {
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, *it);
+        std::ignore = MFX_STS_TRACE(sts);
+    }
 
     m_buf.erase(begin, end);
     m_id.erase(idBegin, idBegin + poolSize);
@@ -316,7 +330,8 @@ mfxStatus SetHRD(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterHRD *hrd_param;
 
-    MFX_DESTROY_VABUFFER(hrdBuf_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, hrdBuf_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -364,7 +379,8 @@ mfxStatus SetRateControl(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterRateControl *rate_param;
 
-    MFX_DESTROY_VABUFFER(rateParamBuf_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, rateParamBuf_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -417,7 +433,8 @@ mfxStatus SetFrameRate(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterFrameRate *frameRate_param;
 
-    MFX_DESTROY_VABUFFER(frameRateBuf_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, frameRateBuf_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -450,7 +467,8 @@ mfxStatus SetMaxSliceSize(
     VAContextID  vaContextEncode,
     VABufferID & maxSliceSizeBuf_id)
 {
-    MFX_DESTROY_VABUFFER(maxSliceSizeBuf_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, maxSliceSizeBuf_id);
+    MFX_CHECK_STS(sts);
 
     VAStatus vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,
@@ -489,7 +507,8 @@ mfxStatus SetQualityLevelParams(
     VAEncMiscParameterBuffer *misc_param;
     VAEncMiscParameterBufferQualityLevel *quality_param;
 
-    MFX_DESTROY_VABUFFER(qualityParams_id, vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(vaDisplay, qualityParams_id);
+    MFX_CHECK_STS(sts);
 
     vaSts = vaCreateBuffer(vaDisplay,
                    vaContextEncode,

--- a/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_vaapi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -35,15 +35,6 @@
 
 #include "mfx_mjpeg_encode_hw_utils.h"
 #include "mfx_mjpeg_encode_interface.h"
-
-#define MFX_DESTROY_VABUFFER(vaBufferId, vaDisplay)    \
-do {                                               \
-    if ( vaBufferId != VA_INVALID_ID)              \
-    {                                              \
-        vaDestroyBuffer(vaDisplay, vaBufferId);    \
-        vaBufferId = VA_INVALID_ID;                \
-    }                                              \
-} while (0)
 
 namespace MfxHwMJpegEncode
 {

--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_vaapi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,15 +28,6 @@ namespace MfxHwVP9Encode
 #if defined (MFX_VA_LINUX)
 #include <va/va.h>
 #include <va/va_enc_vp9.h>
-
-#define MFX_DESTROY_VABUFFER(vaBufferId, vaDisplay)    \
-do {                                               \
-    if (vaBufferId != VA_INVALID_ID)               \
-    {                                              \
-        vaDestroyBuffer(vaDisplay, vaBufferId);    \
-        vaBufferId = VA_INVALID_ID;                \
-    }                                              \
-} while (0)
 
     enum {
         MFX_FOURCC_VP9_NV12    = MFX_MAKEFOURCC('V','P','8','N'),

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -1040,10 +1040,13 @@ mfxStatus VAAPIEncoder::Execute(
     //------------------------------------------------------------------
     // buffer creation & configuration
     //------------------------------------------------------------------
+    mfxStatus sts;
     {
         // 1. sequence level
         {
-            MFX_DESTROY_VABUFFER(m_spsBufferId, m_vaDisplay);
+            sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_spsBufferId);
+            MFX_CHECK_STS(sts);
+
             vaSts = vaCreateBuffer(m_vaDisplay,
                                    m_vaContextEncode,
                                    VAEncSequenceParameterBufferType,
@@ -1057,7 +1060,9 @@ mfxStatus VAAPIEncoder::Execute(
         }
         // 2. Picture level
         {
-            MFX_DESTROY_VABUFFER(m_ppsBufferId, m_vaDisplay);
+            sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_ppsBufferId);
+            MFX_CHECK_STS(sts);
+
             vaSts = vaCreateBuffer(m_vaDisplay,
                                    m_vaContextEncode,
                                    VAEncPictureParameterBufferType,
@@ -1082,7 +1087,9 @@ mfxStatus VAAPIEncoder::Execute(
             configBuffers.push_back(m_segMapBufferId);
 
             // 5. Per-segment parameters
-            MFX_DESTROY_VABUFFER(m_segParBufferId, m_vaDisplay);
+            sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_segParBufferId);
+            MFX_CHECK_STS(sts);
+
             vaSts = vaCreateBuffer(m_vaDisplay,
                                    m_vaContextEncode,
                                    VAQMatrixBufferType,
@@ -1104,7 +1111,9 @@ mfxStatus VAAPIEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = 1;
         packed_header_param_buffer.bit_length = packedData.DataLength*8;
 
-        MFX_DESTROY_VABUFFER(m_packedHeaderParameterBufferId, m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedHeaderParameterBufferId);
+        MFX_CHECK_STS(sts);
+
         vaSts = vaCreateBuffer(m_vaDisplay,
                 m_vaContextEncode,
                 VAEncPackedHeaderParameterBufferType,
@@ -1116,7 +1125,9 @@ mfxStatus VAAPIEncoder::Execute(
 
         configBuffers.push_back(m_packedHeaderParameterBufferId);
 
-        MFX_DESTROY_VABUFFER(m_packedHeaderDataBufferId, m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedHeaderDataBufferId);
+        MFX_CHECK_STS(sts);
+
         vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
                             VAEncPackedHeaderDataBufferType,
@@ -1308,33 +1319,55 @@ mfxStatus VAAPIEncoder::Destroy()
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "Destroy");
 
-    MFX_DESTROY_VABUFFER(m_spsBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_ppsBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_segMapBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_segParBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_hrdBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_qualityLevelBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedHeaderParameterBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedHeaderDataBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_tempLayersBufferId, m_vaDisplay);
-    for (VABufferID id : m_frameRateBufferIds)
+    mfxStatus sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_spsBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_ppsBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_segMapBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_segParBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_hrdBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_qualityLevelBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedHeaderParameterBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedHeaderDataBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_tempLayersBufferId);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    for (VABufferID& id : m_frameRateBufferIds)
     {
-        MFX_DESTROY_VABUFFER(id, m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, id);
+        std::ignore = MFX_STS_TRACE(sts);
     }
-    for (VABufferID id : m_rateCtrlBufferIds)
+    for (VABufferID& id : m_rateCtrlBufferIds)
     {
-        MFX_DESTROY_VABUFFER(id, m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, id);
+        std::ignore = MFX_STS_TRACE(sts);
     }
 
     if(m_vaContextEncode != VA_INVALID_ID)
     {
-        vaDestroyContext(m_vaDisplay, m_vaContextEncode);
+        VAStatus vaSts = vaDestroyContext(m_vaDisplay, m_vaContextEncode);
+        std::ignore = MFX_STS_TRACE(vaSts);
         m_vaContextEncode = VA_INVALID_ID;
     }
 
     if(m_vaConfig != VA_INVALID_ID)
     {
-        vaDestroyConfig( m_vaDisplay, m_vaConfig );
+        VAStatus vaSts = vaDestroyConfig( m_vaDisplay, m_vaConfig );
+        std::ignore = MFX_STS_TRACE(vaSts);
         m_vaConfig = VA_INVALID_ID;
     }
 

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
@@ -48,19 +48,6 @@ do {                                               \
     }                                              \
 } while (0)
 
-inline mfxStatus CheckAndDestroyVAbuffer(VADisplay display, VABufferID & buffer_id)
-{
-    if (buffer_id != VA_INVALID_ID)
-    {
-        VAStatus vaSts = vaDestroyBuffer(display, buffer_id);
-        MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-
-        buffer_id = VA_INVALID_ID;
-    }
-
-    return MFX_ERR_NONE;
-}
-
 uint32_t ConvertRateControlMFX2VAAPI(mfxU8 rateControl);
 
 VAProfile ConvertProfileTypeMFX2VAAPI(mfxU32 type);

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,15 +38,6 @@
 
 #include "mfx_h264_encode_interface.h"
 #include "mfx_h264_encode_hw_utils.h"
-
-#define MFX_DESTROY_VABUFFER(vaBufferId, vaDisplay)    \
-do {                                               \
-    if ( vaBufferId != VA_INVALID_ID)              \
-    {                                              \
-        vaDestroyBuffer(vaDisplay, vaBufferId);    \
-        vaBufferId = VA_INVALID_ID;                \
-    }                                              \
-} while (0)
 
 uint32_t ConvertRateControlMFX2VAAPI(mfxU8 rateControl);
 

--- a/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
@@ -59,25 +59,23 @@ mfxStatus VAAPIFEIPREENCEncoder::Destroy()
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "FEI::PreENC::Destroy");
 
-    mfxStatus sts = MFX_ERR_NONE;
-
-    MFX_DESTROY_VABUFFER(m_statParamsId, m_vaDisplay);
+    mfxStatus sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statParamsId);
+    std::ignore = MFX_STS_TRACE(sts);
 
     for( mfxU32 i = 0; i < m_statMVId.size(); i++ )
     {
-        MFX_DESTROY_VABUFFER(m_statMVId[i], m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statMVId[i]);
+        std::ignore = MFX_STS_TRACE(sts);
     }
 
     for( mfxU32 i = 0; i < m_statOutId.size(); i++ )
     {
-        MFX_DESTROY_VABUFFER(m_statOutId[i], m_vaDisplay);
+        sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statOutId[i]);
+        std::ignore = MFX_STS_TRACE(sts);
     }
 
-    sts = VAAPIEncoder::Destroy();
-
-    return sts;
-
-} // mfxStatus VAAPIFEIPREENCEncoder::Destroy()
+    return VAAPIEncoder::Destroy();
+}
 
 
 mfxStatus VAAPIFEIPREENCEncoder::CreateAccelerationService(MfxVideoParam const & par)
@@ -569,7 +567,6 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
     /* Link output VA buffers */
     statParams.stats_params.outputs = outBuffers.data(); //bufIDs for outputs
 
-    //MFX_DESTROY_VABUFFER(statParamsId, m_vaDisplay);
     vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
                             (VABufferType)VAStatsStatisticsParameterBufferType,
@@ -631,9 +628,12 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
         m_statFeedbackCache.push_back(currentFeedback);
     }
 
-    MFX_DESTROY_VABUFFER(mvPredid,     m_vaDisplay);
-    MFX_DESTROY_VABUFFER(statParamsId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(qpid,         m_vaDisplay);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, mvPredid);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, statParamsId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, qpid);
+    MFX_CHECK_STS(mfxSts);
 
     mdprintf(stderr, "submit_vaapi done: %d\n", task.m_frameOrder);
     return MFX_ERR_NONE;

--- a/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1759,9 +1759,8 @@ VAAPIFEIPAKEncoder::VAAPIFEIPAKEncoder()
 , m_statParamsId(VA_INVALID_ID)
 , m_statMVId(VA_INVALID_ID)
 , m_statOutId(VA_INVALID_ID)
-//, m_codedBufferId[0](VA_INVALID_ID)
+, m_codedBufferId{VA_INVALID_ID, VA_INVALID_ID}
 {
-    m_codedBufferId[0] = m_codedBufferId[1] = VA_INVALID_ID;
 } // VAAPIFEIPAKEncoder::VAAPIFEIPAKEncoder()
 
 VAAPIFEIPAKEncoder::~VAAPIFEIPAKEncoder()
@@ -1775,17 +1774,22 @@ mfxStatus VAAPIFEIPAKEncoder::Destroy()
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "FEI::PAK::Destroy");
 
-    mfxStatus sts = MFX_ERR_NONE;
+    mfxStatus sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statParamsId);
+    std::ignore = MFX_STS_TRACE(sts);
 
-    MFX_DESTROY_VABUFFER(m_statParamsId,     m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_statMVId,         m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_statOutId,        m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_codedBufferId[0], m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_codedBufferId[1], m_vaDisplay);
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statMVId);
+    std::ignore = MFX_STS_TRACE(sts);
 
-    sts = VAAPIEncoder::Destroy();
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_statOutId);
+    std::ignore = MFX_STS_TRACE(sts);
 
-    return sts;
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_codedBufferId[0]);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_codedBufferId[1]);
+    std::ignore = MFX_STS_TRACE(sts);
+
+    return VAAPIEncoder::Destroy();
 
 } // mfxStatus VAAPIFEIPAKEncoder::Destroy()
 
@@ -2043,7 +2047,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = !packedAud.SkipEmulationByteCount;
         packed_header_param_buffer.bit_length          = packedAud.DataLength * 8;
 
-        MFX_DESTROY_VABUFFER(m_packedAudHeaderBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderParameterBufferType,
@@ -2053,7 +2056,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
                                 &m_packedAudHeaderBufferId);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
-        MFX_DESTROY_VABUFFER(m_packedAudBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderDataBufferType,
@@ -2076,7 +2078,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = !packedSps.SkipEmulationByteCount;
         packed_header_param_buffer.bit_length          = packedSps.DataLength*8;
 
-        MFX_DESTROY_VABUFFER(m_packedSpsHeaderBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderParameterBufferType,
@@ -2086,7 +2087,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
                                 &m_packedSpsHeaderBufferId);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
-        MFX_DESTROY_VABUFFER(m_packedSpsBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderDataBufferType,
@@ -2257,7 +2257,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = !packedPps.SkipEmulationByteCount;
         packed_header_param_buffer.bit_length          = packedPps.DataLength*8;
 
-        MFX_DESTROY_VABUFFER(m_packedPpsHeaderBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderParameterBufferType,
@@ -2268,7 +2267,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
         mdprintf(stderr, "m_packedPpsHeaderBufferId=%d\n", m_packedPpsHeaderBufferId);
 
-        MFX_DESTROY_VABUFFER(m_packedPpsBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderDataBufferType,
@@ -2290,7 +2288,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = 1;
         packed_header_param_buffer.bit_length          = sei.Size() * 8;
 
-        MFX_DESTROY_VABUFFER(m_packedSeiHeaderBufferId, m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderParameterBufferType,
@@ -2300,7 +2297,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
                                 &m_packedSeiHeaderBufferId);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
-        MFX_DESTROY_VABUFFER(m_packedSeiBufferId,m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderDataBufferType,
@@ -2317,8 +2313,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
 
     for (size_t i = 0; i < m_slice.size(); ++i)
     {
-        // Note: legacy use 5,6,7 type values, but for FEI 0,1,2
-
         m_slice[i].macroblock_address            = pDataSliceHeader->Slice[i].MBAddress;
         m_slice[i].num_macroblocks               = pDataSliceHeader->Slice[i].NumMBs;
         m_slice[i].slice_type                    = pDataSliceHeader->Slice[i].SliceType;
@@ -2328,7 +2322,7 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         m_slice[i].disable_deblocking_filter_idc = pDataSliceHeader->Slice[i].DisableDeblockingFilterIdc;
         m_slice[i].slice_alpha_c0_offset_div2    = pDataSliceHeader->Slice[i].SliceAlphaC0OffsetDiv2;
         m_slice[i].slice_beta_offset_div2        = pDataSliceHeader->Slice[i].SliceBetaOffsetDiv2;
-    } // for (size_t i = 0; i < m_slice.size(); ++i)
+    }
 
     mfxU32 prefix_bytes = (task.m_AUStartsFromSlice[fieldId] + 8) * m_headerPacker.isSvcPrefixUsed();
 
@@ -2368,7 +2362,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         packed_header_param_buffer.has_emulation_bytes = 0;
         packed_header_param_buffer.bit_length          = packedSlice.DataLength - (prefix_bytes * 8); // DataLength is already in bits !
 
-        //MFX_DESTROY_VABUFFER(m_packedSliceHeaderBufferId[i], m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderParameterBufferType,
@@ -2378,7 +2371,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
                                 &m_packedSliceHeaderBufferId[i]);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
-        //MFX_DESTROY_VABUFFER(m_packedSliceBufferId[i], m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncPackedHeaderDataBufferType,
@@ -2392,7 +2384,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
 
     for( size_t i = 0; i < m_slice.size(); i++ )
     {
-        //MFX_DESTROY_VABUFFER(m_sliceBufferId[i], m_vaDisplay);
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
                                 VAEncSliceParameterBufferType,
@@ -2401,7 +2392,6 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
                                 &m_slice[i],
                                 &m_sliceBufferId[i]);
         MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
-        //configBuffers.push_back(m_sliceBufferId[i]);
         mdprintf(stderr, "m_sliceBufferId[%zu]=%d\n", i, m_sliceBufferId[i]);
     }
 
@@ -2467,25 +2457,43 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         m_statFeedbackCache.push_back(currentFeedback);
     }
 
-    MFX_DESTROY_VABUFFER(m_vaFeiMVOutId[0],         m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_vaFeiMCODEOutId[0],      m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedAudHeaderBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedAudBufferId,       m_vaDisplay);
-    MFX_DESTROY_VABUFFER(vaFeiFrameControlId,       m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedSpsHeaderBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedSpsBufferId,       m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_spsBufferId,             m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_ppsBufferId,             m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedPpsHeaderBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedPpsBufferId,       m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedSeiHeaderBufferId, m_vaDisplay);
-    MFX_DESTROY_VABUFFER(m_packedSeiBufferId,       m_vaDisplay);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_vaFeiMVOutId[0]);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_vaFeiMCODEOutId[0]);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedAudHeaderBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedAudBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, vaFeiFrameControlId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSpsHeaderBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSpsBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_spsBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_ppsBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedPpsHeaderBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedPpsBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSeiHeaderBufferId);
+    MFX_CHECK_STS(mfxSts);
+    mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSeiBufferId);
+    MFX_CHECK_STS(mfxSts);
 
     for( size_t i = 0; i < m_slice.size(); i++ )
     {
-        MFX_DESTROY_VABUFFER(m_sliceBufferId[i],             m_vaDisplay);
-        MFX_DESTROY_VABUFFER(m_packedSliceHeaderBufferId[i], m_vaDisplay);
-        MFX_DESTROY_VABUFFER(m_packedSliceBufferId[i],       m_vaDisplay);
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_sliceBufferId[i]);
+        MFX_CHECK_STS(mfxSts);
+
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSliceHeaderBufferId[i]);
+        MFX_CHECK_STS(mfxSts);
+
+        mfxSts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedSliceBufferId[i]);
+        MFX_CHECK_STS(mfxSts);
     }
 
     mdprintf(stderr, "submit_vaapi done: %d\n", task.m_frameOrder);
@@ -2590,7 +2598,8 @@ mfxStatus VAAPIFEIPAKEncoder::QueryStatus(
                 MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
                 // ??? may affect for performance
-                MFX_DESTROY_VABUFFER(m_codedBufferId[feiFieldId], m_vaDisplay);
+                sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_codedBufferId[feiFieldId]);
+                MFX_CHECK_STS(sts);
             }
 
             // remove task

--- a/_studio/shared/include/mfx_utils.h
+++ b/_studio/shared/include/mfx_utils.h
@@ -31,6 +31,10 @@
 
 #include <cassert>
 
+#if defined(MFX_VA_LINUX)
+#include <va/va.h>
+#endif
+
 #ifndef MFX_DEBUG_TRACE
 #define MFX_STS_TRACE(sts) sts
 #else
@@ -145,5 +149,20 @@ constexpr const T& clamp( const T& v, const T& lo, const T& hi, Compare comp )
 
 #define MFX_COPY_FIELD(Field)       buf_dst.Field = buf_src.Field
 #define MFX_COPY_ARRAY_FIELD(Array) std::copy(std::begin(buf_src.Array), std::end(buf_src.Array), std::begin(buf_dst.Array))
+
+#if defined(MFX_VA_LINUX)
+inline mfxStatus CheckAndDestroyVAbuffer(VADisplay display, VABufferID & buffer_id)
+{
+    if (buffer_id != VA_INVALID_ID)
+    {
+        VAStatus vaSts = vaDestroyBuffer(display, buffer_id);
+        MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
+
+        buffer_id = VA_INVALID_ID;
+    }
+
+    return MFX_ERR_NONE;
+}
+#endif
 
 #endif // __MFXUTILS_H__


### PR DESCRIPTION
This PR replaces macro which ignored returned status with function that handles it.

All components patched. Fixes #1065