### PR TITLE
Fix comparison operators for plugin guids

### DIFF
--- a/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_plugin_hw.h
+++ b/_studio/hevc_fei/h265_fei/include/mfx_h265_fei_encode_plugin_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ namespace MfxHwH265FeiEncode
 
         static mfxStatus CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg)
         {
-            if (memcmp(&guid, &MFX_PLUGINID_HEVC_FEI_ENCODE, sizeof(mfxPluginUID)))
+            if (guid != MFX_PLUGINID_HEVC_FEI_ENCODE)
             {
                 return MFX_ERR_NOT_FOUND;
             }

--- a/_studio/hevce_hw/h265/include/mfx_h265_encode_plugin_hw.h
+++ b/_studio/hevce_hw/h265/include/mfx_h265_encode_plugin_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ public:
         {
             return MFX_ERR_NULL_PTR;
         }
-        if (memcmp(&guid, &MFX_PLUGINID_HEVCE_HW, sizeof(mfxPluginUID)))
+        if (guid != MFX_PLUGINID_HEVCE_HW)
         {
             return MFX_ERR_NOT_FOUND;
         }

--- a/_studio/mfx_lib/plugin/include/mfx_h264la_plugin.h
+++ b/_studio/mfx_lib/plugin/include/mfx_h264la_plugin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@
 #include "mfxplugin++.h"
 #include "mfxvideo++int.h"
 #include "mfxenc.h"
+#include "mfx_utils.h"
 
 
 #if defined( AS_H264LA_PLUGIN )
@@ -82,7 +83,7 @@ public:
         return new MFXH264LAPlugin(false);
     }
     static mfxStatus CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg) {
-        if (memcmp(& guid , &MFX_PLUGINID_H264LA_HW, sizeof(mfxPluginUID))) {
+        if (guid != MFX_PLUGINID_H264LA_HW) {
             return MFX_ERR_NOT_FOUND;
         }
         MFXH264LAPlugin* tmp_pplg = 0;

--- a/_studio/mfx_lib/plugin/include/mfx_vpp_plugin.h
+++ b/_studio/mfx_lib/plugin/include/mfx_vpp_plugin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ public:
         return new MFXVPP_Plugin(false);
     }
     static mfxStatus CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg) {
-        if (memcmp(& guid , &g_VPP_PluginGuid, sizeof(mfxPluginUID))) {
+        if (guid != g_VPP_PluginGuid) {
             return MFX_ERR_NOT_FOUND;
         }
         MFXVPP_Plugin* tmp_pplg = 0;

--- a/_studio/mfx_lib/plugin/src/mfx_hevc_dec_plugin.cpp
+++ b/_studio/mfx_lib/plugin/src/mfx_hevc_dec_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,7 @@ mfxStatus MFXHEVCDecoderPlugin::GetPluginParam(mfxPluginParam* par)
 
 mfxStatus MFXHEVCDecoderPlugin::CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg)
 {
-    if (memcmp(& guid , &g_HEVCDecoderGuid, sizeof(mfxPluginUID))) {
+    if (guid != g_HEVCDecoderGuid) {
         return MFX_ERR_NOT_FOUND;
     }
 

--- a/_studio/mfx_lib/plugin/src/mfx_vp8_dec_plugin.cpp
+++ b/_studio/mfx_lib/plugin/src/mfx_vp8_dec_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -78,7 +78,7 @@ mfxStatus MFXVP8DecoderPlugin::GetPluginParam(mfxPluginParam* par)
 
 mfxStatus MFXVP8DecoderPlugin::CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg)
 {
-    if (memcmp(& guid , &g_VP8DecoderGuid, sizeof(mfxPluginUID))) {
+    if (guid != g_VP8DecoderGuid) {
         return MFX_ERR_NOT_FOUND;
     }
 

--- a/_studio/mfx_lib/plugin/src/mfx_vp9_dec_plugin.cpp
+++ b/_studio/mfx_lib/plugin/src/mfx_vp9_dec_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -78,7 +78,7 @@ mfxStatus MFXVP9DecoderPlugin::GetPluginParam(mfxPluginParam* par)
 
 mfxStatus MFXVP9DecoderPlugin::CreateByDispatcher(mfxPluginUID guid, mfxPlugin* mfxPlg)
 {
-    if (memcmp(& guid , &g_VP9DecoderGuid, sizeof(mfxPluginUID))) {
+    if (guid != g_VP9DecoderGuid) {
         return MFX_ERR_NOT_FOUND;
     }
 

--- a/_studio/mfx_lib/shared/src/libmfxsw_decode.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_decode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -533,7 +533,7 @@ mfxStatus MFXVideoDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream *bs, 
                 {
                     session->m_plgDec.get()->GetPlugin(plugin);
                     MFX_CHECK_STS(plugin.GetPluginParam(plugin.pthis, &par));
-                    if (!memcmp(&MFX_PLUGINID_HEVCD_SW, &par.PluginUID, sizeof(MFX_PLUGINID_HEVCD_SW)))
+                    if (MFX_PLUGINID_HEVCD_SW == par.PluginUID)
                     {
                         task.pDst[0] = 0;
                     }

--- a/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -215,7 +215,7 @@ mfxStatus MFXVideoUSER_Register(mfxSession session, mfxU32 type,
         mfxRes = par->GetPluginParam(par->pthis, &pluginParam);
         MFX_CHECK_STS(mfxRes);
 #if defined (MFX_ENABLE_HEVC_VIDEO_FEI_ENCODE)
-        if (!memcmp(&MFX_PLUGINID_HEVC_FEI_ENCODE, &pluginParam.PluginUID, sizeof(MFX_PLUGINID_HEVC_FEI_ENCODE)))
+        if (MFX_PLUGINID_HEVC_FEI_ENCODE == pluginParam.PluginUID)
         {
             //WA!! to keep backward compatibility with FEI plugin, need to save it's registration
             //so able to select between HEVC FEI and regular HEVC encode

--- a/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw_plugin.cpp
@@ -228,11 +228,8 @@ mfxStatus MFXVideoUSER_Register(mfxSession session, mfxU32 type,
             return MFX_ERR_NONE;
         }
 #endif
-        for (auto& uid : NativePlugins)
-        {
-            if (!memcmp(&uid, &pluginParam.PluginUID, sizeof(uid)))
-                return MFX_ERR_NONE; //do nothing
-        }
+        if (std::find(std::begin(NativePlugins), std::end(NativePlugins), pluginParam.PluginUID) != std::end(NativePlugins))
+            return MFX_ERR_NONE; //do nothing
 
         // create a new plugin's instance
         pluginPtr.reset(CreateUSERSpecificClass(type));

--- a/_studio/shared/include/mfx_utils.h
+++ b/_studio/shared/include/mfx_utils.h
@@ -24,6 +24,7 @@
 #include "mfx_config.h"
 
 #include "mfxstructures.h"
+#include "mfxplugin.h"
 
 #include "umc_structures.h"
 #include "mfx_trace.h"
@@ -173,5 +174,15 @@ inline mfxStatus CheckAndDestroyVAbuffer(VADisplay display, VABufferID & buffer_
     return MFX_ERR_NONE;
 }
 #endif
+
+static inline bool operator==(mfxPluginUID const& l, mfxPluginUID const& r)
+{
+    return std::equal(l.Data, l.Data + 16, r.Data);
+}
+
+static inline bool operator!=(mfxPluginUID const& l, mfxPluginUID const& r)
+{
+    return !(l == r);
+}
 
 #endif // __MFXUTILS_H__

--- a/_studio/vp9e_hw/vp9/include/mfx_vp9_encode_plugin_hw.h
+++ b/_studio/vp9e_hw/vp9/include/mfx_vp9_encode_plugin_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ public:
         {
             return MFX_ERR_NULL_PTR;
         }
-        if (memcmp(&guid, &MFX_PLUGINID_VP9E_HW, sizeof(mfxPluginUID)))
+        if (guid != MFX_PLUGINID_VP9E_HW)
         {
             return MFX_ERR_NOT_FOUND;
         }


### PR DESCRIPTION
Avoid usage of low-level memory comparison in favor of operator ==