### PR TITLE
[HEVCd] Skip frames after new SPS without any subsequent slice

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1689,7 +1689,7 @@ UMC::Status TaskSupplier_H265::AddOneFrame(UMC::MediaData * pSource)
     }
 
     if (m_checkCRAInsideResetProcess && !pSource)
-        return UMC::UMC_ERR_FAILED;
+        return UMC::UMC_ERR_NOT_ENOUGH_DATA;
 
     size_t moveToSpsOffset = m_checkCRAInsideResetProcess ? pSource->GetDataSize() : 0;
 


### PR DESCRIPTION
Decoder sets m_checkCRAInsideResetProcess flag when finds (which differs
from previous one) or invalid SPS. Before this change decoder didn't complete
decoding process and returned MFX_ERR_UNDEFINED_BEHAVIOR if couldn't find
any subsequent slice. Now it completes process skipping frames after
(invalid) SPS.