### PR TITLE
h264e: restore check adaptive max frame size

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -784,8 +784,16 @@ namespace
 
         if (hwCaps.UserMaxFrameSizeSupport == 0 && !IsEnabledSwBrc && IsOn(extOpt3.AdaptiveMaxFrameSize))
         {
-            extOpt3.AdaptiveMaxFrameSize = 0;
+            extOpt3.AdaptiveMaxFrameSize = MFX_CODINGOPTION_UNKNOWN;
             unsupported = true;
+        }
+
+        if (hwCaps.UserMaxFrameSizeSupport == 1 && !IsEnabledSwBrc &&
+            (extOpt3.MaxFrameSizeP == 0 || IsOn(par.mfx.LowPower)) &&
+            IsOn(extOpt3.AdaptiveMaxFrameSize))
+        {
+            extOpt3.AdaptiveMaxFrameSize = MFX_CODINGOPTION_UNKNOWN;
+            changed = true;
         }
 #endif
         return unsupported ? MFX_ERR_UNSUPPORTED : (changed ? MFX_WRN_INCOMPATIBLE_VIDEO_PARAM : MFX_ERR_NONE);


### PR DESCRIPTION
-AdaptiveMaxFrameSize can't be ON if MaxFrameSizeP = 0 or LowPower is ON