### PR TITLE
[h264e] Fix wrong initialCpbRemovalDelay rounding

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
@@ -2031,7 +2031,7 @@ mfxU32 Hrd::GetInitCpbRemovalDelay() const
         return 0;
 
     double delay = MFX_MAX(0.0, m_trn_cur - m_taf_prv);
-    mfxU32 initialCpbRemovalDelay = mfxU32(90000 * delay + 0.5);
+    mfxU32 initialCpbRemovalDelay = mfxU32(90000 * delay);
 
     return initialCpbRemovalDelay == 0
         ? 1 // should not be equal to 0

--- a/_studio/mfx_lib/fei/h264_la/mfx_h264_la.cpp
+++ b/_studio/mfx_lib/fei/h264_la/mfx_h264_la.cpp
@@ -47,6 +47,7 @@
 #include "mfx_ext_buffers.h"
 
 using namespace MfxEncLA;
+using MfxHwH264Encode::IsOn;
 
 static mfxU16 GetGopSize(mfxVideoParam *par)
 {
@@ -54,10 +55,12 @@ static mfxU16 GetGopSize(mfxVideoParam *par)
 }
 static mfxU16 GetRefDist(mfxVideoParam *par)
 {
-    mfxExtLAControl *pControl = (mfxExtLAControl *) GetExtBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_LOOKAHEAD_CTRL);
+    mfxExtLAControl *pControl = (mfxExtLAControl *)GetExtBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_LOOKAHEAD_CTRL);
     mfxU16 GopSize = GetGopSize(par);
-    mfxU16 refDist = par->mfx.GopRefDist == 0 ? ((pControl && pControl->BPyramid == MFX_CODINGOPTION_ON) ? 8 : 3) : par->mfx.GopRefDist;
-    return refDist <= GopSize ? refDist: GopSize;
+    mfxU16 refDist = par->mfx.GopRefDist;
+    if (refDist == 0)
+        refDist = IsOn(par->mfx.LowPower) ? 1 : ((pControl && IsOn(pControl->BPyramid)) ? 8 : 3);
+    return (std::min)(refDist, GopSize);
 }
 static mfxU16 GetAsyncDeph(mfxVideoParam *par)
 {


### PR DESCRIPTION
Wrong rounding may cause HDR overflow in some streams