### PR TITLE
sample_multi_transcode: enable HEVC encode with temporal layers

### DIFF
--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -279,6 +279,15 @@ namespace TranscodingSample
         mfxU16 nQPB;
         bool bDisableQPOffset;
 
+        mfxU16 nAvcTemp;
+        mfxU16 nBaseLayerPID;
+        mfxU16 nAvcTemporalLayers[8];
+        mfxU16 nSPSId;
+        mfxU16 nPPSId;
+        mfxU16 nPicTimingSEI;
+        mfxU16 nNalHrdConformance;
+        mfxU16 nVuiNalHrdParameters;
+
         bool bOpenCL;
         mfxU16 reserved[4];
 
@@ -809,6 +818,10 @@ namespace TranscodingSample
 #if MFX_VERSION >= 1022
         mfxExtDecVideoProcessing m_decPostProcessing;
 #endif //MFX_VERSION >= 1022
+
+        mfxExtAvcTemporalLayers  m_AvcTemporalLayers;
+        mfxExtCodingOptionSPSPPS m_CodingOptionSPSPPS;
+        mfxExtCodingOption       m_CodingOption;
 
         mfxExtLAControl          m_ExtLAControl;
         // for setting MaxSliceSize

--- a/samples/sample_multi_transcode/include/transcode_utils.h
+++ b/samples/sample_multi_transcode/include/transcode_utils.h
@@ -65,6 +65,7 @@ namespace TranscodingSample
     protected:
         mfxStatus ParseParFile(FILE* file);
         mfxStatus TokenizeLine(msdk_char *pLine, mfxU32 length);
+        mfxU32    GetStringLength(msdk_char *pTempLine, mfxU32 length);
 
 #if MFX_VERSION >= 1022
         static bool isspace(char a);


### PR DESCRIPTION
New test suite: smt_hevcd_to_hevce_temporal_layers
Add new switches for temporal layers
Update par file parsing to handle string literals
WA for compiler error on Windows - too many if-else
  clauses in cmd-line parsing causes build error