### PR TITLE
mfx_vpp: support CSC from P010 to UYVY on Linux

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -929,6 +929,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
              out->vpp.Out.FourCC != MFX_FOURCC_P010 &&
              out->vpp.Out.FourCC != MFX_FOURCC_P210 &&
              out->vpp.Out.FourCC != MFX_FOURCC_YUY2 &&
+#if defined(MFX_VA_LINUX)
+             out->vpp.Out.FourCC != MFX_FOURCC_UYVY &&
+#endif
              out->vpp.Out.FourCC != MFX_FOURCC_AYUV &&
 #if (MFX_VERSION >= 1027)
              out->vpp.Out.FourCC != MFX_FOURCC_Y210 &&


### PR DESCRIPTION
This makes the gst pipeline below works on Linux

gst-launch-1.0 videotestsrc ! video/x-raw,format=P010_10LE ! msdkvpp ! \
video/x-raw,format=UYVY ! fakesink

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>