### PR TITLE
cmrt: remove useless asserts

### DIFF
--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmvm.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmvm.h
@@ -1110,9 +1110,7 @@ const vector<T, R2*WD> matrix<T, R, C>::genx_select(OFFSET ioff, OFFSET joff)
 {
     static_assert((!std::is_same<T, double>::value), "genx_select is not supported for matrices with element type of 'double'");
     static_assert(R2 > 0, "invalid dimensions");
-    static_assert(VS >= 0, "invalid dimensions");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(HS >= 0, "invalid dimensions");
     assert(ioff < R);
     assert(joff < C);
 
@@ -1130,8 +1128,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector<T2, WD>& index)
 {
     static_assert(is_inttype<T2>::value, "invalid type");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index.get(i) < SZ), WD, i);
@@ -1150,8 +1146,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector_ref<T2, WD>& index)
 {
     static_assert(is_inttype<T2>::value, "invalid type");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index.get(i) < SZ), WD, i);
@@ -1171,8 +1165,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector<T2, WD>& index_x, const vect
 {
     static_assert((std::is_unsigned<T2>::value), "iselect index vector element type must be unsigned");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index_x.get(i) < R), WD, i);
@@ -1192,8 +1184,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector_ref<T2, WD>& index_x, const 
 {
     static_assert((std::is_unsigned<T2>::value), "iselect index vector element type must be unsigned");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index_x.get(i) < R), WD, i);
@@ -1214,8 +1204,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector<T2, WD>& index_x, const vect
 {
     static_assert((std::is_unsigned<T2>::value), "iselect index vector element type must be unsigned");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index_x.get(i) < R), WD, i);
@@ -1235,8 +1223,6 @@ vector<T, WD> matrix<T, R, C>::iselect(const vector_ref<T2, WD>& index_x, const 
 {
     static_assert((std::is_unsigned<T2>::value), "iselect index vector element type must be unsigned");
     static_assert(WD > 0, "invalid dimensions");
-    static_assert(R >= 0, "invalid dimensions");
-    static_assert(C >= 0, "invalid dimensions");
 
     for (uint i = 0; i < WD; i++) {
         SIMDCF_WRAPPER(assert(index_x.get(i) < R), WD, i);


### PR DESCRIPTION
-variable uint (unsigned int) always >= 0,
 so assert(variable >= 0) is equal assert(1)