### PR TITLE
mfx_vpp: fix mirroring when IOPattern equals d3d->d3d on Linux

### DIFF
--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -421,6 +421,12 @@ mfxStatus VAAPIVideoProcessing::QueryCapabilities(mfxVppCaps& caps)
     }
 #endif
 
+    if ((m_pipelineCaps.mirror_flags & VA_MIRROR_HORIZONTAL) &&
+        (m_pipelineCaps.mirror_flags & VA_MIRROR_VERTICAL))
+    {
+        caps.uMirroring = 1;
+    }
+
     if (m_pipelineCaps.max_output_width && m_pipelineCaps.max_output_height)
     {
         caps.uMaxWidth = m_pipelineCaps.max_output_width;
@@ -485,7 +491,6 @@ mfxStatus VAAPIVideoProcessing::QueryCapabilities(mfxVppCaps& caps)
         }
     }
 
-    caps.uMirroring = 1;
     caps.uScaling = 1;
 
     return MFX_ERR_NONE;
@@ -1038,6 +1043,22 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
         break;
     }
 #endif
+
+    /*
+     * Execute mirroring for MIRROR_WO_EXEC only because MSDK will do
+     * copy-with-mirror for others.
+     */
+    if (pParams->mirroringPosition == MIRROR_WO_EXEC) {
+        switch (pParams->mirroring) {
+        case MFX_MIRRORING_HORIZONTAL:
+            m_pipelineParam[0].mirror_state = VA_MIRROR_HORIZONTAL;
+            break;
+
+        case MFX_MIRRORING_VERTICAL:
+            m_pipelineParam[0].mirror_state = VA_MIRROR_VERTICAL;
+            break;
+        }
+    }
 
     // source cropping
     mfxFrameInfo *inInfo = &(pRefSurf->frameInfo);


### PR DESCRIPTION
Before this fix, mirroring on Linux supports horizontal mirroring only when IOPattern equals d3d->d3d. In addition, mirroring can't work with other VPP features, e.g. rotation

Example:
gst-launch-1.0 videotestsrc num-buffers=10 ! video/x-raw,format=I420 ! \
msdkvpp rotation=90 mirroring=2 ! video/x-raw,format=YUY2 ! fakesink

ffmpeg -y -hwaccel qsv -c:v h264_qsv -i input.h264 -vf \
'format=qsv,vpp_qsv=transpose=vflip' -c:v h264_qsv output.h264 [*]
    
[*] The ffmpeg command needs two patches from Linjie
https://patchwork.ffmpeg.org/patch/13594/
https://patchwork.ffmpeg.org/patch/13595/
    
Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
Tested-by: Linjie Fu <linjie.fu@intel.com>
