### PR TITLE
[HEVCE] update tiles independence from hw pipes

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -182,8 +182,6 @@ mfxStatus CheckHeaders(
         || (!caps.ddi_caps.YUV422ReconSupport && (par.m_sps.chroma_format_idc == 2))
         || (caps.ddi_caps.Color420Only && (par.m_sps.chroma_format_idc != 1))));
 
-    MFX_CHECK_COND(caps.ddi_caps.NumScalablePipesMinus1 == 0 || par.m_pps.num_tile_columns_minus1 <= caps.ddi_caps.NumScalablePipesMinus1);
-
     if (par.m_pps.tiles_enabled_flag)
     {
         MFX_CHECK_COND(par.m_pps.loop_filter_across_tiles_enabled_flag);

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1856,8 +1856,9 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
         mfxU32 minTileHeight = MIN_TILE_SIZE_HEIGHT;
 
         // min 2x2 lcu is supported on VDEnc
+        // TODO: replace indirect NumScalablePipesMinus1 by platform
         if (caps.ddi_caps.NumScalablePipesMinus1 > 0 && IsOn(par.mfx.LowPower))
-            minTileHeight *= 2;
+            minTileHeight = 128;
 
         mfxU16 nCol = (mfxU16)CeilDiv(par.m_ext.HEVCParam.PicWidthInLumaSamples, minTileWidth);
         mfxU16 nRow = (mfxU16)CeilDiv(par.m_ext.HEVCParam.PicHeightInLumaSamples, minTileHeight);
@@ -1865,11 +1866,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
         changed += CheckMax(par.m_ext.HEVCTiles.NumTileColumns, nCol);
         changed += CheckMax(par.m_ext.HEVCTiles.NumTileRows, nRow);
 
-        if (caps.ddi_caps.NumScalablePipesMinus1 > 0) {
-            MaxTileColumns = (mfxU16)caps.ddi_caps.NumScalablePipesMinus1 + 1;
-            changed += CheckMax(par.m_ext.HEVCTiles.NumTileColumns, MaxTileColumns);
-        }
-        else if ((par.m_platform == MFX_HW_ICL || par.m_platform == MFX_HW_ICL_LP) && IsOn(par.mfx.LowPower) && par.m_ext.HEVCTiles.NumTileColumns > 1 && par.m_ext.HEVCTiles.NumTileRows > 1) {
+        if ((par.m_platform == MFX_HW_ICL || par.m_platform == MFX_HW_ICL_LP) && IsOn(par.mfx.LowPower) && par.m_ext.HEVCTiles.NumTileColumns > 1 && par.m_ext.HEVCTiles.NumTileRows > 1) {
             // for ICL VDEnc only 1xN or Nx1 configurations are allowed for single pipe
             // we ignore "Rows" condition
             changed += CheckMax(par.m_ext.HEVCTiles.NumTileRows, 1);


### PR DESCRIPTION
Updated info that driver chooses NumOfScalablePipes
depending on configuration and there are no restrictions
to tile configuration from possible scalable pipes.
MDP-58316