### PR TITLE
Allow a larger surface for mpeg2/jpeg encoding

### DIFF
--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1031,8 +1031,8 @@ mfxStatus MFXVideoENCODEMJPEG_HW::CheckEncodeFrameParam(
             MFX_CHECK(surface->Data.Y != 0 || isExternalFrameAllocator, MFX_ERR_UNDEFINED_BEHAVIOR);
         }
 
-        if (surface->Info.Width != m_vParam.mfx.FrameInfo.Width || surface->Info.Height != m_vParam.mfx.FrameInfo.Height)
-            sts = MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+        MFX_CHECK(surface->Info.Width >= m_vParam.mfx.FrameInfo.Width, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(surface->Info.Height >= m_vParam.mfx.FrameInfo.Height, MFX_ERR_INVALID_VIDEO_PARAM);
     }
     else
     {

--- a/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
@@ -1675,8 +1675,9 @@ namespace MPEG2EncoderHW
             {
                 return MFX_ERR_UNDEFINED_BEHAVIOR;
             }
-            bWarning = bWarning || (!m_InputSurfaces.CheckInputFrame(&surface->Info));
 
+            MFX_CHECK(surface->Info.Width >= m_VideoParamsEx.mfxVideoParams.mfx.FrameInfo.Width, MFX_ERR_INVALID_VIDEO_PARAM);
+            MFX_CHECK(surface->Info.Height >= m_VideoParamsEx.mfxVideoParams.mfx.FrameInfo.Height, MFX_ERR_INVALID_VIDEO_PARAM);
             MFX_CHECK(surface->Info.FourCC == MFX_FOURCC_NV12, MFX_ERR_UNDEFINED_BEHAVIOR);
 
             if (surface->Data.Y)

--- a/_studio/mfx_lib/shared/include/mfx_enc_common.h
+++ b/_studio/mfx_lib/shared/include/mfx_enc_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -62,10 +62,6 @@ public:
 
      inline bool isOpaq() {return  m_bOpaq;}
      inline bool isSysMemFrames () {return m_bSysMemFrames;}
-     inline bool CheckInputFrame(mfxFrameInfo* pFrameInfo)
-     {
-         return (m_Info.Width == pFrameInfo->Width && m_Info.Height == pFrameInfo->Height);     
-     }
 
      inline mfxFrameSurface1 *GetOriginalSurface(mfxFrameSurface1 *surface)
      {


### PR DESCRIPTION
Like other CODECs, we may allow a larger surface for mpeg2/jpeg
encoding. If do so, we may use the same way to allocate surfaces for all
CODECs in user application / library.