### PR TITLE
[HEVCe] Fix max slices number

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
@@ -163,7 +163,7 @@ constexpr mfxU8    IDX_INVALID           = 0xff;
 constexpr mfxU8    HW_SURF_ALIGN_W       = 16;
 constexpr mfxU8    HW_SURF_ALIGN_H       = 16;
 
-constexpr mfxU8    MAX_SLICES            = 200; // WA for driver issue regarding CNL and older platforms
+constexpr mfxU16   MAX_SLICES            = 600; // conforms to level 6 limits
 constexpr mfxU8    DEFAULT_LTR_INTERVAL  = 16;
 constexpr mfxU8    DEFAULT_PPYR_INTERVAL = 3;
 

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -623,6 +623,8 @@ mfxU16 MakeSlices(MfxVideoParam& par, mfxU32 SliceStructure)
         par.m_slice[i].SegmentAddress = TsToRs[par.m_slice[i].SegmentAddress];
     }
 
+    assert(par.m_slice.size() <= MAX_SLICES);
+
     return (mfxU16)par.m_slice.size();
 }
 


### PR DESCRIPTION
1)Fix MAX_SLICES value according to codec level 6
  (ITU-T H-265 02/2018, Table A.6)
2)Add assert check for slices number