### PR TITLE
fix for rendering with drm

### DIFF
--- a/samples/sample_decode/src/sample_decode.cpp
+++ b/samples/sample_decode/src/sample_decode.cpp
@@ -258,7 +258,6 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
         {
             pParams->memType = D3D9_MEMORY;
             pParams->mode = MODE_RENDERING;
-            pParams->libvaBackend = MFX_LIBVA_DRM_MODESET;
             if (strInput[i][5]) {
                 if (strInput[i][5] != '-') {
                     PrintHelp(strInput[0], MSDK_STRING("unsupported monitor type"));

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -1781,7 +1781,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
 #if defined(LIBVA_DRM_SUPPORT)
         else if (0 == msdk_strncmp(argv[i], MSDK_STRING("-rdrm"), 5))
         {
-            InputParams.libvaBackend = MFX_LIBVA_DRM_MODESET;
             InputParams.monitorType = getMonitorType(&argv[i][5]);
             if (argv[i][5]) {
                 if (argv[i][5] != '-') {


### PR DESCRIPTION
Observing problem while using rdrm with both Sample_Decode and sample_multi_transcode applications. when rdrm is used, it is intenally invoking card0 as a GPU render node which is creating a problem when memory allocation. 