### PR TITLE
[MCTF - ICL] Removal of excess CreateQueue calls

### DIFF
--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -1420,8 +1420,6 @@ mfxI32 CMC::MCTF_RUN_TASK_NA(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1452,10 +1450,6 @@ mfxI32 CMC::MCTF_RUN_TASK(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
-    /*res = queue->Enqueue(task, e);
-    MCTF_CHECK_CM_ERR(res, res);*/
     return res;
 }
 
@@ -1495,8 +1489,6 @@ mfxI32 CMC::MCTF_RUN_DOUBLE_TASK(
     MCTF_CHECK_CM_ERR(res, res);
     res = task->AddKernel(mcKernel);
     MCTF_CHECK_CM_ERR(res, res);
-    /*res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);*/
     res = queue->Enqueue(task, e);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1526,8 +1518,6 @@ mfxI32 CMC::MCTF_RUN_MCTASK(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e, threadSpaceMC2);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1556,8 +1546,6 @@ mfxI32 CMC::MCTF_RUN_TASK(
         MCTF_CHECK_CM_ERR(res, res);
     }
     res = task->AddKernel(kernel);
-    MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
     MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e, tS);
     MCTF_CHECK_CM_ERR(res, res);


### PR DESCRIPTION
CreateQueue(Ex) is called at init of MCTF, but later when
the kernel has been configured for operation the code had
extra CreateQueue calls, which reset the original queue,
this is an issue on ICL because ICL requires special queue
creation by using CreateQueueEx. By removing the additional
CreateQueue calls the original queue (properly configured)
is not reset and MCTF works correctly.

Issue: MDP-48160
Test: vpp_mctf_denoise

Signed-off-by: Sebastian Possos <sebastian.possos@intel.com>