### PR TITLE
[jpegd] Use correct mfxVideoParam in VideoVppJpegD3D9 initialization

### DIFF
--- a/_studio/shared/include/mfx_umc_alloc_wrapper.h
+++ b/_studio/shared/include/mfx_umc_alloc_wrapper.h
@@ -229,7 +229,8 @@ class mfx_UMC_FrameAllocator_D3D_Converter : public mfx_UMC_FrameAllocator_D3D
 {
     std::unique_ptr<VideoVppJpegD3D9> m_pCc;
 
-    mfxStatus FindSurfaceByMemId(UMC::FrameData* in, bool isOpaq, const mfxHDLPair &hdlPair,
+    mfxStatus InitVideoVppJpegD3D9(const mfxVideoParam *params);
+    mfxStatus FindSurfaceByMemId(const UMC::FrameData* in, bool isOpaq, const mfxHDLPair &hdlPair,
                                  // output param
                                  mfxFrameSurface1 &surface);
 public:


### PR DESCRIPTION
The regression was introduced in bb9a4a08, mfxVideoParam in
mfx_UMC_FrameAllocator_D3D_Converter::InitMfx() is for decoder only,
it ignores VPP step.

Issue: MDP-57600