### PR TITLE
[Encode] Changed rules for AYUV&Y410 reconstructed surfaces allocation

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
@@ -109,14 +109,20 @@ bool GetRecInfo(const MfxVideoParam& par, mfxFrameInfo& rec)
     if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 10)
     {
         rec.FourCC = MFX_FOURCC_Y410;
-        rec.Width /= 2;
-        rec.Height *= 3;
+        /* Pitch = 4*W for Y410 format
+           Pitch need to align on 256
+           So, width aligment is 256/4 = 64 */
+        rec.Width = (mfxU16)mfx::align2_value(rec.Width, 256/4);
+        rec.Height = (mfxU16)mfx::align2_value(rec.Height * 3 / 2, 8);
     }
     else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 8)
     {
         rec.FourCC = MFX_FOURCC_AYUV;
-        rec.Width /= 4;
-        rec.Height *= 3;
+        /* Pitch = 4*W for AYUV format
+           Pitch need to align on 512
+           So, width aligment is 512/4 = 128 */
+        rec.Width = (mfxU16)mfx::align2_value(rec.Width, 512 / 4);
+        rec.Height = (mfxU16)mfx::align2_value(rec.Height *3/4, 8);
     }
     else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV422) && CO3.TargetBitDepthLuma == 10)
     {

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw.cpp
@@ -153,14 +153,20 @@ void SetReconInfo(VP9MfxVideoParam const & par, mfxFrameInfo& fi)
     if (format == MFX_CHROMAFORMAT_YUV444 && depth == BITDEPTH_10)
     {
         fi.FourCC = MFX_FOURCC_Y410;
-        fi.Width = fi.Width / 2;
-        fi.Height = fi.Height * 3;
+        /* Pitch = 4*W for Y410 format
+           Pitch need to align on 256
+           So, width aligment is 256/4 = 64 */
+        fi.Width = (mfxU16)mfx::align2_value(fi.Width, 256 / 4);
+        fi.Height = (mfxU16)mfx::align2_value(fi.Height * 3 / 2, 8);
     }
     else if (format == MFX_CHROMAFORMAT_YUV444 && depth == BITDEPTH_8)
     {
         fi.FourCC = MFX_FOURCC_AYUV;
-        fi.Width = fi.Width / 4;
-        fi.Height = fi.Height * 3;
+        /* Pitch = 4*W for AYUV format
+           Pitch need to align on 512
+           So, width aligment is 512/4 = 128 */
+        fi.Width = (mfxU16)mfx::align2_value(fi.Width, 512 / 4);
+        fi.Height = (mfxU16)mfx::align2_value(fi.Height * 3 / 4, 8);
     }
     else if (format == MFX_CHROMAFORMAT_YUV420 && depth == BITDEPTH_10)
     {


### PR DESCRIPTION
This allow 8k encoding.
This is 2nd attempt. Previous attempts:
https://github.com/Intel-Media-SDK/MediaSDK/pull/1441 (merged)
https://github.com/Intel-Media-SDK/MediaSDK/pull/1453 (reverted)
Aligned with driver (2nd attempt too):
https://github.com/intel/media-driver/commit/a674421e8aa5fb0b17a49446c54b0080ee07999e

Issue: MDP-52033
Test: beh_hevce_10b_444_{y410/ayuv}_big_resolution*

Signed-off-by: Andrey Larionov <andrey.larionov@intel.com>