### PR TITLE
Weston 10 bit support

### DIFF
--- a/samples/sample_common/src/vaapi_device.cpp
+++ b/samples/sample_common/src/vaapi_device.cpp
@@ -353,7 +353,7 @@ mfxStatus CVAAPIDeviceWayland::Init(mfxHDL hWindow, mfxU16 nViews, mfxU32 nAdapt
 
 mfxStatus CVAAPIDeviceWayland::RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocator * /*pmfxAlloc*/)
 {
-    uint32_t drm_format = 0;
+    uint32_t drm_format = pSurface->Info.FourCC;
     int offsets[3], pitches[3];
     mfxStatus mfx_res = MFX_ERR_NONE;
     vaapiMemId * memId = NULL;


### PR DESCRIPTION
Add P010 support for weston rendering. 
Having issue with decode and render H265-10 bit in weston. this fix solve the issue. 

Signed-off-by: Kasireddy, Vivek <vivek.kasireddy@intel.com>