### PR TITLE
samples: use std syncronization primitives

### DIFF
--- a/samples/sample_common/include/base_allocator.h
+++ b/samples/sample_common/include/base_allocator.h
@@ -25,8 +25,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include <functional>
 #include "mfxvideo.h"
 #include <memory>
-
-class MSDKMutex;
+#include <mutex>
 
 struct mfxAllocatorParams
 {
@@ -67,7 +66,6 @@ private:
 // request type contains either FROM_ENCODE or FROM_VPPIN
 
 // This class does not allocate any actual memory
-class MSDKMutex;
 
 class BaseFrameAllocator: public MFXFrameAllocator
 {
@@ -81,7 +79,7 @@ public:
     virtual mfxStatus FreeFrames(mfxFrameAllocResponse *response);
 
 protected:
-    std::unique_ptr<MSDKMutex> mtx;
+    std::mutex mtx;
     typedef std::list<mfxFrameAllocResponse>::iterator Iter;
     static const mfxU32 MEMTYPE_FROM_MASK = MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_FROM_DECODE | \
                                             MFX_MEMTYPE_FROM_VPPIN | MFX_MEMTYPE_FROM_VPPOUT | \

--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2018, Intel Corporation
+Copyright (c) 2005-2019, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -24,6 +24,9 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include <string>
 #include <sstream>
 #include <vector>
+#include <map>
+#include <stdexcept>
+#include <mutex>
 
 #include "mfxstructures.h"
 #include "mfxvideo.h"
@@ -36,7 +39,6 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include "vm/time_defs.h"
 #include "vm/atomic_defs.h"
 #include "vm/thread_defs.h"
-#include <map>
 
 #include "sample_types.h"
 
@@ -46,9 +48,6 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include "avc_headers.h"
 #include "avc_nal_spl.h"
 
-#ifdef ENABLE_MCTF
-#include  <stdexcept>
-#endif
 
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
@@ -766,11 +765,11 @@ ParamT * GetMctfParamBuffer(mfxFrameSurface1* pmfxSurface, bool DeallocateAll = 
 {
     // map <pointer, busy-status>
     static std::map<ParamT*, bool> mfxFrameParamPool;
-    static MSDKMutex ExclusiveAccess;
+    static std::mutex ExclusiveAccess;
+
     typedef typename std::map<ParamT*, bool>::iterator map_iter;
 
-
-    AutomaticMutex guard(ExclusiveAccess);
+    std::lock_guard<std::mutex> guard(ExclusiveAccess);
     if (!pmfxSurface && !DeallocateAll)
         return NULL;
     if (DeallocateAll)

--- a/samples/sample_common/src/base_allocator.cpp
+++ b/samples/sample_common/src/base_allocator.cpp
@@ -88,7 +88,6 @@ mfxStatus MFXFrameAllocator::GetHDL_(mfxHDL pthis, mfxMemId mid, mfxHDL *handle)
 
 BaseFrameAllocator::BaseFrameAllocator()
 {
-    mtx.reset(new MSDKMutex());
 }
 
 BaseFrameAllocator::~BaseFrameAllocator()
@@ -181,7 +180,7 @@ mfxStatus BaseFrameAllocator::AllocFrames(mfxFrameAllocRequest *request, mfxFram
 
 mfxStatus BaseFrameAllocator::FreeFrames(mfxFrameAllocResponse *response)
 {
-    AutomaticMutex lock(*mtx);
+    std::lock_guard<std::mutex> lock(mtx);
 
     if (response == 0)
         return MFX_ERR_INVALID_HANDLE;
@@ -219,7 +218,8 @@ mfxStatus BaseFrameAllocator::FreeFrames(mfxFrameAllocResponse *response)
 
 mfxStatus BaseFrameAllocator::Close()
 {
-    AutomaticMutex lock(*mtx);
+    std::lock_guard<std::mutex> lock(mtx);
+
     std::list<UniqueResponse> ::iterator i;
     for (i = m_ExtResponses.begin(); i!= m_ExtResponses.end(); i++)
     {

--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2018, Intel Corporation
+Copyright (c) 2005-2019, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include <map>
 #include <future>
 #include <chrono>
+#include <mutex>
 
 #include "sample_defs.h"
 #include "sample_utils.h"
@@ -547,15 +548,15 @@ namespace TranscodingSample
         mfxStatus         ReleaseSurfaceAll();
         void              CancelBuffering();
 
-        SafetySurfaceBuffer               *m_pNext;
+        SafetySurfaceBuffer         *m_pNext;
 
     protected:
 
-        MSDKMutex                 m_mutex;
-        std::list<SurfaceDescriptor>       m_SList;
-        bool m_IsBufferingAllowed;
-        MSDKEvent* pRelEvent;
-        MSDKEvent* pInsEvent;
+        std::mutex                   m_mutex;
+        std::list<SurfaceDescriptor> m_SList;
+        bool                         m_IsBufferingAllowed;
+        MSDKEvent*                   pRelEvent;
+        MSDKEvent*                   pInsEvent;
     private:
         DISALLOW_COPY_AND_ASSIGN(SafetySurfaceBuffer);
     };
@@ -846,8 +847,8 @@ namespace TranscodingSample
         bool                   m_bIsInit;
 
         mfxU32          m_NumFramesForReset;
-        MSDKMutex       m_mReset;
-        MSDKMutex       m_mStopSession;
+        std::mutex      m_mReset;
+        std::mutex      m_mStopSession;
         bool            m_bRobustFlag;
 
         bool isHEVCSW;

--- a/samples/sample_plugins/rotate_cpu/src/plugin_rotate.cpp
+++ b/samples/sample_plugins/rotate_cpu/src/plugin_rotate.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2018, Intel Corporation
+Copyright (c) 2005-2019, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -23,6 +23,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include "vm/thread_defs.h"
 #include <map>
 #include <tuple>
+#include <mutex>
 #include "plugin_rotate.h"
 
 // disable "unreferenced formal parameter" warning -
@@ -33,7 +34,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 typedef  std::tuple<mfxMemId, mfxHDL> UniqueMid;
 std::map<UniqueMid, int> mappingResourceManager;
 
-MSDKMutex mapping_mutex;
+std::mutex mapping_mutex;
 
 #define SWAP_BYTES(a, b) {mfxU8 tmp; tmp = a; a = b; b = tmp;}
 
@@ -420,8 +421,7 @@ mfxStatus Processor::LockFrame(mfxFrameSurface1 *frame)
     MSDK_CHECK_POINTER(frame, MFX_ERR_NULL_PTR);
     mfxStatus sts = MFX_ERR_NONE;
 
-    /* mutex locker */
-    AutomaticMutex locker(mapping_mutex);
+    std::lock_guard<std::mutex> locker(mapping_mutex);
 
     // MemId=0, that is surface was created without allocator
     // No neeed in lock/unlock
@@ -448,8 +448,7 @@ mfxStatus Processor::UnlockFrame(mfxFrameSurface1 *frame)
     MSDK_CHECK_POINTER(frame, MFX_ERR_NULL_PTR);
     mfxStatus sts = MFX_ERR_NONE;
 
-    /* mutex locker */
-    AutomaticMutex locker(mapping_mutex);
+    std::lock_guard<std::mutex> locker(mapping_mutex);
 
     // MemId=0, that is surface was created without allocator
     // No neeed in lock/unlock


### PR DESCRIPTION
Replaced MSDKMutex with std::mutex and appropriate guards in most trivial cases