### PR TITLE
vp8d/vp9d/vc1d: add report decoded FrameType

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -59,6 +59,17 @@ struct ThreadTaskInfo
     bool              needCheckVppStatus;
     mfxU32            numDecodeTasksToCheck;
 };
+
+static void SetFrameType(mfxFrameSurface1 &surface_out)
+{
+    auto extFrameInfo = reinterpret_cast<mfxExtDecodedFrameInfo *>(GetExtendedBuffer(surface_out.Data.ExtParam, surface_out.Data.NumExtParam, MFX_EXTBUFF_DECODED_FRAME_INFO));
+    if (extFrameInfo == nullptr)
+        return;
+
+    // terms I/P/B frames not applicable for JPEG,
+    // so all frames marked as I
+    extFrameInfo->FrameType = MFX_FRAMETYPE_I;
+}
 
 class MFX_JPEG_Utility
 {
@@ -649,6 +660,8 @@ mfxStatus VideoDECODEMJPEG::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 
 
         if (!(*surface_out))
             return MFX_ERR_UNDEFINED_BEHAVIOR;
+
+        SetFrameType(**surface_out);
 
         (*surface_out)->Info.FrameId.ViewId = 0; // (mfxU16)pFrame->m_viewId;
 

--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -84,6 +84,25 @@ bool CheckHardwareSupport(VideoCORE *p_core, mfxVideoParam *p_video_param)
     MFX_CHECK(mfxSts == MFX_ERR_NONE, false);
 
     return true;
+}
+
+static void SetFrameType(const VP9DecoderFrame &frameInfo, mfxFrameSurface1 &surface_out)
+{
+    auto extFrameInfo = reinterpret_cast<mfxExtDecodedFrameInfo *>(GetExtendedBuffer(surface_out.Data.ExtParam, surface_out.Data.NumExtParam, MFX_EXTBUFF_DECODED_FRAME_INFO));
+    if (extFrameInfo == nullptr)
+        return;
+
+    switch (frameInfo.frameType)
+    {
+        case KEY_FRAME:
+            extFrameInfo->FrameType = MFX_FRAMETYPE_I;
+            break;
+        case INTER_FRAME:
+            extFrameInfo->FrameType = MFX_FRAMETYPE_P;
+            break;
+        default:
+            extFrameInfo->FrameType = MFX_FRAMETYPE_UNKNOWN;
+    }
 }
 
 mfxStatus VideoDECODEVP9_HW::UpdateRefFrames()
@@ -1128,6 +1147,8 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1
 
     if (m_frameInfo.showFrame)
     {
+        SetFrameType(m_frameInfo, **surface_out);
+
         (*surface_out)->Data.TimeStamp = bs->TimeStamp != static_cast<mfxU64>(MFX_TIMESTAMP_UNKNOWN) ? bs->TimeStamp : GetMfxTimeStamp(m_frameOrder * m_in_framerate);
         (*surface_out)->Data.Corrupted = 0;
         (*surface_out)->Data.FrameOrder = m_frameOrder;


### PR DESCRIPTION
-Add reporting type of decoded frame via extended buffer
 MFX_EXTBUFF_DECODED_FRAME_INFO

Fixes: #333