### PR TITLE
core: fix HW core's ChooseProfile

### DIFF
--- a/_studio/mfx_lib/Android.mk
+++ b/_studio/mfx_lib/Android.mk
@@ -164,6 +164,7 @@ MFX_LIB_SHARED_FILES_2 := $(addprefix shared/src/, \
     libmfx_allocator.cpp \
     libmfx_allocator_vaapi.cpp \
     libmfx_core.cpp \
+    libmfx_core_hw.cpp \
     libmfx_core_factory.cpp \
     libmfx_core_vaapi.cpp \
     mfx_umc_alloc_wrapper.cpp \

--- a/_studio/mfx_lib/CMakeLists.txt
+++ b/_studio/mfx_lib/CMakeLists.txt
@@ -132,6 +132,7 @@ foreach( prefix ${MSDK_STUDIO_ROOT}/shared/src )
     ${prefix}/libmfx_allocator.cpp
     ${prefix}/libmfx_allocator_vaapi.cpp
     ${prefix}/libmfx_core.cpp
+    ${prefix}/libmfx_core_hw.cpp
     ${prefix}/libmfx_core_factory.cpp
     ${prefix}/libmfx_core_vaapi.cpp
     ${prefix}/mfx_umc_alloc_wrapper.cpp

--- a/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
+++ b/_studio/mfx_lib/decode/mpeg2/src/mfx_mpeg2_decode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@
 #include "mfx_umc_alloc_wrapper.h"
 #include "libmfx_core_hw.h"
 
+#include "umc_va_base.h"
 #include "umc_mpeg2_utils.h"
 #include "umc_mpeg2_decoder_va.h"
 

--- a/_studio/mfx_lib/plugin/CMakeLists.txt
+++ b/_studio/mfx_lib/plugin/CMakeLists.txt
@@ -86,6 +86,7 @@ list( APPEND plugin_common_sources
   ${prefix}/libmfx_core.cpp
   ${prefix}/libmfx_core_factory.cpp
   ${prefix}/libmfx_core_vaapi.cpp
+  ${prefix}/libmfx_core_hw.cpp
   ${prefix}/mfx_umc_alloc_wrapper.cpp
   ${MSDK_LIB_ROOT}/cmrt_cross_platform/src/cmrt_cross_platform.cpp
 )

--- a/_studio/shared/include/libmfx_core_hw.h
+++ b/_studio/shared/include/libmfx_core_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,17 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "mfx_common.h"
-
-
 #ifndef __LIBMFX_CORE__HW_H__
 #define __LIBMFX_CORE__HW_H__
 
-#include "umc_va_base.h"
+#if defined(MFX_VA)
 
-mfxU32 ChooseProfile(mfxVideoParam * param, eMFXHWType hwType);
+#include "mfx_common.h"
+
+mfxU32 ChooseProfile(mfxVideoParam const*, eMFXHWType);
 bool IsHwMvcEncSupported();
 
+#endif //MFX_VA
+
 #endif
-
-

--- a/_studio/shared/src/libmfx_core_hw.cpp
+++ b/_studio/shared/src/libmfx_core_hw.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2007-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if defined (MFX_VA)
+
+#include "libmfx_core_hw.h"
+#include "mfx_common_decode_int.h"
+#include "mfx_enc_common.h"
+#include "mfx_ext_buffers.h"
+
+#include "umc_va_base.h"
+
+using namespace UMC;
+
+mfxU32 ChooseProfile(mfxVideoParam const* param, eMFXHWType)
+{
+    mfxU32 profile = UMC::VA_VLD;
+
+    // video accelerator is needed for decoders only
+    switch (param->mfx.CodecId)
+    {
+    case MFX_CODEC_VC1:
+        profile |= VA_VC1;
+        break;
+
+    case MFX_CODEC_MPEG2:
+        profile |= VA_MPEG2;
+        break;
+
+    case MFX_CODEC_AVC:
+        profile |= VA_H264;
+        break;
+
+    case MFX_CODEC_JPEG:
+        profile |= VA_JPEG;
+        break;
+
+    case MFX_CODEC_VP8:
+        profile |= VA_VP8;
+        break;
+
+    case MFX_CODEC_VP9:
+        profile |= VA_VP9;
+        switch (param->mfx.FrameInfo.FourCC)
+        {
+        case MFX_FOURCC_P010:
+            profile |= VA_PROFILE_10;
+            break;
+        case MFX_FOURCC_AYUV:
+            profile |= VA_PROFILE_444;
+            break;
+#if (MFX_VERSION >= 1027)
+        case MFX_FOURCC_Y410:
+            profile |= VA_PROFILE_10 | VA_PROFILE_444;
+            break;
+#endif
+        }
+        break;
+
+
+    case MFX_CODEC_HEVC:
+        profile |= VA_H265;
+        switch (param->mfx.FrameInfo.FourCC)
+        {
+            case MFX_FOURCC_P010:
+                profile |= VA_PROFILE_10;
+                break;
+            case MFX_FOURCC_YUY2:
+                profile |= VA_PROFILE_422;
+                break;
+            case MFX_FOURCC_AYUV:
+                profile |= VA_PROFILE_444;
+                break;
+#if (MFX_VERSION >= 1027)
+            case MFX_FOURCC_Y210:
+                profile |= VA_PROFILE_10 | VA_PROFILE_422;
+                break;
+            case MFX_FOURCC_Y410:
+                profile |= VA_PROFILE_10 | VA_PROFILE_444;
+                break;
+#endif
+        }
+
+#if (MFX_VERSION >= 1027)
+        {
+            mfxU32 const profile_idc = ExtractProfile(param->mfx.CodecProfile);
+
+            if (profile_idc == MFX_PROFILE_HEVC_REXT)
+                profile |= VA_PROFILE_REXT;
+        }
+#endif
+
+        break;
+
+    default:
+        return UMC::UNKNOWN;
+    }
+
+
+    return profile;
+}
+
+
+#endif
+/* EOF */


### PR DESCRIPTION
 - Align `ChooseProfile` function w/ current impl.
   of `VAAPIVideoCORE::CreateVA`
 - Remove vp9 422 chroma formats
 - Reuse `ChooseProfile` for profile selection
   while creating VAAPI video accel.

Test: random pick from decoders' conformance suites -
      hevcd_conf, hevc10d_conf, hevcd_10b_422_y210_conf, hevcd_10b_444_y410_conf,
      h264d_conf, mpeg2d_conf, jpegd_conf, mjpegd_conf,
      vp9d_8b_420_nv12_conf, vp9d_10b_420_p010_conf,
      vp9d_8b_444_ayuv_conf, vp9d_10b_444_y410_conf