### PR TITLE
h265d: fix static analysis warning

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_headers.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_headers.h
@@ -38,7 +38,8 @@ class HeaderSet
 public:
 
     HeaderSet(Heap_Objects  *pObjHeap)
-        : m_pObjHeap(pObjHeap)
+        : m_Header()
+        , m_pObjHeap(pObjHeap)
         , m_currentID(-1)
     {
     }


### PR DESCRIPTION
-Add initialization HeaderSet::m_Header