### PR TITLE
Make sure to compare guids correctly

### DIFF
--- a/_studio/shared/include/mfxvideo++int.h
+++ b/_studio/shared/include/mfxvideo++int.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@
 #ifndef GUID_TYPE_DEFINED
 
 #include <string.h>
+#include <algorithm>
 
 typedef struct {
 
@@ -57,7 +58,11 @@ typedef struct {
 
 static inline int operator==(const GUID & guidOne, const GUID & guidOther)
 {
-    return !memcmp(&guidOne, &guidOther, sizeof(GUID));
+    return
+        guidOne.Data1 == guidOther.Data1 &&
+        guidOne.Data2 == guidOther.Data2 &&
+        guidOne.Data3 == guidOther.Data3 &&
+        std::equal(guidOne.Data4, guidOne.Data4 + sizeof(guidOne.Data4), guidOther.Data4);
 }
 
 #define GUID_TYPE_DEFINED


### PR DESCRIPTION
Fix for #1398

On Ubuntu 19.04 compiler (gcc-8.3.0) aligns GUID stucture size which
we defined internally in mediasdk by 8 and does not zero out the
structure when allocated on stack. As a result when we use current
approach to compare guids via !memcpy(a,b,sizeof(GUID)) we actually
compare unitialized regions and mistakenly think some guids not
equal which leads to runtime errors. For example, we might fail
to enable LowPower encoding on this command line:
  sample_encode h264 -w 176 -h 144 -f 30 -cqp \
    -qpi 30 -qpp 30 -qpb 30 -qsv-ff -nv12 -i a.yuv -o a.264

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>