### PR TITLE
To fix security issue in 'printf' function call

### DIFF
--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -382,7 +382,7 @@ mfxStatus CDecodingPipeline::Init(sInputParams *pParams)
             }
             if(sts==MFX_ERR_UNSUPPORTED)
             {
-                msdk_printf(isDefaultPlugin ?
+                msdk_printf(MSDK_STRING("%s"), isDefaultPlugin ?
                     MSDK_STRING("Default plugin cannot be loaded (possibly you have to define plugin explicitly)\n")
                     : MSDK_STRING("Explicitly specified plugin cannot be loaded.\n"));
             }

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -1362,7 +1362,7 @@ mfxStatus CEncodingPipeline::Init(sInputParams *pParams)
             }
             if (sts == MFX_ERR_UNSUPPORTED)
             {
-                msdk_printf(isDefaultPlugin ?
+                msdk_printf(MSDK_STRING("%s"), isDefaultPlugin ?
                     MSDK_STRING("Default plugin cannot be loaded (possibly you have to define plugin explicitly)\n")
                     : MSDK_STRING("Explicitly specified plugin cannot be loaded.\n"));
             }

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -491,7 +491,7 @@ mfxStatus CTranscodingPipeline::EncodePreInit(sInputParams *pParams)
                     }
                     if(sts==MFX_ERR_UNSUPPORTED)
                     {
-                        msdk_printf(isDefaultPlugin ?
+                        msdk_printf(MSDK_STRING("%s"), isDefaultPlugin ?
                             MSDK_STRING("Default plugin cannot be loaded (possibly you have to define plugin explicitly)\n")
                             : MSDK_STRING("Explicitly specified plugin cannot be loaded.\n"));
                     }


### PR DESCRIPTION
Function 'printf' can accepts format string that may be influenced by user, causing format string vulnerability. To fix this issue a specification for character string added in 'printf' format string.