### PR TITLE
Deleted unnecessary assertion

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
@@ -1435,7 +1435,6 @@ namespace MfxHwH264Encode
         case MFX_LOOKAHEAD_DS_4x :
             return 4;
         default:
-            assert(0);
             return LookAheadDS;
         }
     }


### PR DESCRIPTION
There is no problem if we get in the default case. For example if LookAheadDS=4
we get valid returned value. In other cases returned value checks in next steps.