### PR TITLE
[sample_multi_transcode] Enable tiles for HEVC encoder

### DIFF
--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -797,6 +797,7 @@ namespace TranscodingSample
 
         // HEVC
         mfxExtHEVCParam          m_ExtHEVCParam;
+        mfxExtHEVCTiles          m_ExtHEVCTiles;
         // VP9
         mfxExtVP9Param           m_ExtVP9Param;
 

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -2273,9 +2273,10 @@ mfxStatus CmdProcessor::VerifyAndCorrectInputParams(TranscodingSample::sInputPar
         return MFX_ERR_UNSUPPORTED;
     }
 
-    if((InputParams.nEncTileRows || InputParams.nEncTileCols) && (InputParams.EncodeId != MFX_CODEC_VP9))
+    if((InputParams.nEncTileRows || InputParams.nEncTileCols) && (InputParams.EncodeId != MFX_CODEC_VP9) &&
+        (InputParams.EncodeId != MFX_CODEC_HEVC))
     {
-        msdk_printf(MSDK_STRING("WARNING: -trows and -tcols are only supported for VP9 encoder, these parameters will be ignored.\n"));
+        msdk_printf(MSDK_STRING("WARNING: -trows and -tcols are only supported for VP9 and HEVC encoder, these parameters will be ignored.\n"));
         InputParams.nEncTileRows = 0;
         InputParams.nEncTileCols = 0;
     }


### PR DESCRIPTION
This is to enable tiles for HEVC encoder in sample_multi_transcode.