### PR TITLE
[VP9e] Add one more surface for correct work in async mode

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_utils.h
@@ -641,7 +641,7 @@ constexpr auto NUM_OF_SUPPORTED_EXT_BUFFERS = 7; // mfxExtVP9Param, mfxExtOpaque
     {
         // number of input surfaces is same for VIDEO and SYSTEM memory
         // because so far encoder doesn't support LookAhead and B-frames
-        return video.AsyncDepth;
+        return video.AsyncDepth + ((video.AsyncDepth > 1)? 1: 0);
     }
 
     class Task


### PR DESCRIPTION
Need extra surface for prevent situation, when we have free tasks, but
we cannot assign new one, because all surfaces are busy. For example:
mode "-async 3". On init sample_encode sets max surface count for tasks.
When encoding run we request for free surface. If surfaces run out, than
we start waiting for free surface (~10 ms) and only after that we do
SyncOperation. In hevc in "-async 3" mode we must alloc 3 surfaces, but
also we add one more extra surface, in order to get around above
situation. So, we do SyncOperation, free surface and can use it again
(in this way we have only 3 tasks in queue and do not break anything).
But in vp9 we dont alloc extra surface, and on each iteration we need
to wait, in this cause we get low FPS.

Issue: MDP-57848