### PR TITLE
[jpegd] Enable SFC for CSC to ARGB during jpeg 420 decode.

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
+++ b/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
@@ -107,9 +107,9 @@ public:
     virtual mfxStatus AllocateFrameData(UMC::FrameData *&data);
     virtual mfxStatus FillEntryPoint(MFX_ENTRY_POINT *pEntryPoint, mfxFrameSurface1 *surface_work, mfxFrameSurface1 *surface_out);
 
-    mfxU32 AdjustFrameAllocRequest(mfxFrameAllocRequest *request, mfxInfoMFX *info, eMFXHWType hwType, eMFXVAType vaType);
+    mfxU32 AdjustFrameAllocRequest(mfxFrameAllocRequest *request, mfxInfoMFX *info, eMFXHWType hwType, eMFXVAType vaType, bool usePostProcessing);
 
-    static void AdjustFourCC(mfxFrameInfo *requestFrameInfo, mfxInfoMFX *info, eMFXHWType hwType, eMFXVAType vaType, bool *needVpp);
+    static void AdjustFourCC(mfxFrameInfo *requestFrameInfo, const mfxInfoMFX *info, eMFXHWType hwType, eMFXVAType vaType, bool usePostProc, bool *needVpp);
 
     static mfxStatus CheckVPPCaps(VideoCORE * core, mfxVideoParam * par);
 

--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -517,6 +517,7 @@ mfxStatus CheckDecodersExtendedBuffers(mfxVideoParam const* par)
 
 
     static const mfxU32 g_decoderSupportedExtBuffersMJPEG[] = {MFX_EXTBUFF_JPEG_HUFFMAN,
+                                                               MFX_EXTBUFF_DEC_VIDEO_PROCESSING,
                                                                MFX_EXTBUFF_JPEG_QT};
 
     const mfxU32 *supported_buffers = 0;

--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -478,7 +478,9 @@ Status LinuxVideoAccelerator::Init(VideoAcceleratorParams* pInfo)
 
         if (UMC_OK == umcRes && pParams->m_needVideoProcessingVA)
         {
-            if (va_attributes[2].value == VA_DEC_PROCESSING_NONE)
+            // for VAProfileJPEGBaseline current driver doesn't report
+            // VAConfigAttribDecProcessing status correctly
+            if (va_attributes[2].value == VA_DEC_PROCESSING_NONE && va_profile != VAProfileJPEGBaseline)
                 umcRes = UMC_ERR_FAILED;
             else
                 attribsNumber++;

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -771,7 +771,7 @@ mfxStatus CDecodingPipeline::InitMfxParams(sInputParams *pParams)
         || m_mfxVideoParams.mfx.FrameInfo.FourCC == MFX_FOURCC_Y210
 #endif
         )
-    ) 
+    )
     {
         m_mfxVideoParams.mfx.FrameInfo.Shift = 1;
     }
@@ -782,16 +782,28 @@ mfxStatus CDecodingPipeline::InitMfxParams(sInputParams *pParams)
     {
 
         if ( (m_mfxVideoParams.mfx.FrameInfo.CropW != pParams->Width && pParams->Width) ||
-            (m_mfxVideoParams.mfx.FrameInfo.CropH != pParams->Height && pParams->Height) )
+            (m_mfxVideoParams.mfx.FrameInfo.CropH != pParams->Height && pParams->Height)||
+            (pParams->videoType == MFX_CODEC_JPEG && pParams->fourcc == MFX_FOURCC_RGB4 &&
+             m_mfxVideoParams.mfx.JPEGColorFormat != m_mfxVideoParams.mfx.FrameInfo.ChromaFormat))
         {
             /* By default VPP used for resize */
             m_bVppIsUsed = true;
             /* But... lets try to use decoder's post processing */
             if ( ((MODE_DECODER_POSTPROC_AUTO == pParams->nDecoderPostProcessing) ||
                   (MODE_DECODER_POSTPROC_FORCE == pParams->nDecoderPostProcessing)) &&
-                 (MFX_CODEC_AVC == m_mfxVideoParams.mfx.CodecId) && /* Only for AVC */
+                 (MFX_CODEC_AVC == m_mfxVideoParams.mfx.CodecId ||
+                  MFX_CODEC_JPEG == m_mfxVideoParams.mfx.CodecId) && /* Only for AVC and JPEG */
                  (MFX_PICSTRUCT_PROGRESSIVE == m_mfxVideoParams.mfx.FrameInfo.PicStruct)) /* ...And only for progressive!*/
             {   /* it is possible to use decoder's post-processing */
+
+                // JPEG only suppoted w/o resize, so use W/H from DecodeHeader(), if they are not set
+                if (MFX_CODEC_JPEG == m_mfxVideoParams.mfx.CodecId &&
+                    (!pParams->Width || !pParams->Height))
+                {
+                    pParams->Width  = m_mfxVideoParams.mfx.FrameInfo.CropW;
+                    pParams->Height = m_mfxVideoParams.mfx.FrameInfo.CropH;
+                }
+
                 m_bVppIsUsed = false;
                 m_DecoderPostProcessing.In.CropX = 0;
                 m_DecoderPostProcessing.In.CropY = 0;
@@ -814,7 +826,7 @@ mfxStatus CDecodingPipeline::InitMfxParams(sInputParams *pParams)
             /* POSTPROC_FORCE */
             if (MODE_DECODER_POSTPROC_FORCE == pParams->nDecoderPostProcessing)
             {
-               if ((MFX_CODEC_AVC != m_mfxVideoParams.mfx.CodecId) ||
+              if ( (MFX_CODEC_AVC != m_mfxVideoParams.mfx.CodecId && MFX_CODEC_JPEG != m_mfxVideoParams.mfx.CodecId) ||
                    (MFX_PICSTRUCT_PROGRESSIVE != m_mfxVideoParams.mfx.FrameInfo.PicStruct))
                {
                    /* it is impossible to use decoder's post-processing */


### PR DESCRIPTION
Off dy default (2-step conversion via internal VPP is used), enabled via
MFX_EXTBUFF_DEC_VIDEO_PROCESSING in prameter's extended buffer.

Issue: MDP-57617