### PR TITLE
[h265d] match profile according to fourcc if it's unknown

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -984,6 +984,11 @@ bool CheckVideoParam_H265(mfxVideoParam *in, eMFXHWType type)
     if ((in->mfx.FrameInfo.AspectRatioW || in->mfx.FrameInfo.AspectRatioH) && !(in->mfx.FrameInfo.AspectRatioW && in->mfx.FrameInfo.AspectRatioH))
         return false;
 
+    if (in->mfx.CodecProfile == MFX_PROFILE_UNKNOWN)
+    {
+        in->mfx.CodecProfile = MatchProfile(in->mfx.FrameInfo.FourCC);
+    }
+
     if (in->mfx.CodecProfile != MFX_PROFILE_HEVC_MAIN &&
         in->mfx.CodecProfile != MFX_PROFILE_HEVC_MAIN10 &&
         in->mfx.CodecProfile != MFX_PROFILE_HEVC_MAINSP &&


### PR DESCRIPTION
Match profile if it's unkown like CheckGUID() does.

Fix #1576.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>