### PR TITLE
VA: remove unnecessary cast for VA buffers type

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -1459,9 +1459,8 @@ mfxStatus VAAPIEncoder::Execute(Task const & task, mfxHDLPair pair)
 
         vaSts = vaCreateBuffer(m_vaDisplay,
             m_vaContextEncode,
-
-            (VABufferType)VAEncQPBufferType,
-            m_cuqpMap.m_pitch ,
+            VAEncQPBufferType,
+            m_cuqpMap.m_pitch,
             m_cuqpMap.m_h_aligned,
             &m_cuqpMap.m_buffer[0],
             &VABufferNew(VABID_QpBuffer, 0));

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -2141,7 +2141,7 @@ mfxStatus VAAPIEncoder::Execute(
             MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MVP)");
             vaSts = vaCreateBuffer(m_vaDisplay,
                     m_vaContextEncode,
-                    (VABufferType)VAEncFEIMVPredictorBufferType,
+                    VAEncFEIMVPredictorBufferType,
                     sizeof(VAEncFEIMVPredictorH264)*mvpred->NumMBAlloc,
                     1, //limitation from driver, num elements should be 1
                     mvpred->MB,
@@ -2154,7 +2154,7 @@ mfxStatus VAAPIEncoder::Execute(
             MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MBctrl)");
             vaSts = vaCreateBuffer(m_vaDisplay,
                     m_vaContextEncode,
-                    (VABufferType)VAEncFEIMBControlBufferType,
+                    VAEncFEIMBControlBufferType,
                     sizeof(VAEncFEIMBControlH264)*mbctrl->NumMBAlloc,
                     1, //limitation from driver, num elements should be 1
                     mbctrl->MB,
@@ -2168,7 +2168,7 @@ mfxStatus VAAPIEncoder::Execute(
 #if MFX_VERSION >= 1023
             vaSts = vaCreateBuffer(m_vaDisplay,
                     m_vaContextEncode,
-                    (VABufferType)VAEncQPBufferType,
+                    VAEncQPBufferType,
                     sizeof(VAEncQPBufferH264)*mbqp->NumMBAlloc,
                     1, //limitation from driver, num elements should be 1
                     mbqp->MB,
@@ -2176,7 +2176,7 @@ mfxStatus VAAPIEncoder::Execute(
 #else
             vaSts = vaCreateBuffer(m_vaDisplay,
                     m_vaContextEncode,
-                    (VABufferType)VAEncQPBufferType,
+                    VAEncQPBufferType,
                     sizeof (VAEncQPBufferH264)*mbqp->NumQPAlloc,
                     1, //limitation from driver, num elements should be 1
                     mbqp->QP,
@@ -2213,7 +2213,7 @@ mfxStatus VAAPIEncoder::Execute(
                     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer");
                     vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
-                            (VABufferType)VAEncFEIDistortionBufferType,
+                            VAEncFEIDistortionBufferType,
                             vaFeiMBStatBufSize,
                             1, //limitation from driver, num elements should be 1
                             NULL, //should be mapped later
@@ -2252,7 +2252,7 @@ mfxStatus VAAPIEncoder::Execute(
                     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer");
                     vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
-                            (VABufferType)VAEncFEIMVBufferType,
+                            VAEncFEIMVBufferType,
                             vaFeiMVOutBufSize,
                             1, //limitation from driver, num elements should be 1
                             NULL, //should be mapped later
@@ -2278,7 +2278,7 @@ mfxStatus VAAPIEncoder::Execute(
                     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer");
                     vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
-                            (VABufferType)VAEncFEIMBCodeBufferType,
+                            VAEncFEIMBCodeBufferType,
                             vaFeiMCODEOutBufSize,
                             1, //limitation from driver, num elements should be 1
                             NULL, //should be mapped later
@@ -2798,7 +2798,7 @@ mfxStatus VAAPIEncoder::Execute(
             // LibVA expect full buffer size w/o interlace adjustments
             vaSts = vaCreateBuffer(m_vaDisplay,
                 m_vaContextEncode,
-                (VABufferType)VAEncQPBufferType,
+                VAEncQPBufferType,
                 bufW * sizeof(VAEncQPBufferH264),
                 ((m_sps.picture_height_in_mbs + 7) & ~7),
                 &m_mbqp_buffer[0],
@@ -2831,7 +2831,7 @@ mfxStatus VAAPIEncoder::Execute(
 
             vaSts = vaCreateBuffer(m_vaDisplay,
                     m_vaContextEncode,
-                    (VABufferType)VAEncMacroblockDisableSkipMapBufferType,
+                    VAEncMacroblockDisableSkipMapBufferType,
                     (bufW * bufH),
                     1,
                     &m_mb_noskip_buffer[0],

--- a/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_fei_vaapi.cpp
@@ -197,7 +197,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
         // this buffer is always frame sized for mixed picstructs case
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsStatisticsBufferType,
+                                VAStatsStatisticsBufferType,
                                 sizeof(VAStatsStatisticsH264) * currNumMbs_first_buff,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -208,7 +208,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
         // this buffer is always half frame sized
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsStatisticsBottomFieldBufferType,
+                                VAStatsStatisticsBottomFieldBufferType,
                                 sizeof(VAStatsStatisticsH264) * currNumMbs / 2,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -220,7 +220,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
 
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsMVBufferType,
+                                VAStatsMVBufferType,
                                 //sizeof (VAMotionVector)*mvsOut->NumMBAlloc * 16, //16 MV per MB
                                 sizeof(VAMotionVector) * currNumMbs_first_buff * 16,
                                 1, //limitation from driver, num elements should be 1
@@ -230,7 +230,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
 
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsMVBufferType,
+                                VAStatsMVBufferType,
                                 //sizeof (VAMotionVector)*mvsOut->NumMBAlloc * 16, //16 MV per MB
                                 sizeof(VAMotionVector) * currNumMbs / 2 * 16,
                                 1, //limitation from driver, num elements should be 1
@@ -248,7 +248,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
         // buffer for frame
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsStatisticsBufferType,
+                                VAStatsStatisticsBufferType,
                                 sizeof(VAStatsStatisticsH264) * currNumMbs,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -261,7 +261,7 @@ mfxStatus VAAPIFEIPREENCEncoder::CreatePREENCAccelerationService(MfxVideoParam c
 
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsMVBufferType,
+                                VAStatsMVBufferType,
                                 //sizeof (VAMotionVector)*mvsOut->NumMBAlloc * 16, //16 MV per MB
                                 sizeof(VAMotionVector)* currNumMbs * 16,
                                 1,
@@ -389,7 +389,7 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
     {
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAStatsMVPredictorBufferType,
+                                VAStatsMVPredictorBufferType,
                                 sizeof(VAMotionVector) *feiMVPred->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 feiMVPred->MB,
@@ -405,7 +405,7 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
     {
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncQPBufferType,
+                                VAEncQPBufferType,
                                 sizeof(VAEncQPBufferH264)*feiQP->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 feiQP->MB,
@@ -420,7 +420,7 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
     {
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncQPBufferType,
+                                VAEncQPBufferType,
                                 sizeof (VAEncQPBufferH264)*feiQP->NumQPAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 feiQP->QP,
@@ -569,7 +569,7 @@ mfxStatus VAAPIFEIPREENCEncoder::Execute(
 
     vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextEncode,
-                            (VABufferType)VAStatsStatisticsParameterBufferType,
+                            VAStatsStatisticsParameterBufferType,
                             sizeof (statParams),
                             1,
                             &statParams,
@@ -1148,7 +1148,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MVP)");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMVPredictorBufferType,
+                                VAEncFEIMVPredictorBufferType,
                                 sizeof(VAEncFEIMVPredictorH264)*mvpred->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 mvpred->MB,
@@ -1162,7 +1162,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MBctrl)");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMBControlBufferType,
+                                VAEncFEIMBControlBufferType,
                                 sizeof(VAEncFEIMBControlH264)*mbctrl->NumMBAlloc,
                                 1,//limitation from driver, num elements should be 1
                                 mbctrl->MB,
@@ -1177,7 +1177,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
 #if MFX_VERSION >= 1023
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncQPBufferType,
+                                VAEncQPBufferType,
                                 sizeof(VAEncQPBufferH264)*mbqp->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 mbqp->MB,
@@ -1185,7 +1185,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
 #else
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncQPBufferType,
+                                VAEncQPBufferType,
                                 sizeof (VAEncQPBufferH264)*mbqp->NumQPAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 mbqp->QP,
@@ -1202,7 +1202,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MBstat)");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIDistortionBufferType,
+                                VAEncFEIDistortionBufferType,
                                 sizeof(VAEncFEIDistortionH264)*mbstat->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -1217,7 +1217,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MV)");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMVBufferType,
+                                VAEncFEIMVBufferType,
                                 sizeof(VAMotionVector) * 16 * mvout->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -1232,7 +1232,7 @@ mfxStatus VAAPIFEIENCEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateBuffer (MBcode)");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMBCodeBufferType,
+                                VAEncFEIMBCodeBufferType,
                                 sizeof(VAEncFEIMBCodeH264)*mbcodeout->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 NULL, //should be mapped later
@@ -2123,7 +2123,7 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "MV");
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMVBufferType,
+                                VAEncFEIMVBufferType,
                                 sizeof(VAMotionVector) * 16 * mvout->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 mvout->MB,
@@ -2138,7 +2138,7 @@ mfxStatus VAAPIFEIPAKEncoder::Execute(
 
         vaSts = vaCreateBuffer(m_vaDisplay,
                                 m_vaContextEncode,
-                                (VABufferType)VAEncFEIMBCodeBufferType,
+                                VAEncFEIMBCodeBufferType,
                                 sizeof(VAEncFEIMBCodeH264)*mbcodeout->NumMBAlloc,
                                 1, //limitation from driver, num elements should be 1
                                 mbcodeout->MB,

--- a/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
@@ -1085,7 +1085,7 @@ mfxStatus VAAPIEncoder::FillMBQPBuffer(
 
     vaSts = vaCreateBuffer(m_vaDisplay,
         m_vaContextEncode,
-        (VABufferType)VAEncQPBufferType,
+        VAEncQPBufferType,
         bufW,
         bufH,//m_mbqpDataBuffer.size(),
         &m_mbqpDataBuffer[0],


### PR DESCRIPTION
These types are defined in VA headers, so no cast is required