### PR TITLE
Avoid nullptr situaton of supplier->GetDPBList() in PackPicParams fun…

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_cenc.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_cenc.cpp
@@ -129,6 +129,9 @@ namespace UMC_HEVC_DECODER
         for(; index < rps->getNumberOfNegativePictures() + rps->getNumberOfPositivePictures(); index++)
                 pocList[numRefPicSetStCurrBefore + numRefPicSetStCurrAfter++] = picParam->CurrPic.pic_order_cnt + rps->getDeltaPOC(index);
 
+        if(!(supplier->GetDPBList()))
+            throw h265_exception(UMC_ERR_FAILED);
+
         for(; index < rps->getNumberOfNegativePictures() + rps->getNumberOfPositivePictures() + rps->getNumberOfLongtermPictures(); index++)
         {
             int32_t poc = rps->getPOC(index);


### PR DESCRIPTION
Add an if() branch to avoid nullptr 