### PR TITLE
sample_decode: check and report errors in case of X11 DRI3 rendering

### DIFF
--- a/samples/sample_common/include/vaapi_utils.h
+++ b/samples/sample_common/include/vaapi_utils.h
@@ -352,10 +352,12 @@ namespace MfxLoader
                                     uint8_t,
                                     uint8_t,
                                     int32_t);
+        typedef xcb_dri3_pixmap_from_buffer_type xcb_dri3_pixmap_from_buffer_checked_type;
+
         XCB_Dri3_Proxy();
         ~XCB_Dri3_Proxy();
 
-        const xcb_dri3_pixmap_from_buffer_type  xcb_dri3_pixmap_from_buffer;
+        const xcb_dri3_pixmap_from_buffer_checked_type  xcb_dri3_pixmap_from_buffer_checked;
     };
 
     class Xcb_Proxy
@@ -367,13 +369,15 @@ namespace MfxLoader
         typedef uint32_t (*xcb_generate_id_type) (xcb_connection_t *);
         typedef xcb_void_cookie_t (*xcb_free_pixmap_type) (xcb_connection_t *, xcb_pixmap_t);
         typedef int (*xcb_flush_type)(xcb_connection_t *);
+        typedef xcb_generic_error_t* (*xcb_request_check_type)(xcb_connection_t *c, xcb_void_cookie_t cookie);
 
         Xcb_Proxy();
         ~Xcb_Proxy();
 
-        const xcb_generate_id_type      xcb_generate_id;
-        const xcb_free_pixmap_type  xcb_free_pixmap;
-        const xcb_flush_type        xcb_flush;
+        const xcb_generate_id_type   xcb_generate_id;
+        const xcb_free_pixmap_type   xcb_free_pixmap;
+        const xcb_flush_type         xcb_flush;
+        const xcb_request_check_type xcb_request_check;
     };
 
     class X11_Xcb_Proxy
@@ -413,10 +417,12 @@ namespace MfxLoader
                                     uint64_t,
                                     uint32_t,
                                     const xcb_present_notify_t *);
+        typedef xcb_present_pixmap_type xcb_present_pixmap_checked_type;
+
         Xcbpresent_Proxy();
         ~Xcbpresent_Proxy();
 
-        const xcb_present_pixmap_type   xcb_present_pixmap;
+        const xcb_present_pixmap_checked_type xcb_present_pixmap_checked;
     };
 
 #endif // X11_DRI3_SUPPORT

--- a/samples/sample_common/src/vaapi_utils.cpp
+++ b/samples/sample_common/src/vaapi_utils.cpp
@@ -161,7 +161,7 @@ VA_DRMProxy::~VA_DRMProxy()
 #if defined(X11_DRI3_SUPPORT)
 XCB_Dri3_Proxy::XCB_Dri3_Proxy()
     : lib("libxcb-dri3.so.0")
-    , SIMPLE_LOADER_FUNCTION(xcb_dri3_pixmap_from_buffer)
+    , SIMPLE_LOADER_FUNCTION(xcb_dri3_pixmap_from_buffer_checked)
 {
 }
 
@@ -173,6 +173,7 @@ Xcb_Proxy::Xcb_Proxy()
     , SIMPLE_LOADER_FUNCTION(xcb_generate_id)
     , SIMPLE_LOADER_FUNCTION(xcb_free_pixmap)
     , SIMPLE_LOADER_FUNCTION(xcb_flush)
+    , SIMPLE_LOADER_FUNCTION(xcb_request_check)
 {
 }
 
@@ -190,7 +191,7 @@ X11_Xcb_Proxy::~X11_Xcb_Proxy()
 
 Xcbpresent_Proxy::Xcbpresent_Proxy()
     : lib("libxcb-present.so.0")
-    , SIMPLE_LOADER_FUNCTION(xcb_present_pixmap)
+    , SIMPLE_LOADER_FUNCTION(xcb_present_pixmap_checked)
 {
 }
 


### PR DESCRIPTION
Fixes: #1396

In case of X11 DRI3 we try to directly render output surfaces via memory
sharing mechanism. For that we extract DMA buffer handle (file descriptor)
from video surfaces and create XCB pixmap from it, but this operation
might fail since rendering scanout might not be supported for some color
formats we use for media. For example, typically we decode into NV12 which
is not supported for scanouts. Hence the following might fail:
  sample_decode h264 -i input.264 -r -f 30

Before this patch user will see the following error which is not very
descriptive:
  X Error of failed request:  BadAlloc (insufficient resources for operation)
    Major opcode of failed request:  149 ()
    Minor opcode of failed request:  2
    Serial number of failed request:  19
    Current serial number in output stream:  22

After this patch user will get:
  Failed to create xcb pixmap from the NV12 surface: try another
    color format (e.g. RGB4)
  DeliverOutput return error = -6

Which hopefull will lead user trying to run the following command line
which should work assuming scanout from rgb4 is supported (which usually is):
  sample_decode h264 -i input.264 -r -f 30 -rgb4

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>