### PR TITLE
[h264e] Fix wrong initialCpbRemovalDelay rounding

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
@@ -2031,7 +2031,7 @@ mfxU32 Hrd::GetInitCpbRemovalDelay() const
         return 0;
 
     double delay = MFX_MAX(0.0, m_trn_cur - m_taf_prv);
-    mfxU32 initialCpbRemovalDelay = mfxU32(90000 * delay + 0.5);
+    mfxU32 initialCpbRemovalDelay = mfxU32(90000 * delay);
 
     return initialCpbRemovalDelay == 0
         ? 1 // should not be equal to 0


### PR DESCRIPTION
Wrong rounding may cause HDR overflow in some streams