### PR TITLE
Fix klocwork issue in umc_h265_va_packer_cenc.cpp

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_cenc.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_cenc.cpp
@@ -132,7 +132,9 @@ namespace UMC_HEVC_DECODER
         for(; index < rps->getNumberOfNegativePictures() + rps->getNumberOfPositivePictures() + rps->getNumberOfLongtermPictures(); index++)
         {
             int32_t poc = rps->getPOC(index);
-            H265DecoderFrame *pFrm = supplier->GetDPBList()->findLongTermRefPic(pCurrentFrame, poc, pSeqParamSet->log2_max_pic_order_cnt_lsb, !rps->getCheckLTMSBPresent(index));
+            H265DecoderFrame *pFrm = 0;
+            if(findLongTermRefPic(pCurrentFrame, poc, pSeqParamSet->log2_max_pic_order_cnt_lsb, !rps->getCheckLTMSBPresent(index)) != 0)
+               pFrm = supplier->GetDPBList()->findLongTermRefPic(pCurrentFrame, poc, pSeqParamSet->log2_max_pic_order_cnt_lsb, !rps->getCheckLTMSBPresent(index));
 
             if (pFrm)
             {


### PR DESCRIPTION
Fix klocwork issue. 
Issue ID: 99914
Pointer 'supplier->GetDPBList()' returned from call to function 'GetDPBList' at line 143 may be NULL and will be dereferenced at line 143
