### PR TITLE
[sample_decode] Fix access violation

### DIFF
--- a/samples/sample_common/src/mfx_buffering.cpp
+++ b/samples/sample_common/src/mfx_buffering.cpp
@@ -124,6 +124,8 @@ CBuffering::FreeBuffers()
     m_UsedSurfacesPool.m_pSurfacesTail = NULL;
     m_UsedVppSurfacesPool.m_pSurfacesHead = NULL;
     m_UsedVppSurfacesPool.m_pSurfacesTail = NULL;
+    m_OutputSurfacesPool.m_pSurfacesHead = NULL;
+    m_OutputSurfacesPool.m_pSurfacesTail = NULL;
 
     m_FreeSurfacesPool.m_pSurfaces = NULL;
     m_FreeVppSurfacesPool.m_pSurfaces = NULL;


### PR DESCRIPTION
FreeList() is not setting Tail pointer of m_OutputSurfacesPool to null.
This lead Tail pointer contains some invalid value after Reset().
Dereferencing of such pointer causes access violation.
To prevent this, for similar structures, there is a force NULL equating.
This changes is adding same equating for
m_OutputSurfacesPool Head and Tail pointers.

Issue: MDP-56738