### PR TITLE
Fix of HEVC encoded picture width/height update

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -653,10 +653,15 @@ namespace ExtBuffer
 
             return false;
         }
-        if (buf.PicWidthInLumaSamples == 0)
-            buf.PicWidthInLumaSamples  = align2_value(par.mfx.FrameInfo.CropW > 0 ? (mfxU16)(par.mfx.FrameInfo.CropW + par.mfx.FrameInfo.CropX)  : par.mfx.FrameInfo.Width,  codedPicAlignment);
 
-        if (buf.PicHeightInLumaSamples == 0)
+        bool needUpdate = false;
+        if (buf.PicWidthInLumaSamples > par.mfx.FrameInfo.Width || buf.PicHeightInLumaSamples > par.mfx.FrameInfo.Height)
+            needUpdate = true;
+
+        if (buf.PicWidthInLumaSamples == 0 || needUpdate)
+            buf.PicWidthInLumaSamples = align2_value(par.mfx.FrameInfo.CropW > 0 ? (mfxU16)(par.mfx.FrameInfo.CropW + par.mfx.FrameInfo.CropX)  : par.mfx.FrameInfo.Width,  codedPicAlignment);
+
+        if (buf.PicHeightInLumaSamples == 0 || needUpdate)
             buf.PicHeightInLumaSamples = align2_value(par.mfx.FrameInfo.CropH > 0 ? (mfxU16)(par.mfx.FrameInfo.CropH + par.mfx.FrameInfo.CropY)  : par.mfx.FrameInfo.Height, codedPicAlignment);
 
         return true;


### PR DESCRIPTION
In case of joint use of HEVC SAO and VPP rotate, parameters PicWidthInLumaSamples
and PicHeightInLumaSamples are not updated for the changed resolution, so we
get MFX_ERR_INVALID_VIDEO_PARAM. Patch fixes this.