### PR TITLE
fix complie issue when va version is less than 1.2 and reduce CPU load of sample_decode

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -955,7 +955,7 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     m_caps.ddi_caps.BitDepth8Only = (attrs[idx_map[VAConfigAttribRTFormat]].value &
         (VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV420_12)) ? 0 : 1;
 #else
-    m_caps.BitDepth8Only = 1;
+    m_caps.ddi_caps.BitDepth8Only = 1;
 #endif
     m_caps.ddi_caps.YUV422ReconSupport = attrs[idx_map[VAConfigAttribRTFormat]].value & VA_RT_FORMAT_YUV422 ? 1 : 0;
     m_caps.ddi_caps.YUV444ReconSupport = attrs[idx_map[VAConfigAttribRTFormat]].value & VA_RT_FORMAT_YUV444 ? 1 : 0;

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -1525,9 +1525,12 @@ mfxStatus CDecodingPipeline::DeliverOutput(mfxFrameSurface1* frame)
             res = m_hwdev->RenderFrame(frame, m_pGeneralAllocator);
 #endif
 
-            while( m_delayTicks && (m_startTick + m_delayTicks > msdk_time_get_tick()) )
+            msdk_tick current_tick = msdk_time_get_tick();
+            while( m_delayTicks && (m_startTick + m_delayTicks > current_tick) )
             {
-                MSDK_SLEEP(0);
+                msdk_tick left_tick = m_startTick + m_delayTicks - current_tick;
+                MSDK_SLEEP( (left_tick *1000) / msdk_time_get_frequency());
+                current_tick = msdk_time_get_tick();
             };
             m_startTick=msdk_time_get_tick();
         }


### PR DESCRIPTION
structure ENCODE_CAPS_HEVC has been refactored, but the related codes on path where VA version < 1.2 were not changed.
Signed-off-by: Zhongmin Wu <zhongmin.wu@intel.com>