### PR TITLE
smt: add API guards around mfxExtVP9Param usage

### DIFF
--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -818,8 +818,10 @@ namespace TranscodingSample
         // HEVC
         mfxExtHEVCParam          m_ExtHEVCParam;
         mfxExtHEVCTiles          m_ExtHEVCTiles;
+#if (MFX_VERSION >= 1026)
         // VP9
         mfxExtVP9Param           m_ExtVP9Param;
+#endif
 
 #if (MFX_VERSION >= 1024)
         mfxExtBRC                m_ExtBRC;

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -175,7 +175,6 @@ CTranscodingPipeline::CTranscodingPipeline():
     MSDK_ZERO_MEMORY(m_CodingOption3);
     MSDK_ZERO_MEMORY(m_ExtHEVCParam);
     MSDK_ZERO_MEMORY(m_ExtHEVCTiles);
-    MSDK_ZERO_MEMORY(m_ExtVP9Param);
 #if MFX_VERSION >= 1022
     MSDK_ZERO_MEMORY(m_decPostProcessing);
     m_decPostProcessing.Header.BufferId = MFX_EXTBUFF_DEC_VIDEO_PROCESSING;
@@ -194,8 +193,11 @@ CTranscodingPipeline::CTranscodingPipeline():
     m_ExtHEVCTiles.Header.BufferId = MFX_EXTBUFF_HEVC_TILES;
     m_ExtHEVCTiles.Header.BufferSz = sizeof(mfxExtHEVCTiles);
 
+#if (MFX_VERSION >= 1026)
+    MSDK_ZERO_MEMORY(m_ExtVP9Param);
     m_ExtVP9Param.Header.BufferId = MFX_EXTBUFF_VP9_PARAM;
     m_ExtVP9Param.Header.BufferSz = sizeof(mfxExtVP9Param);
+#endif
 
 #if (MFX_VERSION >= 1024)
     MSDK_ZERO_MEMORY(m_ExtBRC);

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -2380,10 +2380,17 @@ mfxStatus CmdProcessor::VerifyAndCorrectInputParams(TranscodingSample::sInputPar
         return MFX_ERR_UNSUPPORTED;
     }
 
-    if((InputParams.nEncTileRows || InputParams.nEncTileCols) && (InputParams.EncodeId != MFX_CODEC_VP9) &&
-        (InputParams.EncodeId != MFX_CODEC_HEVC))
+    if ((InputParams.nEncTileRows || InputParams.nEncTileCols) && (InputParams.EncodeId != MFX_CODEC_HEVC)
+#if (MFX_VERSION >= 1029)
+      && (InputParams.EncodeId != MFX_CODEC_VP9)
+#endif
+       )
     {
-        msdk_printf(MSDK_STRING("WARNING: -trows and -tcols are only supported for VP9 and HEVC encoder, these parameters will be ignored.\n"));
+        msdk_printf(MSDK_STRING("WARNING: -trows and -tcols are only supported for"
+#if (MFX_VERSION >= 1029)
+                                " VP9 and"
+#endif
+                                " HEVC encoder, these parameters will be ignored.\n"));
         InputParams.nEncTileRows = 0;
         InputParams.nEncTileCols = 0;
     }


### PR DESCRIPTION
- ```mfxExtVP9Param``` was introduced in API 1.26
- added API 1.29 guards around tiles input parameters processing (since real logic in code was already covered by such guards)