### PR TITLE
vp9e: prevent double destroy of m_segMapBufferId buffer.

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -1332,8 +1332,8 @@ mfxStatus VAAPIEncoder::Destroy()
     sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_ppsBufferId);
     std::ignore = MFX_STS_TRACE(sts);
 
-    sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_segMapBufferId);
-    std::ignore = MFX_STS_TRACE(sts);
+    // m_segMapBufferId buffer is allocated through internal allocator and will be destroyed there
+    m_segMapBufferId = VA_INVALID_ID;
 
     sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_segParBufferId);
     std::ignore = MFX_STS_TRACE(sts);


### PR DESCRIPTION
It is allocated through internal allocator and will be destroyed there