### PR TITLE
[metrics_monitor] Use VERSION_GREATER for version checking

### DIFF
--- a/samples/metrics_monitor/CMakeLists.txt
+++ b/samples/metrics_monitor/CMakeLists.txt
@@ -1,12 +1,9 @@
 # metrics_monitor library
 
-pkg_check_modules(PKG_LIBDRM libdrm>=2.4.92)
+if( PKG_LIBDRM_FOUND AND
+   (${PKG_LIBDRM_VERSION} VERSION_GREATER 2.4.91))
 
-if( PKG_LIBDRM_FOUND)
-
-    include_directories (
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    )
+    include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
     set( sources "" )
 
@@ -32,33 +29,32 @@ if( PKG_LIBDRM_FOUND)
 
     install( TARGETS metrics_monitor RUNTIME DESTINATION ${MFX_SAMPLES_INSTALL_BIN_DIR} )
 
-endif()
+    # test_monitor
 
-# test_monitor
+    pkg_check_modules(PKG_PCIACCESS pciaccess)
 
-pkg_check_modules(PKG_PCIACCESS pciaccess)
+    if( PKG_PCIACCESS_FOUND AND
+        BUILD_TESTS)
 
-if( PKG_LIBDRM_FOUND AND
-    PKG_PCIACCESS_FOUND AND
-    BUILD_TESTS)
+        file( GLOB_RECURSE test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/test/*.c" )
 
-    file( GLOB_RECURSE test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/test/*.c" )
+        add_executable( test_monitor ${test_srcs})
+        target_include_directories( test_monitor PRIVATE ./include ${PKG_LIBDRM_INCLUDE_DIRS})
+        target_link_libraries( test_monitor pthread rt gtest cttmetrics ${PKG_LIBDRM_LIBRARIES})
 
-    add_executable( test_monitor ${test_srcs})
-    target_include_directories( test_monitor PRIVATE ./include ${PKG_LIBDRM_INCLUDE_DIRS})
-    target_link_libraries( test_monitor pthread rt gtest cttmetrics ${PKG_LIBDRM_LIBRARIES})
+        set_target_properties(test_monitor PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE})
 
-    set_target_properties(test_monitor PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BIN_DIR}/${CMAKE_BUILD_TYPE})
+    else()
 
-else()
+        if( NOT PKG_PCIACCESS_FOUND )
+            message( STATUS "pciaccess was not found (optional), the following will not be built: test_monitor." )
+        endif()
 
-    if( NOT PKG_PCIACCESS_FOUND )
-        message( STATUS "pciaccess was not found (optional), the following will not be built: test_monitor." )
-    endif()
+        if( NOT PKG_LIBDRM_FOUND )
+            message( STATUS "libdrm was not found (optional), the following will not be built: test_monitor." )
+        endif()
 
-    if( NOT PKG_LIBDRM_FOUND )
-        message( STATUS "libdrm was not found (optional), the following will not be built: test_monitor." )
     endif()
 
 endif()


### PR DESCRIPTION
Fixes: #1446

cmake-3.6 doesn't respect a minimal version specified for a component.
It doesn't work properly for constructions like:
pkg_check_modules(PKG_AAA AAA>=1.2.3)
if( PKG_AAA_FOUND)
endif()

So let's use this instead as a workaround:
if( ${PKG_XXX_VERSION} VERSION_GREATER 1.2.2 )

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>