### PR TITLE
[VP9D] resolution change check removed if VA used

### DIFF
--- a/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp9/src/mfx_vp9_dec_decode_hw.cpp
@@ -1094,10 +1094,14 @@ mfxStatus VideoDECODEVP9_HW::DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1
         if (m_vPar.mfx.FrameInfo.Width > m_vInitPar.mfx.FrameInfo.Width || m_vPar.mfx.FrameInfo.Height > m_vInitPar.mfx.FrameInfo.Height)
             return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
 
+// this check is not needed if re-allocation of internal surface function is implemented 
+// (currently only in VAAPI linux)
+#ifndef MFX_VA_LINUX
         if (KEY_FRAME == frameInfo.frameType &&
             (m_vPar.mfx.FrameInfo.Width != m_vInitPar.mfx.FrameInfo.Width || m_vPar.mfx.FrameInfo.Height != m_vInitPar.mfx.FrameInfo.Height) &&
             1 != m_index)
             return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
+#endif
     }
 
     //update frame info


### PR DESCRIPTION
Can been removed when VA surface reallocation patch implemented.

MDP-53745