### PR TITLE
[vp9e] update temporal layers after reset

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_vaapi.h
@@ -163,6 +163,7 @@ do {                                               \
 
         // max number of temp layers is 8, but now supported only 4
         VABufferID m_tempLayersBufferId;
+        bool       m_tempLayersParamsReset;
         std::vector<VABufferID> m_frameRateBufferIds; // individual buffer for every temporal layer
         std::vector<VABufferID> m_rateCtrlBufferIds;  // individual buffer for every temporal layer
 

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -589,6 +589,7 @@ VAAPIEncoder::VAAPIEncoder()
 , m_packedHeaderParameterBufferId(VA_INVALID_ID)
 , m_packedHeaderDataBufferId(VA_INVALID_ID)
 , m_tempLayersBufferId(VA_INVALID_ID)
+, m_tempLayersParamsReset(false)
 , m_width(0)
 , m_height(0)
 , m_isBrcResetRequired(false)
@@ -889,11 +890,11 @@ mfxStatus VAAPIEncoder::Reset(VP9MfxVideoParam const & par)
     mfxSts = SetHRD(par, m_vaDisplay, m_vaContextEncode, m_hrdBufferId);
     MFX_CHECK_WITH_ASSERT(MFX_ERR_NONE == mfxSts, MFX_ERR_DEVICE_FAILED);
 
-    if (par.m_numLayers)
-    {
-        mfxSts = SetTemporalStructure(par, m_vaDisplay, m_vaContextEncode, m_tempLayersBufferId);
-        MFX_CHECK_WITH_ASSERT(MFX_ERR_NONE == mfxSts, MFX_ERR_DEVICE_FAILED);
-    }
+    // even we have not temporal layers (after reset), 
+    // we have to update driver temporal layers structures in the next render cycle
+    mfxSts = SetTemporalStructure(par, m_vaDisplay, m_vaContextEncode, m_tempLayersBufferId);
+    MFX_CHECK_WITH_ASSERT(MFX_ERR_NONE == mfxSts, MFX_ERR_DEVICE_FAILED);
+    m_tempLayersParamsReset = true;
 
     mfxSts = SetRateControl(par, m_vaDisplay, m_vaContextEncode, m_rateCtrlBufferIds);
     MFX_CHECK_WITH_ASSERT(MFX_ERR_NONE == mfxSts, MFX_ERR_DEVICE_FAILED);
@@ -1132,8 +1133,11 @@ mfxStatus VAAPIEncoder::Execute(
         configBuffers.push_back(m_hrdBufferId);
 
         // 9. temporal layers
-        if (m_video.m_numLayers)
+        if (m_video.m_numLayers || m_tempLayersParamsReset)
+        {
             configBuffers.push_back(m_tempLayersBufferId);
+            m_tempLayersParamsReset = false;
+        }
 
         // 10. RC parameters
         SetRateControl(m_video, m_vaDisplay, m_vaContextEncode, m_rateCtrlBufferIds, m_isBrcResetRequired);


### PR DESCRIPTION
After reset driver keep using old temporal layers and it leads to FPE. 
Driver still using temporal layers, even we don't send them in next cycle and had cleared temporal layers structure. We can clear temporal layers structure and send it (empty) in first sequence parameters update after reset to avoid it.

MDP-52486