### PR TITLE
Revert "[Encode] Changed rules for AYUV&Y410 reconstructed surfaces allocation"

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
@@ -120,20 +120,14 @@ bool GetRecInfo(const MfxVideoParam& par, mfxFrameInfo& rec)
     if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 10)
     {
         rec.FourCC = MFX_FOURCC_Y410;
-        /* Pitch = 4*W for Y410 format
-           Pitch need to align on 256
-           So, width aligment is 256/4 = 64 */
-        rec.Width = (mfxU16)Align(rec.Width, 256/4);
-        rec.Height = (mfxU16)Align(rec.Height * 3 / 2, 8);
+        rec.Width /= 2;
+        rec.Height *= 3;
     }
     else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 8)
     {
         rec.FourCC = MFX_FOURCC_AYUV;
-        /* Pitch = 4*W for AYUV format
-           Pitch need to align on 512
-           So, width aligment is 512/4 = 128 */
-        rec.Width = (mfxU16)Align(rec.Width, 512 / 4);
-        rec.Height = (mfxU16)Align(rec.Height *3/4, 8);
+        rec.Width /= 4;
+        rec.Height *= 3;
     }
     else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV422) && CO3.TargetBitDepthLuma == 10)
     {

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
@@ -153,20 +153,14 @@ void SetReconInfo(VP9MfxVideoParam const & par, mfxFrameInfo& fi)
     if (format == MFX_CHROMAFORMAT_YUV444 && depth == BITDEPTH_10)
     {
         fi.FourCC = MFX_FOURCC_Y410;
-        /* Pitch = 4*W for Y410 format
-           Pitch need to align on 256
-           So, width aligment is 256/4 = 64 */
-        fi.Width = (mfxU16)mfx::align2_value(fi.Width, 256 / 4);
-        fi.Height = (mfxU16)mfx::align2_value(fi.Height * 3 / 2, 8);
+        fi.Width = fi.Width / 2;
+        fi.Height = fi.Height * 3;
     }
     else if (format == MFX_CHROMAFORMAT_YUV444 && depth == BITDEPTH_8)
     {
         fi.FourCC = MFX_FOURCC_AYUV;
-        /* Pitch = 4*W for AYUV format
-           Pitch need to align on 512
-           So, width aligment is 512/4 = 128 */
-        fi.Width = (mfxU16)mfx::align2_value(fi.Width, 512 / 4);
-        fi.Height = (mfxU16)mfx::align2_value(fi.Height * 3 / 4, 8);
+        fi.Width = fi.Width / 4;
+        fi.Height = fi.Height * 3;
     }
     else if (format == MFX_CHROMAFORMAT_YUV420 && depth == BITDEPTH_10)
     {


### PR DESCRIPTION
Reverts Intel-Media-SDK/MediaSDK#1441
Following media-driver change: https://github.com/intel/media-driver/commit/9c32273adfd50268683b3d4658b0b143aca231e4
