### PR TITLE
Update ICL device Ids

### DIFF
--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -307,16 +307,20 @@ typedef struct {
     { 0x5A49, MFX_HW_CNL, MFX_GT2 },
 
     /* ICL LP */
+    { 0xFF05, MFX_HW_ICL_LP, MFX_GT1 },
     { 0x8A50, MFX_HW_ICL_LP, MFX_GT2 },
     { 0x8A51, MFX_HW_ICL_LP, MFX_GT2 },
-    { 0x8A5C, MFX_HW_ICL_LP, MFX_GT2 },
-    { 0x8A5D, MFX_HW_ICL_LP, MFX_GT2 },
     { 0x8A52, MFX_HW_ICL_LP, MFX_GT2 },
-    { 0x8A5A, MFX_HW_ICL_LP, MFX_GT2 },
-    { 0x8A5B, MFX_HW_ICL_LP, MFX_GT2 },
-    { 0x8A71, MFX_HW_ICL_LP, MFX_GT1 },
-    { 0x8A70, MFX_HW_ICL_LP, MFX_GT1 }
-
+    { 0x8A53, MFX_HW_ICL_LP, MFX_GT2 },
+    { 0x8A56, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A57, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A58, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A59, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A5A, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A5B, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A5C, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A5D, MFX_HW_ICL_LP, MFX_GT1 },
+    { 0x8A71, MFX_HW_ICL_LP, MFX_GT1 }  // GT05, but 1 ok in this context
  };
 
 /* END: IOCTLs definitions */


### PR DESCRIPTION
Aligned with commit https://github.com/intel/media-driver/tree/7679797bcf6ce498520f623d435577385d024b67
Including 0x8A70 removal from list.