### PR TITLE
[sample_multi_transcode] Enable tiles for HEVC encoder

### DIFF
--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -797,6 +797,7 @@ namespace TranscodingSample
 
         // HEVC
         mfxExtHEVCParam          m_ExtHEVCParam;
+        mfxExtHEVCTiles          m_ExtHEVCTiles;
         // VP9
         mfxExtVP9Param           m_ExtVP9Param;
 

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -174,6 +174,7 @@ CTranscodingPipeline::CTranscodingPipeline():
     MSDK_ZERO_MEMORY(m_CodingOption2);
     MSDK_ZERO_MEMORY(m_CodingOption3);
     MSDK_ZERO_MEMORY(m_ExtHEVCParam);
+    MSDK_ZERO_MEMORY(m_ExtHEVCTiles);
     MSDK_ZERO_MEMORY(m_ExtVP9Param);
 #if MFX_VERSION >= 1022
     MSDK_ZERO_MEMORY(m_decPostProcessing);
@@ -2529,14 +2530,20 @@ MFX_IOPATTERN_IN_VIDEO_MEMORY : MFX_IOPATTERN_IN_SYSTEM_MEMORY);
         m_mfxEncParams.IOPattern = InPatternFromParent;
 
 #if MFX_VERSION >= 1029
-    m_ExtVP9Param.NumTileRows    = pInParams->nEncTileRows;
-    m_ExtVP9Param.NumTileColumns = pInParams->nEncTileCols;
-
-    if (m_ExtVP9Param.NumTileRows
-        && m_ExtVP9Param.NumTileColumns
-        && m_mfxEncParams.mfx.CodecId == MFX_CODEC_VP9)
+    if (pInParams->nEncTileRows && pInParams->nEncTileCols)
     {
-        m_EncExtParams.push_back((mfxExtBuffer*)&m_ExtVP9Param);
+        if (m_mfxEncParams.mfx.CodecId == MFX_CODEC_HEVC)
+        {
+            m_ExtHEVCTiles.NumTileRows    = pInParams->nEncTileRows;
+            m_ExtHEVCTiles.NumTileColumns = pInParams->nEncTileCols;
+            m_EncExtParams.push_back((mfxExtBuffer*)&m_ExtHEVCTiles);
+        }
+        else if (m_mfxEncParams.mfx.CodecId == MFX_CODEC_VP9)
+        {
+            m_ExtVP9Param.NumTileRows    = pInParams->nEncTileRows;
+            m_ExtVP9Param.NumTileColumns = pInParams->nEncTileCols;
+            m_EncExtParams.push_back((mfxExtBuffer*)&m_ExtVP9Param);
+        }
     }
 #endif
 


### PR DESCRIPTION
This commit is to enable "tiles" for HEVC encoder in sample_multi_transcode.