### PR TITLE
Avoid uninitialized of m_payloads

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_au_splitter.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_au_splitter.cpp
@@ -40,9 +40,16 @@ SeiPayloadArray::SeiPayloadArray()
 SeiPayloadArray::SeiPayloadArray(const SeiPayloadArray & payloads)
 {
     size_t count = payloads.GetPayloadCount();
-    for (size_t i = 0; i < count; i++)
+    if (count == 0)
     {
-        AddPayload(payloads.GetPayload(i));
+        SeiPayloadArray();
+    }
+    else
+    {
+        for (size_t i = 0; i < count; i++)
+        {
+            AddPayload(payloads.GetPayload(i));
+        }
     }
 }
 


### PR DESCRIPTION
The "m_payload" may uninitialized in constructor function SeiPayloadArray(const SeiPayloadArray & payloads) of umc_h264_au_splitter.cpp