### PR TITLE
[hevce] Use MFX_TASK_THREADING_INTRA

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
@@ -1,15 +1,15 @@
 // Copyright (c) 2017-2019 Intel Corporation
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -78,6 +78,11 @@ public:
     virtual mfxStatus GetEncodeStat(mfxEncodeStat * /*stat*/)
     {
         return MFX_ERR_UNSUPPORTED;
+    }
+
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void)
+    {
+        return MFX_TASK_THREADING_INTRA;
     }
 
     virtual mfxStatus EncodeFrameCheck(mfxEncodeCtrl * /*ctrl*/, mfxFrameSurface1 * /*surface*/, mfxBitstream * /*bs*/, mfxFrameSurface1 ** /*reordered_surface*/, mfxEncodeInternalParams * /*pInternalParams*/)


### PR DESCRIPTION
"DEDICATED" reduces density for multisession workloads in join mode.

MDP-57311

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>