### PR TITLE
Fix gtest usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ cmake_dependent_option(BUILD_SAMPLES "Build samples?" ON "BUILD_DISPATCHER" OFF 
 # following BUILD_TOOLS option declaration assures that.
 cmake_dependent_option(BUILD_TOOLS "Build tools?" "${BUILD_ALL}" "BUILD_SAMPLES" OFF)
 option(BUILD_TESTS "Build tests?" "${BUILD_ALL}")
+option(USE_SYSTEM_GTEST "Use system installed gtest?" OFF)
 
 include( ${BUILDER_ROOT}/FindOpenCL.cmake )
 include( ${BUILDER_ROOT}/FindFunctions.cmake )
@@ -91,22 +92,24 @@ include( ${BUILDER_ROOT}/FindITT.cmake )
 include( ${BUILDER_ROOT}/ConfTargets.cmake )
 
 if (BUILD_TESTS)
-  # Our intent is to use gtest for building, we do not want to install it.
-  # To achieve that we need to force set INSTALL_GTEST=OFF otherwise
-  # according to cmake rules it will be overwritten by option() default
-  # which might be ON.
-  set(INSTALL_GTEST OFF CACHE BOOL "Do _not_ install gtest" FORCE)
+  if (NOT USE_SYSTEM_GTEST)
+    # Our intent is to use gtest for building, we do not want to install it.
+    # To achieve that we need to force set INSTALL_GTEST=OFF otherwise
+    # according to cmake rules it will be overwritten by option() default
+    # which might be ON.
+    set(INSTALL_GTEST OFF CACHE BOOL "Do _not_ install gtest" FORCE)
 
-  add_subdirectory(${CMAKE_HOME_DIRECTORY}/googletest)
+    add_subdirectory(${CMAKE_HOME_DIRECTORY}/googletest)
 
-  # For some Linux distro versions there is an unused-result warning
-  # generated inside the Gtest code at a call to fwrite. Since Gtest sets -Werror
-  # internally the only way to make it compile without modifying its source is to disable the
-  # unused-result warnings for Gtest/Gmock only.
-  target_compile_options (gtest PRIVATE "-Wno-unused-result")
-  target_compile_options (gmock PRIVATE "-Wno-unused-result")
-  target_compile_options (gtest_main PRIVATE "-Wno-unused-result")
-  target_compile_options (gmock_main PRIVATE "-Wno-unused-result")
+    # For some Linux distro versions there is an unused-result warning
+    # generated inside the Gtest code at a call to fwrite. Since Gtest sets -Werror
+    # internally the only way to make it compile without modifying its source is to disable the
+    # unused-result warnings for Gtest/Gmock only.
+    target_compile_options (gtest PRIVATE "-Wno-unused-result")
+    target_compile_options (gmock PRIVATE "-Wno-unused-result")
+    target_compile_options (gtest_main PRIVATE "-Wno-unused-result")
+    target_compile_options (gmock_main PRIVATE "-Wno-unused-result")
+  endif()
 
   enable_testing()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,27 @@ include( ${BUILDER_ROOT}/FindInternals.cmake )
 include( ${BUILDER_ROOT}/FindITT.cmake )
 include( ${BUILDER_ROOT}/ConfTargets.cmake )
 
+if (BUILD_TESTS)
+  # Our intent is to use gtest for building, we do not want to install it.
+  # To achieve that we need to force set INSTALL_GTEST=OFF otherwise
+  # according to cmake rules it will be overwritten by option() default
+  # which might be ON.
+  set(INSTALL_GTEST OFF CACHE BOOL "Do _not_ install gtest" FORCE)
+
+  add_subdirectory(${CMAKE_HOME_DIRECTORY}/googletest)
+
+  # For some Linux distro versions there is an unused-result warning
+  # generated inside the Gtest code at a call to fwrite. Since Gtest sets -Werror
+  # internally the only way to make it compile without modifying its source is to disable the
+  # unused-result warnings for Gtest/Gmock only.
+  target_compile_options (gtest PRIVATE "-Wno-unused-result")
+  target_compile_options (gmock PRIVATE "-Wno-unused-result")
+  target_compile_options (gtest_main PRIVATE "-Wno-unused-result")
+  target_compile_options (gmock_main PRIVATE "-Wno-unused-result")
+
+  enable_testing()
+endif()
+
 # should prepend others to define target mfx
 if (BUILD_DISPATCHER)
   add_subdirectory(api/mfx_dispatch/linux)
@@ -111,25 +132,6 @@ if (BUILD_RUNTIME)
 endif()
 
 if (BUILD_TESTS)
-  enable_testing()
-
-  # Our intent is to use gtest for building, we do not want to install it.
-  # To achieve that we need to force set INSTALL_GTEST=OFF otherwise
-  # according to cmake rules it will be overwritten by option() default
-  # which might be ON.
-  set(INSTALL_GTEST OFF CACHE BOOL "Do _not_ install gtest" FORCE)
-
-  add_subdirectory(${CMAKE_HOME_DIRECTORY}/googletest)
-
-  # For some Linux distro versions there is an unused-result warning
-  # generated inside the Gtest code at a call to fwrite. Since Gtest sets -Werror
-  # internally the only way to make it compile without modifying its source is to disable the
-  # unused-result warnings for Gtest/Gmock only.
-  target_compile_options (gtest PRIVATE "-Wno-unused-result")
-  target_compile_options (gmock PRIVATE "-Wno-unused-result")
-  target_compile_options (gtest_main PRIVATE "-Wno-unused-result")
-  target_compile_options (gmock_main PRIVATE "-Wno-unused-result")
-
   add_subdirectory(tests)
 endif()
 

--- a/tests/mfx_dispatch/linux/CMakeLists.txt
+++ b/tests/mfx_dispatch/linux/CMakeLists.txt
@@ -59,4 +59,23 @@ add_test(NAME run_mfx_dispatch_test
   COMMAND ./mfx_dispatch_test
   WORKING_DIRECTORY ${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE})
 
-set_property(TEST run_mfx_dispatch_test PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE}")
+set(LIBRARY_PATH "${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE}")
+
+# If we build against embedded copy of gtest/gmock, we need to make sure that
+# we load those .so libraries which we built and avoid system libraries which
+# also might present. Hence, we explicitly set LD_LIBRARY_PATH per target
+# properties.
+if(TARGET gtest)
+  get_target_property(type gtest TYPE)
+  if(type STREQUAL "SHARED_LIBRARY")
+    set(LIBRARY_PATH "${LIBRARY_PATH}:$<TARGET_FILE_DIR:gtest>")
+  endif()
+endif()
+if(TARGET gmock)
+  get_target_property(type gmock TYPE)
+  if(type STREQUAL "SHARED_LIBRARY")
+    set(LIBRARY_PATH "${LIBRARY_PATH}:$<TARGET_FILE_DIR:gmock>")
+  endif()
+endif()
+
+set_property(TEST run_mfx_dispatch_test PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${LIBRARY_PATH}")


### PR DESCRIPTION
This attempts to fix:
* Avoid loading system level gtest.so if we were built against our internal copy
* Allow "blind" usage of system level gtest
