### PR TITLE
[MCTF - ICL] Removal of excess CreateQueue calls

### DIFF
--- a/AllBuild.sln
+++ b/AllBuild.sln
@@ -8,10 +8,19 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_common", "samples\sample_common\sample_common.vcxproj", "{5FADB243-53C3-4776-A20F-8BD65C10CF41}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_decode", "samples\sample_decode\sample_decode.vcxproj", "{F22D082D-FDDD-4946-A11B-5276F0994C74}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_encode", "samples\sample_encode\sample_encode.vcxproj", "{33834A6A-4466-4339-8C7C-FBA250BC1957}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_multi_transcode", "samples\sample_multi_transcode\sample_multi_transcode.vcxproj", "{58D93FCA-FDE9-4D22-8E8D-402EEBACF2BD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_rotate_plugin", "samples\sample_plugins\rotate_cpu\sample_rotate_plugin.vcxproj", "{C5F515E3-379A-4678-B947-509B3603D826}"
 EndProject
@@ -20,10 +29,19 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample plugins", "Sample plugins", "{E4C0D92D-FE15-43AE-A86D-A9866C0A50E6}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_vpp", "samples\sample_vpp\sample_vpp.vcxproj", "{A0872728-B771-49B5-93FA-D7140631A829}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_camera", "samples\sample_camera\sample_camera.vcxproj", "{A812C44D-0255-4796-9042-BCAE99963E7D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample_plugin_opencl", "samples\sample_plugins\rotate_opencl\sample_plugin_opencl.vcxproj", "{E90AE63E-F219-4389-A955-26E78BD1BD9A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627} = {A9F7AEFB-DC6C-49E8-8E71-5351ABDCE627}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{CD184324-7B3B-48FD-9B41-4A4638B41459}"
 EndProject

--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1630,38 +1630,6 @@ mfxU32 VideoDECODEMJPEGBase_HW::AdjustFrameAllocRequest(mfxFrameAllocRequest *re
     // set FourCC
     AdjustFourCC(&request->Info, info, hwType, vaType, &needVpp);
 
-    // WA for rotation of unaligned images
-    mfxU16 mcuWidth;
-    mfxU16 mcuHeight;
-    mfxU16 paddingWidth;
-    mfxU16 paddingHeight;
-
-    switch(info->JPEGChromaFormat)
-    {
-    case MFX_CHROMAFORMAT_YUV411:
-        mcuWidth  = 32;
-        mcuHeight = 8;
-        break;
-    case MFX_CHROMAFORMAT_YUV420:
-        mcuWidth  = 16;
-        mcuHeight = 16;
-        break;
-    case MFX_CHROMAFORMAT_YUV422H:
-        mcuWidth  = 16;
-        mcuHeight = 8;
-        break;
-    case MFX_CHROMAFORMAT_YUV422V:
-        mcuWidth  = 8;
-        mcuHeight = 16;
-        break;
-    case MFX_CHROMAFORMAT_YUV400:
-    case MFX_CHROMAFORMAT_YUV444:
-    default:
-        mcuWidth  = 8;
-        mcuHeight = 8;
-        break;
-    }
-
     if(info->Rotation == MFX_ROTATION_90 || info->Rotation == MFX_ROTATION_180 || info->Rotation == MFX_ROTATION_270)
     {
         needVpp = true;
@@ -1673,31 +1641,6 @@ mfxU32 VideoDECODEMJPEGBase_HW::AdjustFrameAllocRequest(mfxFrameAllocRequest *re
         std::swap(request->Info.AspectRatioH, request->Info.AspectRatioW);
         std::swap(request->Info.CropH, request->Info.CropW);
         std::swap(request->Info.CropY, request->Info.CropX);
-    }
-
-
-    if(info->Rotation == MFX_ROTATION_90 || info->Rotation == MFX_ROTATION_270)
-        std::swap(mcuWidth, mcuHeight);
-
-    paddingWidth = (mfxU16)((2<<16) - request->Info.CropW) % mcuWidth;
-    paddingHeight = (mfxU16)((2<<16) - request->Info.CropH) % mcuHeight;
-
-    switch(info->Rotation)
-    {
-    case MFX_ROTATION_90:
-        request->Info.CropX = paddingWidth;
-        request->Info.CropW = request->Info.CropW + paddingWidth;
-        break;
-    case MFX_ROTATION_180:
-        request->Info.CropX = paddingWidth;
-        request->Info.CropW = request->Info.CropW + paddingWidth;
-        request->Info.CropY = paddingHeight;
-        request->Info.CropH = request->Info.CropH + paddingHeight;
-        break;
-    case MFX_ROTATION_270:
-        request->Info.CropY = paddingHeight;
-        request->Info.CropH = request->Info.CropH + paddingHeight;
-        break;
     }
 
     m_needVpp = needVpp;

--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_ddi.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_ddi.h
@@ -119,7 +119,7 @@ typedef enum tagENCODER_TYPE
 } ENCODER_TYPE;
 
 DriverEncoder* CreatePlatformH265Encoder(VideoCORE* core, ENCODER_TYPE type = ENCODER_DEFAULT);
-mfxStatus QueryHwCaps(VideoCORE* core, GUID guid, ENCODE_CAPS_HEVC & caps);
+mfxStatus QueryHwCaps(VideoCORE* core, GUID guid, ENCODE_CAPS_HEVC & caps, mfxU32 width, mfxU32 height);
 mfxStatus CheckHeaders(MfxVideoParam const & par, ENCODE_CAPS_HEVC const & caps);
 
 mfxStatus FillCUQPDataDDI(Task& task, MfxVideoParam &par, VideoCORE& core, mfxFrameInfo &CUQPFrameInfo);

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
@@ -427,7 +427,9 @@ mfxStatus MFXVideoENCODEH265_HW::QueryIOSurf(VideoCORE *core, mfxVideoParam *par
 
     (void)SetLowpowerDefault(tmp);
 
-    sts = QueryHwCaps(core, GetGUID(tmp), caps);
+    sts = QueryHwCaps(core, GetGUID(tmp), caps,
+            tmp.m_ext.HEVCParam.PicWidthInLumaSamples,
+            tmp.m_ext.HEVCParam.PicHeightInLumaSamples);
     MFX_CHECK_STS(sts);
 
     MfxHwH265Encode::CheckVideoParam(tmp, caps);
@@ -508,7 +510,9 @@ mfxStatus MFXVideoENCODEH265_HW::Query(VideoCORE *core, mfxVideoParam *in, mfxVi
 
         mfxStatus lpsts = SetLowpowerDefault(tmp);
 
-        sts = QueryHwCaps(core, GetGUID(tmp), caps);
+        sts = QueryHwCaps(core, GetGUID(tmp), caps,
+                tmp.m_ext.HEVCParam.PicWidthInLumaSamples,
+                tmp.m_ext.HEVCParam.PicHeightInLumaSamples);
         MFX_CHECK_STS(sts);
 
         mfxExtCodingOptionSPSPPS* pSPSPPS = ExtBuffer::Get(*in);

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -134,7 +134,7 @@ mfxStatus HardcodeCaps(ENCODE_CAPS_HEVC& caps, VideoCORE* core)
     return sts;
 }
 
-mfxStatus QueryHwCaps(VideoCORE* core, GUID guid, ENCODE_CAPS_HEVC & caps)
+mfxStatus QueryHwCaps(VideoCORE* core, GUID guid, ENCODE_CAPS_HEVC & caps, mfxU32 width, mfxU32 height)
 {
     std::unique_ptr<DriverEncoder> ddi;
 
@@ -142,7 +142,7 @@ mfxStatus QueryHwCaps(VideoCORE* core, GUID guid, ENCODE_CAPS_HEVC & caps)
     ddi.reset(CreatePlatformH265Encoder(core));
     MFX_CHECK(ddi.get(), MFX_ERR_UNSUPPORTED);
 
-    mfxStatus sts = ddi.get()->CreateAuxilliaryDevice(core, guid, 1920, 1088);
+    mfxStatus sts = ddi.get()->CreateAuxilliaryDevice(core, guid, width, height);
     MFX_CHECK_STS(sts);
 
     sts = ddi.get()->QueryEncodeCaps(caps);

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -315,6 +315,9 @@ uint32_t ConvertRateControlMFX2VAAPI(mfxU8 rateControl, bool bSWBRC)
         case MFX_RATECONTROL_VBR:    return VA_RC_VBR | VA_RC_MB;
         case MFX_RATECONTROL_ICQ:    return VA_RC_ICQ | VA_RC_MB;
         case MFX_RATECONTROL_VCM:    return VA_RC_VCM | VA_RC_MB;
+#ifdef MFX_ENABLE_QVBR
+        case MFX_RATECONTROL_QVBR:   return VA_RC_QVBR | VA_RC_MB;
+#endif
         default: assert(!"Unsupported RateControl"); return 0;
     }
 }
@@ -925,6 +928,10 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
 
     m_caps.VCMBitRateControl =
         attrs[ idx_map[VAConfigAttribRateControl] ].value & VA_RC_VCM ? 1 : 0; //Video conference mode
+#ifdef MFX_ENABLE_QVBR
+    m_caps.QVBRBRCSupport = attrs[ idx_map[VAConfigAttribRateControl] ].value & VA_RC_QVBR ? 1 : 0;
+#endif
+
     m_caps.RollingIntraRefresh =
             (attrs[idx_map[VAConfigAttribEncIntraRefresh]].value & (~VA_ATTRIB_NOT_SUPPORTED)) ? 1 : 0 ;
     m_caps.UserMaxFrameSizeSupport = 1;

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -957,17 +957,14 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     m_caps.YUV422ReconSupport = attrs[idx_map[VAConfigAttribRTFormat]].value & VA_RT_FORMAT_YUV422 ? 1 : 0;
     m_caps.YUV444ReconSupport = attrs[idx_map[VAConfigAttribRTFormat]].value & VA_RT_FORMAT_YUV444 ? 1 : 0;
 
-    if ((attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value != VA_ATTRIB_NOT_SUPPORTED) &&
-        (attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value != 0))
-        m_caps.MaxPicWidth = attrs[idx_map[VAConfigAttribMaxPictureWidth] ].value;
-    else
-        m_caps.MaxPicWidth = 1920;
+    MFX_CHECK(attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value != VA_ATTRIB_NOT_SUPPORTED, MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value != VA_ATTRIB_NOT_SUPPORTED, MFX_ERR_UNSUPPORTED);
+    MFX_CHECK_COND(attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value && attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value);
+    MFX_CHECK(attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value >= m_width, MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value >= m_height, MFX_ERR_UNSUPPORTED);
+    m_caps.MaxPicWidth  = attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value;
+    m_caps.MaxPicHeight = attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value;
 
-    if ((attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value != VA_ATTRIB_NOT_SUPPORTED) &&
-        (attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value != 0))
-        m_caps.MaxPicHeight = attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value;
-    else
-        m_caps.MaxPicHeight = 1088;
 
     m_caps.SliceStructure = 4;
     m_caps.SliceByteSizeCtrl = 1; //It means that GPU may further split the slice region that slice control data specifies into finer slice segments based on slice size upper limit (MaxSliceSize).

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
@@ -329,7 +329,7 @@ mfxStatus MFXVideoENCODEVP9_HW::Init(mfxVideoParam *par)
     sts = m_ddi->Register(m_segmentMaps.GetFrameAllocReponse(), D3DDDIFMT_INTELENCODE_MBSEGMENTMAP);
     MFX_CHECK_STS(sts);
 
-    mfxU16 blockSize = MapIdToBlockSize(MFX_VP9_SEGMENT_ID_BLOCK_SIZE_32x32);
+    mfxU16 blockSize = MapIdToBlockSize(MFX_VP9_SEGMENT_ID_BLOCK_SIZE_64x64);
     // allocate enough space for segmentation map for lowest supported segment block size and highest supported resolution
     mfxU16 wInBlocks = (static_cast<mfxU16>(caps.MaxPicWidth) + blockSize - 1) / blockSize;
     mfxU16 hInBlocks = (static_cast<mfxU16>(caps.MaxPicHeight) + blockSize - 1) / blockSize;

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -1654,10 +1654,6 @@ mfxStatus SetDefaults(
         SetDefault(par.mfx.RateControlMethod, MFX_RATECONTROL_CBR);
     }
 
-    if (IsBufferBasedBRC(par.mfx.RateControlMethod))
-    {
-        SetDefault(par.m_initialDelayInKb, par.m_bufferSizeInKb / 2);
-    }
     if (IsBitrateBasedBRC(par.mfx.RateControlMethod))
     {
         if (par.m_numLayers)
@@ -1691,6 +1687,10 @@ mfxStatus SetDefaults(
     }
 
     SetDefault(par.m_bufferSizeInKb, GetDefaultBufferSize(par));
+    if (IsBufferBasedBRC(par.mfx.RateControlMethod))
+    {
+        SetDefault(par.m_initialDelayInKb, par.m_bufferSizeInKb / 2);
+    }
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP)
     {

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -728,10 +728,8 @@ mfxStatus CheckSegmentationParam(mfxExtVP9Segmentation& seg, mfxU32 frameWidth, 
         unsupported = true;
     }
 
-    // for Gen10 driver supports only 16x16 granularity for segmentation map
-    // but every 32x32 block of seg map should contain equal segment ids because of HW limitation
-    // so segment map is accepted from application in terms of 32x32 or 64x64 blocks
-    if (seg.SegmentIdBlockSize && seg.SegmentIdBlockSize < MFX_VP9_SEGMENT_ID_BLOCK_SIZE_32x32)
+    // currently only 64x64 block size for segmentation map supported (HW limitation)
+    if (seg.SegmentIdBlockSize && seg.SegmentIdBlockSize != MFX_VP9_SEGMENT_ID_BLOCK_SIZE_64x64)
     {
         seg.SegmentIdBlockSize = 0;
         unsupported = true;

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -319,7 +319,7 @@ namespace MfxHwVP9Encode
             }
         }
 
-        // for now application seg map is accepted in 32x32 and 64x64 blocks
+        // for now application seg map is accepted in 64x64 blocks
         // and driver seg map is always in 16x16 blocks
         // need to map one to another
 

--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1420,8 +1420,6 @@ mfxI32 CMC::MCTF_RUN_TASK_NA(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1452,10 +1450,6 @@ mfxI32 CMC::MCTF_RUN_TASK(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
-    /*res = queue->Enqueue(task, e);
-    MCTF_CHECK_CM_ERR(res, res);*/
     return res;
 }
 
@@ -1495,8 +1489,6 @@ mfxI32 CMC::MCTF_RUN_DOUBLE_TASK(
     MCTF_CHECK_CM_ERR(res, res);
     res = task->AddKernel(mcKernel);
     MCTF_CHECK_CM_ERR(res, res);
-    /*res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);*/
     res = queue->Enqueue(task, e);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1526,8 +1518,6 @@ mfxI32 CMC::MCTF_RUN_MCTASK(
     }
     res = task->AddKernel(kernel);
     MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
-    MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e, threadSpaceMC2);
     MCTF_CHECK_CM_ERR(res, res);
     return res;
@@ -1556,8 +1546,6 @@ mfxI32 CMC::MCTF_RUN_TASK(
         MCTF_CHECK_CM_ERR(res, res);
     }
     res = task->AddKernel(kernel);
-    MCTF_CHECK_CM_ERR(res, res);
-    res = device->CreateQueue(queue);
     MCTF_CHECK_CM_ERR(res, res);
     res = queue->Enqueue(task, e, tS);
     MCTF_CHECK_CM_ERR(res, res);

--- a/android/Android.bp
+++ b/android/Android.bp
@@ -5,11 +5,11 @@ cc_library_headers {
         "soong_libmfx_api_headers"
     ],
 
-    export_include_dirs = [
+    export_include_dirs: [
         "include"
     ],
 
-    export_header_lib_headers = [
+    export_header_lib_headers: [
         "soong_libmfx_api_headers"
     ],
 

--- a/api/Android.bp
+++ b/api/Android.bp
@@ -1,7 +1,7 @@
 cc_library_headers {
     name: "soong_libmfx_api_headers",
 
-    export_include_dirs = [
+    export_include_dirs: [
         "include"
     ],
 

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -208,6 +208,82 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("\n"));
 }
 
+mfxStatus ParseAdditionalParams(msdk_char *strInput[], mfxU8 nArgNum, mfxU8& i, sInputParams* pParams)
+{
+		if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-AvcTemporalLayers")))
+		{
+			pParams->nAvcTemp = 1;
+			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+			mfxU16 arr[8] = { 0,0,0,0,0,0,0,0 };
+			int j, k;
+			k = msdk_sscanf(strInput[i + 1], MSDK_STRING("%hu %hu %hu %hu %hu %hu %hu %hu"), &arr[0], &arr[1], &arr[2], &arr[3], &arr[4], &arr[5], &arr[6], &arr[7]);
+			for (j = 0; j < 8; j++)
+			{
+				pParams->nAvcTemporalLayers[j] = arr[j];
+			}
+			i += 1;
+		}
+
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-BaseLayerPID")))
+		{
+			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nBaseLayerPID))
+			{
+				PrintHelp(strInput[0], MSDK_STRING("BaseLayerPID is invalid"));
+				return MFX_ERR_UNSUPPORTED;
+			}
+		}
+
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-SPSId")))
+		{
+			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nSPSId))
+			{
+				PrintHelp(strInput[0], MSDK_STRING("SPSId is invalid"));
+				return MFX_ERR_UNSUPPORTED;
+			}
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PPSId")))
+		{
+			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nPPSId))
+			{
+				PrintHelp(strInput[0], MSDK_STRING("PPSId is invalid"));
+				return MFX_ERR_UNSUPPORTED;
+			}
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PicTimingSEI:on")))
+		{
+			pParams->nPicTimingSEI = MFX_CODINGOPTION_ON;
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PicTimingSEI:off")))
+		{
+			pParams->nPicTimingSEI = MFX_CODINGOPTION_OFF;
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-NalHrdConformance:on")))
+		{
+			pParams->nNalHrdConformance = MFX_CODINGOPTION_ON;
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-NalHrdConformance:off")))
+		{
+			pParams->nNalHrdConformance = MFX_CODINGOPTION_OFF;
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-VuiNalHrdParameters:on")))
+		{
+			pParams->nVuiNalHrdParameters = MFX_CODINGOPTION_ON;
+		}
+		else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-VuiNalHrdParameters:off")))
+		{
+			pParams->nVuiNalHrdParameters = MFX_CODINGOPTION_OFF;
+		}
+                else
+                {
+                        return MFX_ERR_NOT_FOUND;
+                }
+  return MFX_ERR_NONE;
+}
+
+
 mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* pParams)
 {
 
@@ -834,72 +910,6 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
         {
             pParams->nTransformSkip = MFX_CODINGOPTION_OFF;
         }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-AvcTemporalLayers")))
-		{
-			pParams->nAvcTemp = 1; 
-			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
-			mfxU16 arr[8] = { 0,0,0,0,0,0,0,0 };
-			int j,k;
-		        k = msdk_sscanf(strInput[i + 1], MSDK_STRING("%hu %hu %hu %hu %hu %hu %hu %hu"), &arr[0], &arr[1], &arr[2], &arr[3], &arr[4], &arr[5], &arr[6], &arr[7]);
-			for (j = 0; j < 8; j++)
-			{
-				pParams->nAvcTemporalLayers[j] = arr[j];
-			}
-			i += 1;
-		}
-
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-BaseLayerPID")))
-	        {
-			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
-			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nBaseLayerPID))
-			{
-				PrintHelp(strInput[0], MSDK_STRING("BaseLayerPID is invalid"));
-				return MFX_ERR_UNSUPPORTED;
-			}
-		}
-
-	else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-SPSId")))
-                {
-			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
-			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nSPSId))
-			{
-				PrintHelp(strInput[0], MSDK_STRING("SPSId is invalid"));
-				return MFX_ERR_UNSUPPORTED;
-			}
-		}
-	else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PPSId")))
-		{
-			VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
-			if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nPPSId))
-			{
-				PrintHelp(strInput[0], MSDK_STRING("PPSId is invalid"));
-				return MFX_ERR_UNSUPPORTED;
-			}
-		}
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PicTimingSEI:on")))
-	{
-            pParams->nPicTimingSEI = MFX_CODINGOPTION_ON;
-        }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-PicTimingSEI:off")))
-        {
-            pParams->nPicTimingSEI = MFX_CODINGOPTION_OFF;
-        }
-	else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-NalHrdConformance:on")))
-        {
-            pParams->nNalHrdConformance = MFX_CODINGOPTION_ON;
-        }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-NalHrdConformance:off")))
-        {
-            pParams->nNalHrdConformance = MFX_CODINGOPTION_OFF;
-        }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-VuiNalHrdParameters:on")))
-        {
-            pParams->nVuiNalHrdParameters = MFX_CODINGOPTION_ON;
-        }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-VuiNalHrdParameters:off")))
-        {
-            pParams->nVuiNalHrdParameters = MFX_CODINGOPTION_OFF;
-        }
         else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-ppyr:on")))
         {
             pParams->nPRefType = MFX_P_REF_PYRAMID;
@@ -1209,9 +1219,13 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
         }
         else
         {
-            msdk_printf(MSDK_STRING("Unknown option: %s\n"), strInput[i]);
-            PrintHelp(strInput[0], NULL);
-            return MFX_ERR_UNSUPPORTED;
+            mfxStatus sts = ParseAdditionalParams(strInput, nArgNum, i, pParams);
+            if (sts < MFX_ERR_NONE)
+            {
+                msdk_printf(MSDK_STRING("Unknown option: %s\n"), strInput[i]);
+                PrintHelp(strInput[0], NULL);
+                return MFX_ERR_UNSUPPORTED;
+            }
         }
     }
 
@@ -1439,7 +1453,6 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
 
     return MFX_ERR_NONE;
 }
-
 
 void ModifyParamsUsingPresets(sInputParams& params)
 {


### PR DESCRIPTION
CreateQueue(Ex) is called at init of MCTF, but later when
the kernel has been configured for operation the code had
extra CreateQueue calls, which reset the original queue,
this is an issue on ICL because ICL requires special queue
creation by using CreateQueueEx. By removing the additional
CreateQueue calls the original queue (properly configured)
is not reset and MCTF works correctly.

Issue: MDP-48160
Test: vpp_mctf_denoise

Signed-off-by: Sebastian Possos <sebastian.possos@intel.com>