### PR TITLE
Added check valid value of LookAheadDS

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3409,6 +3409,12 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         par.mfx.RateControlMethod = 0;
     }
 
+    if (extOpt2->LookAheadDS > MFX_LOOKAHEAD_DS_4x)
+    {
+        extOpt2->LookAheadDS = MFX_LOOKAHEAD_DS_4x;
+        changed = true;
+    }
+
     if (extOpt2->LookAheadDS == MFX_LOOKAHEAD_DS_4x)
     {
         extOpt2->LookAheadDS = MFX_LOOKAHEAD_DS_2x;


### PR DESCRIPTION
In some cases where LookAheadDS is out of range we get MFX_ERR_NONE. For example
if LookAheadDS=4 we don't get errors because LaDSenumToFactor returns valid
value=4 as is the case MFX_LOOKAHEAD_DS_4x. But it isn't right due to
MFX_LOOKAHEAD_DS_4x=3 by enum, so we need to check LookAheadDS.