### PR TITLE
samples: do not abuse public API to reach Wayland device

### DIFF
--- a/samples/sample_common/include/vaapi_device.h
+++ b/samples/sample_common/include/vaapi_device.h
@@ -130,8 +130,6 @@ private:
 
 class Wayland;
 
-#define HANDLE_WAYLAND_DRIVER   (MFX_HANDLE_VA_DISPLAY << 4)
-
 class CVAAPIDeviceWayland : public CHWDevice
 {
 public:
@@ -155,11 +153,9 @@ public:
         if((MFX_HANDLE_VA_DISPLAY == type) && (NULL != pHdl)) {
             *pHdl = m_DRMLibVA.GetVADisplay();
             return MFX_ERR_NONE;
-        } else if((HANDLE_WAYLAND_DRIVER  == type) && (NULL != m_Wayland)) {
-            *pHdl = m_Wayland;
-            return MFX_ERR_NONE;
-    }
-    return MFX_ERR_UNSUPPORTED;
+        }
+
+        return MFX_ERR_UNSUPPORTED;
     }
     virtual mfxStatus RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocator * pmfxAlloc);
     virtual void UpdateTitle(double fps) { }
@@ -169,6 +165,10 @@ public:
         m_isMondelloInputEnabled = isMondelloInputEnabled;
     }
 
+    Wayland * GetWaylandHandle()
+    {
+        return m_Wayland;
+    }
 protected:
     DRMLibVA m_DRMLibVA;
     MfxLoader::VA_WaylandClientProxy  m_WaylandClient;

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -950,13 +950,19 @@ mfxStatus CDecodingPipeline::CreateHWDevice()
     MSDK_CHECK_STATUS(sts, "m_hwdev->Init failed");
 
 #if defined(LIBVA_WAYLAND_SUPPORT)
-    if (m_eWorkMode == MODE_RENDERING && m_libvaBackend == MFX_LIBVA_WAYLAND) {
-        mfxHDL hdl = NULL;
-        mfxHandleType hdlw_t = (mfxHandleType)HANDLE_WAYLAND_DRIVER;
-        Wayland *wld;
-        sts = m_hwdev->GetHandle(hdlw_t, &hdl);
-        MSDK_CHECK_STATUS(sts, "m_hwdev->GetHandle failed");
-        wld = (Wayland*)hdl;
+    if (m_eWorkMode == MODE_RENDERING && m_libvaBackend == MFX_LIBVA_WAYLAND)
+    {
+        CVAAPIDeviceWayland* w_dev = dynamic_cast<CVAAPIDeviceWayland*>(m_hwdev);
+        if (!w_dev)
+        {
+            MSDK_CHECK_STATUS(MFX_ERR_DEVICE_FAILED, "Failed to reach Wayland VAAPI device");
+        }
+        Wayland *wld = w_dev->GetWaylandHandle();
+        if (!wld)
+        {
+            MSDK_CHECK_STATUS(MFX_ERR_DEVICE_FAILED, "Failed to reach Wayland VAAPI device");
+        }
+
         wld->SetRenderWinPos(m_nRenderWinX, m_nRenderWinY);
         wld->SetPerfMode(m_bPerfMode);
     }

--- a/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
+++ b/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
@@ -181,12 +181,17 @@ mfxStatus Launcher::Init(int argc, msdk_char *argv[])
                 MSDK_CHECK_STATUS(sts, "m_hwdev->GetHandle failed");
                 hdl = pVAAPIParams->m_dpy =(VADisplay)va_dpy;
 
-                mfxHDL whdl = NULL;
-                mfxHandleType hdlw_t = (mfxHandleType)HANDLE_WAYLAND_DRIVER;
-                Wayland *wld;
-                sts = m_hwdev->GetHandle(hdlw_t, &whdl);
-                MSDK_CHECK_STATUS(sts, "m_hwdev->GetHandle failed");
-                wld = (Wayland*)whdl;
+                CVAAPIDeviceWayland* w_dev = dynamic_cast<CVAAPIDeviceWayland*>(m_hwdev.get());
+                if (!w_dev)
+                {
+                    MSDK_CHECK_STATUS(MFX_ERR_DEVICE_FAILED, "Failed to reach Wayland VAAPI device");
+                }
+                Wayland *wld = w_dev->GetWaylandHandle();
+                if (!wld)
+                {
+                    MSDK_CHECK_STATUS(MFX_ERR_DEVICE_FAILED, "Failed to reach Wayland VAAPI device");
+                }
+
                 wld->SetRenderWinPos(params.nRenderWinX, params.nRenderWinY);
                 wld->SetPerfMode(params.bPerfMode);
 


### PR DESCRIPTION
Remove custom defined ```mfxHandleType``` for Wayland support: ```HANDLE_WAYLAND_DRIVER```

Use direct API instead