### PR TITLE
build: fix gcc-9 -Wclass-memaccess warning in sample_decode

### DIFF
--- a/samples/sample_decode/include/pipeline_decode.h
+++ b/samples/sample_decode/include/pipeline_decode.h
@@ -127,10 +127,6 @@ struct sInputParams
     msdk_char     strDstFile[MSDK_MAX_FILENAME_LEN];
     sPluginParams pluginParams;
 
-    sInputParams()
-    {
-        MSDK_ZERO_MEMORY(*this);
-    }
 };
 
 template<>struct mfx_ext_buffer_id<mfxExtMVCSeqDesc>{

--- a/samples/sample_decode/src/sample_decode.cpp
+++ b/samples/sample_decode/src/sample_decode.cpp
@@ -681,7 +681,7 @@ int _tmain(int argc, TCHAR *argv[])
 int main(int argc, char *argv[])
 #endif
 {
-    sInputParams        Params;   // input parameters from command line
+    sInputParams        Params = {};   // input parameters from command line
     CDecodingPipeline   Pipeline; // pipeline for decoding, includes input file reader, decoder and output file writer
 
     mfxStatus sts = MFX_ERR_NONE; // return value check


### PR DESCRIPTION
Use initializer list on defenition instead of memset in constructor for POD struct.

Fixes #1547 