### PR TITLE
[build] windows mfx defines in separate file

### DIFF
--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -31,7 +31,10 @@
     #endif
 #endif
 
-#if defined(ANDROID)
+#if defined(_WIN32) || defined(_WIN64)
+    #include "mfx_windows_defs.h"
+
+#elif defined(ANDROID)
     // we don't support config auto-generation on Android and have hardcoded
     // definition instead
     #include "mfx_android_defs.h"
@@ -49,7 +52,7 @@
         #endif
         #define MFX_ENABLE_VPP
     #endif
-#endif // #if defined(ANDROID)
+#endif // #if defined(_WIN32) || defined(_WIN64) || defined(ANDROID)
 
 // Here follows per-codec feature enable options which as of now we don't
 // want to expose on build system level since they are too detailed.

--- a/builder/FindInternals.cmake
+++ b/builder/FindInternals.cmake
@@ -37,6 +37,12 @@ function( mfx_include_dirs )
     ${CMAKE_HOME_DIRECTORY}/contrib/cm/include
   )
 
+  if( Windows )
+    include_directories (
+      ${CMAKE_HOME_DIRECTORY}/windows/include
+    )
+  endif()
+
   set ( MSDK_STUDIO_ROOT ${CMAKE_HOME_DIRECTORY}/_studio PARENT_SCOPE )
   set ( MSDK_LIB_ROOT    ${CMAKE_HOME_DIRECTORY}/_studio/mfx_lib PARENT_SCOPE )
   set ( MSDK_UMC_ROOT    ${CMAKE_HOME_DIRECTORY}/_studio/shared/umc PARENT_SCOPE )

--- a/windows/include/mfx_windows_defs.h
+++ b/windows/include/mfx_windows_defs.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef _MFX_WIN_CONFIG_H_
+#define _MFX_WIN_CONFIG_H_
+
+    #define MFX_ENABLE_KERNELS
+
+    #if ((MFX_VERSION >= 1026) && (!AS_CAMERA_PLUGIN))
+    #define MFX_ENABLE_MCTF
+    #endif
+
+    #define MFX_ENABLE_USER_DECODE
+    #define MFX_ENABLE_USER_ENCODE
+    #define MFX_ENABLE_USER_ENC
+    #define MFX_ENABLE_USER_VPP
+
+    #define MFX_ENABLE_MPEG2_VIDEO_DECODE
+    #define MFX_ENABLE_MJPEG_VIDEO_DECODE
+    #define MFX_ENABLE_H264_VIDEO_DECODE
+    #if defined(MFX_VA)
+        #define MFX_ENABLE_H265_VIDEO_DECODE
+        #define MFX_ENABLE_VP8_VIDEO_DECODE_HW
+        #define MFX_ENABLE_VP9_VIDEO_DECODE_HW
+    #endif
+    #define MFX_ENABLE_VC1_VIDEO_DECODE
+
+    #define MFX_ENABLE_MPEG2_VIDEO_ENCODE
+    #define MFX_ENABLE_MJPEG_VIDEO_ENCODE
+    #define MFX_ENABLE_H264_VIDEO_ENCODE
+    #define MFX_ENABLE_H264_VIDEO_ENCODE_HW
+    #if defined(AS_HEVCD_PLUGIN) || defined(AS_HEVCE_PLUGIN) || defined(MFX_VA)
+        #define MFX_ENABLE_H265_VIDEO_ENCODE
+    #endif
+
+#endif // _MFX_WIN_CONFIG_H_


### PR DESCRIPTION
Preparing for back merging  commits, which replaces UMC_XXX with MFX_XXX,  to close-source.
mfx_config.h includes mfx_android_defs.h or mfx_windows_defs.h or mfxconfig.h
umc_defs.h cleaned from component definitions and simple includes mfx_config.h
