### PR TITLE
[ASG-HEVC] Fix to build if not the latest mfx_version is used

### DIFF
--- a/tools/asg-hevc/include/test_processor.h
+++ b/tools/asg-hevc/include/test_processor.h
@@ -22,13 +22,13 @@
 #define __ASG_HEVC_TEST_PROCESSOR_H__
 
 #include "mfxvideo.h"
+#include "sample_defs.h"
 
 #if MFX_VERSION >= MFX_VERSION_NEXT
 
 #include <fstream>
 
 #include "sample_utils.h"
-#include "sample_defs.h"
 #include "base_allocator.h"
 
 #include "inputparameters.h"


### PR DESCRIPTION
Move inclusion test_processor.h above MFX_VERSION check to define global
identifiers in any case regardless of version. In other case project may not
compile.