### PR TITLE
set h264 encode default fps to 30

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -2991,15 +2991,16 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         }
     }
 
+    // if input frame rate is unreasonable, fix it to a feasible value (30.0)
     if ((par.mfx.FrameInfo.FrameRateExtN == 0) !=
         (par.mfx.FrameInfo.FrameRateExtD == 0))
     {
         if (extBits->SPSBuffer && !IsOff(extOpt3->TimingInfoPresent))
             return Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
 
-        unsupported = true;
-        par.mfx.FrameInfo.FrameRateExtN = 0;
-        par.mfx.FrameInfo.FrameRateExtD = 0;
+        changed = true;
+        par.mfx.FrameInfo.FrameRateExtN = 30;
+        par.mfx.FrameInfo.FrameRateExtD = 1;
     }
 
     if (!IsOff(extOpt3->TimingInfoPresent) &&


### PR DESCRIPTION
if input frame rate is unreasonable, fix it to a feasible value (30).

Signed-off-by: Fuwei Tang <fuweix.tang@intel.com>