### PR TITLE
[sample_encode] Enable tiles for VP9 encoder

### DIFF
--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -108,6 +108,9 @@ struct sInputParams
     mfxU16 nDstWidth; // destination picture width, specified if resizing required
     mfxU16 nDstHeight; // destination picture height, specified if resizing required
 
+    mfxU16 nEncTileRows; // number of rows for encoding tiling
+    mfxU16 nEncTileCols; // number of columns for encoding tiling
+
     MemType memType;
     bool bUseHWLib; // true if application wants to use HW MSDK library
 
@@ -388,6 +391,8 @@ protected:
     // HEVC
     mfxExtHEVCParam m_ExtHEVCParam;
     mfxExtCodingOption3 m_CodingOption3;
+    // VP9
+    mfxExtVP9Param m_ExtVP9Param;
 
     // Set up video signal information
     mfxExtVideoSignalInfo m_VideoSignalInfo;

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -471,6 +471,11 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
     m_mfxEncParams.mfx.FrameInfo.CropW = pInParams->nDstWidth;
     m_mfxEncParams.mfx.FrameInfo.CropH = pInParams->nDstHeight;
 
+#if MFX_VERSION >= MFX_VERSION_NEXT
+    m_ExtVP9Param.NumTileRows    = pInParams->nEncTileRows;
+    m_ExtVP9Param.NumTileColumns = pInParams->nEncTileCols;
+#endif
+
     bool bCodingOption = false;
     if(*pInParams->uSEI && (pInParams->CodecId == MFX_CODEC_AVC ||
                 pInParams->CodecId == MFX_CODEC_HEVC))
@@ -635,6 +640,15 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
         m_ExtHEVCParam.PicHeightInLumaSamples = m_mfxEncParams.mfx.FrameInfo.CropH;
         m_EncExtParams.push_back((mfxExtBuffer*)&m_ExtHEVCParam);
     }
+
+#if MFX_VERSION >= MFX_VERSION_NEXT
+    if (m_ExtVP9Param.NumTileRows
+        && m_ExtVP9Param.NumTileColumns
+        && m_mfxEncParams.mfx.CodecId == MFX_CODEC_VP9)
+    {
+        m_EncExtParams.push_back((mfxExtBuffer*)&m_ExtVP9Param);
+    }
+#endif
 
     if (pInParams->TransferMatrix)
     {
@@ -1123,6 +1137,10 @@ CEncodingPipeline::CEncodingPipeline()
     MSDK_ZERO_MEMORY(m_ExtHEVCParam);
     m_ExtHEVCParam.Header.BufferId = MFX_EXTBUFF_HEVC_PARAM;
     m_ExtHEVCParam.Header.BufferSz = sizeof(m_ExtHEVCParam);
+
+    MSDK_ZERO_MEMORY(m_ExtVP9Param);
+    m_ExtVP9Param.Header.BufferId = MFX_EXTBUFF_VP9_PARAM;
+    m_ExtVP9Param.Header.BufferSz = sizeof(m_ExtVP9Param);
 
     MSDK_ZERO_MEMORY(m_VideoSignalInfo);
     m_VideoSignalInfo.Header.BufferId = MFX_EXTBUFF_VIDEO_SIGNAL_INFO;

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -124,6 +124,8 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-mss]                   - maximum slice size in bytes. Supported only with -hw and h264 codec. This option is not compatible with -num_slice option.\n"));
     msdk_printf(MSDK_STRING("   [-mfs]                   - maximum frame size in bytes. Supported only with h264 and hevc codec for VBR mode.\n"));
     msdk_printf(MSDK_STRING("   [-re]                    - enable region encode mode. Works only with h265 encoder\n"));
+    msdk_printf(MSDK_STRING("   [-trows rows]            - Number of rows for tiled encoding\n"));
+    msdk_printf(MSDK_STRING("   [-tcols cols]            - Number of columns for tiled encoding\n"));
     msdk_printf(MSDK_STRING("   [-CodecProfile]          - specifies codec profile\n"));
     msdk_printf(MSDK_STRING("   [-CodecLevel]            - specifies codec level\n"));
     msdk_printf(MSDK_STRING("   [-GopOptFlag:closed]     - closed gop\n"));
@@ -259,6 +261,24 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
             if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nDstHeight))
             {
                 PrintHelp(strInput[0], MSDK_STRING("Destination picture Height is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-trows")))
+        {
+            VAL_CHECK(i+1 >= nArgNum, i, strInput[i]);
+            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nEncTileRows))
+            {
+                PrintHelp(strInput[0], MSDK_STRING("Encoding tile row count is invalid"));
+                return MFX_ERR_UNSUPPORTED;
+            }
+        }
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-tcols")))
+        {
+            VAL_CHECK(i+1 >= nArgNum, i, strInput[i]);
+            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nEncTileCols))
+            {
+                PrintHelp(strInput[0], MSDK_STRING("Encoding tile column count is invalid"));
                 return MFX_ERR_UNSUPPORTED;
             }
         }


### PR DESCRIPTION
New test suite: sample_encode_vp9e_tile