### PR TITLE
vpp vaapi: Fix buffer removal from pipe

### DIFF
--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -1286,10 +1286,11 @@ mfxStatus VAAPIVideoProcessing::RemoveBufferFromPipe(VABufferID& id)
 {
     if (id != VA_INVALID_ID)
     {
+        VABufferID tmp = id;
         mfxStatus sts = CheckAndDestroyVAbuffer(m_vaDisplay, id);
         MFX_CHECK_STS(sts);
 
-        std::remove(m_filterBufs, m_filterBufs + m_numFilterBufs, id);
+        std::remove(m_filterBufs, m_filterBufs + m_numFilterBufs, tmp);
         m_filterBufs[m_numFilterBufs] = VA_INVALID_ID;
         --m_numFilterBufs;
     }


### PR DESCRIPTION
```CheckAndDestroyVAbuffer``` assigns ```VA_INVALID_ID``` after buffer deallocation.
Old value should be used for buffer removing from pipe