### PR TITLE
vp9d: fix calculation number of required surfaces

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -403,6 +403,12 @@ namespace MFX_VPX_Utility
         p_request->NumFrameMin = p_params->mfx.CodecId == MFX_CODEC_VP8 ? mfxU16(4) : mfxU16(8);
 
         p_request->NumFrameMin += p_params->AsyncDepth ? p_params->AsyncDepth : MFX_AUTO_ASYNC_DEPTH_VALUE;
+
+        // Increase minimum number by one
+        // E.g., decoder unlocks references in sync part (NOT async), so in order to free some surface
+        // application need an additional surface to call DecodeFrameAsync()
+        p_request->NumFrameMin += 1;
+
         p_request->NumFrameSuggested = p_request->NumFrameMin;
 
         if (p_params->IOPattern & MFX_IOPATTERN_OUT_SYSTEM_MEMORY)


### PR DESCRIPTION
-Changed MFX_VPX_Utility::QueryIOSurfInternal()
 required num surfaces =  (max num references) + AsyncDepth + 1