### PR TITLE
[VP9e] Fix setting default value of initialDelayInKb

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -1654,10 +1654,6 @@ mfxStatus SetDefaults(
         SetDefault(par.mfx.RateControlMethod, MFX_RATECONTROL_CBR);
     }
 
-    if (IsBufferBasedBRC(par.mfx.RateControlMethod))
-    {
-        SetDefault(par.m_initialDelayInKb, par.m_bufferSizeInKb / 2);
-    }
     if (IsBitrateBasedBRC(par.mfx.RateControlMethod))
     {
         if (par.m_numLayers)
@@ -1691,6 +1687,10 @@ mfxStatus SetDefaults(
     }
 
     SetDefault(par.m_bufferSizeInKb, GetDefaultBufferSize(par));
+    if (IsBufferBasedBRC(par.mfx.RateControlMethod))
+    {
+        SetDefault(par.m_initialDelayInKb, par.m_bufferSizeInKb / 2);
+    }
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP)
     {


### PR DESCRIPTION
bufferSizeInKb is used before its default values is set, so default value of initialDelayInKb isn't set correctly.