### PR TITLE
sample_common: fix mismatched new [] / delete

### DIFF
--- a/samples/sample_common/src/sample_utils.cpp
+++ b/samples/sample_common/src/sample_utils.cpp
@@ -826,7 +826,7 @@ void CSmplYUVWriter::Close()
                 m_fDestMVC[i] = NULL;
             }
         }
-        delete m_fDestMVC;
+        delete [] m_fDestMVC;
         m_fDestMVC = NULL;
     }
 


### PR DESCRIPTION
m_fDestMVC is allocated as array