### PR TITLE
clang-8: warning: hidden overloaded  virtual function

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -3430,7 +3430,7 @@ mfxStatus CTranscodingPipeline::CalculateNumberOfReqFrames(mfxFrameAllocRequest 
         MSDK_ZERO_MEMORY(VppRequest);
         if (m_bIsPlugin && m_bIsVpp)
         {
-            sts = m_pmfxVPP.get()->QueryIOSurf(&m_mfxPluginParams, &(VppRequest[0]), &m_mfxVppParams);
+            sts = m_pmfxVPP.get()->QueryIOSurfMulti(&m_mfxPluginParams, &(VppRequest[0]), &m_mfxVppParams);
             if (!CheckAsyncDepth(VppRequest[0], m_mfxPluginParams.AsyncDepth) ||
                 !CheckAsyncDepth(VppRequest[1], m_mfxPluginParams.AsyncDepth) ||
                 !CheckAsyncDepth(VppRequest[0], m_mfxVppParams.AsyncDepth) ||
@@ -3919,7 +3919,7 @@ mfxStatus CTranscodingPipeline::Init(sInputParams *pParams,
     if (m_pmfxVPP.get())
     {
         if (m_bIsPlugin && m_bIsVpp)
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);
         else
@@ -4030,7 +4030,7 @@ mfxStatus CTranscodingPipeline::CompleteInit()
     if (m_pmfxVPP.get())
     {
         if (m_bIsPlugin && m_bIsVpp)
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);
         else
@@ -4462,10 +4462,10 @@ mfxStatus CTranscodingPipeline::Reset()
         if (m_bIsPlugin && m_bIsVpp)
         {
             mfxFrameAllocRequest request[2] = { };
-            sts = m_pmfxVPP->QueryIOSurf(&m_mfxPluginParams, request, &m_mfxVppParams);
+            sts = m_pmfxVPP->QueryIOSurfMulti(&m_mfxPluginParams, request, &m_mfxVppParams);
             MSDK_CHECK_STATUS(sts, "m_pmfxVPP->QueryIOSurf failed");
 
-            sts = m_pmfxVPP->Init(&m_mfxPluginParams, &m_mfxVppParams);
+            sts = m_pmfxVPP->InitMulti(&m_mfxPluginParams, &m_mfxVppParams);
         }
         else if (m_bIsPlugin)
             sts = m_pmfxVPP->Init(&m_mfxPluginParams);

--- a/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h
@@ -32,6 +32,7 @@ public:
     virtual ~MFXVideoMultiVPP(void) { Close(); }
 
     // topology methods
+<<<<<<< HEAD
     virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { par1; par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
 
@@ -40,24 +41,42 @@ public:
 
     virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
     { par1; par2; return MFXVideoVPP_Reset(m_session, par); }
+=======
 
-    virtual mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp)
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) override { return QueryIOSurfMulti(par, request); }
+    virtual mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    { (void)par1; (void)par2; return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
+
+    virtual mfxStatus Init(mfxVideoParam *par) override { return InitMulti(par); } 
+    virtual mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    { (void)par1; (void)par2; return MFXVideoVPP_Init(m_session, par); }
+
+    virtual mfxStatus Reset(mfxVideoParam *par) override { return ResetMulti(par); }
+    virtual mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL)
+    { (void)par1; (void)par2; return MFXVideoVPP_Reset(m_session, par); }
+>>>>>>> d7e40258... Added prefixes to old methods and creating new ones with old names that contain the right amount of parametrs
+
+    virtual mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override
     { return MFXVideoVPP_RunFrameVPPAsync(m_session, in, out, aux, syncp); }
 
     virtual mfxStatus SyncOperation(mfxSyncPoint syncp, mfxU32 wait)
     {  return MFXVideoCORE_SyncOperation(m_session, syncp, wait);}
 
-    virtual mfxStatus Close(void) { return MFXVideoVPP_Close(m_session); }
+    virtual mfxStatus Close(void) override { return MFXVideoVPP_Close(m_session); }
 
     // per-component methods
-    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_Query(m_session, in, out); }
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) override { return QueryMulti(in, out); }
+    virtual mfxStatus QueryMulti(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_Query(m_session, in, out); }
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_GetVideoParam(m_session, par); }
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override { return GetVideoParamMulti(par); }
+    virtual mfxStatus GetVideoParamMulti(mfxVideoParam *par, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_GetVideoParam(m_session, par); }
 
-    virtual mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx = 0)
-    { component_idx; return MFXVideoVPP_GetVPPStat(m_session, stat); }
+    virtual mfxStatus GetVPPStat(mfxVPPStat *stat) override { return GetVPPStatMulti(stat); }
+    virtual mfxStatus GetVPPStatMulti(mfxVPPStat *stat, mfxU8 component_idx = 0)
+    { (void)component_idx; return MFXVideoVPP_GetVPPStat(m_session, stat); }
 };
+
 
 #endif//__MFX_MULTI_VPP_H

--- a/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
+++ b/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h
@@ -52,17 +52,23 @@ public:
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported
     // QueryIOSurf must be called prior to Init to create topology
-    mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
+    mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) override;
+    mfxStatus QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
 
     // par1 != null enables first VPP (before Plugin), par2 != null enables second VPP (after Plugin); pipeline Plugin-VPP is not unsupported; topology must be the same as in QueryIOSurf
-    mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
-    mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp);
-    mfxStatus Reset(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL);
-    mfxStatus Close(void);
+    mfxStatus Init(mfxVideoParam *par) override;
+    mfxStatus InitMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) override;
+    mfxStatus Reset(mfxVideoParam *par) override;
+    mfxStatus ResetMulti(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVideoParam *par2 = NULL) override;
+    mfxStatus Close(void) override;
 
-    mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0);
-    mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 component_idx = 0);
-    mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx = 0);
+    mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) override;
+    mfxStatus QueryMulti(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx = 0) override;
+    mfxStatus GetVideoParam(mfxVideoParam *par) override;
+    mfxStatus GetVideoParamMulti(mfxVideoParam *par, mfxU8 component_idx = 0) override;
+    mfxStatus GetVPPStat(mfxVPPStat *stat) override;
+    mfxStatus GetVPPStatMulti(mfxVPPStat *stat, mfxU8 component_idx = 0) override;
 
 protected:
     mfxFrameAllocator   m_FrameAllocator;

--- a/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
+++ b/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp
@@ -93,19 +93,22 @@ MFXVideoVPPPlugin::~MFXVideoVPPPlugin(void)
 }
 
 // per-component methods currently not implemented, you can add your own implementation if needed
-mfxStatus MFXVideoVPPPlugin::Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::Query(mfxVideoParam *in, mfxVideoParam *out) { return QueryMulti(in, out); }
+mfxStatus MFXVideoVPPPlugin::QueryMulti(mfxVideoParam *in, mfxVideoParam *out, mfxU8 component_idx)
 {
     in;out;component_idx;
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVideoParam(mfxVideoParam *par, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::GetVideoParam(mfxVideoParam *par) { return GetVideoParamMulti(par); }
+mfxStatus MFXVideoVPPPlugin::GetVideoParamMulti(mfxVideoParam *par, mfxU8 component_idx)
 {
     par;component_idx;
     return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus MFXVideoVPPPlugin::GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx)
+mfxStatus MFXVideoVPPPlugin::GetVPPStat(mfxVPPStat *stat) { return GetVPPStatMulti(stat); }
+mfxStatus MFXVideoVPPPlugin::GetVPPStatMulti(mfxVPPStat *stat, mfxU8 component_idx)
 {
     stat;component_idx;
     return MFX_ERR_UNSUPPORTED;
@@ -274,7 +277,8 @@ mfxStatus MFXVideoVPPPlugin::AllocateFrames(mfxVideoParam *par, mfxVideoParam *p
     return sts;
 }
 
-mfxStatus MFXVideoVPPPlugin::QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) { return QueryIOSurfMulti(par, request); }
+mfxStatus MFXVideoVPPPlugin::QueryIOSurfMulti(mfxVideoParam *par, mfxFrameAllocRequest request[2], mfxVideoParam *par1, mfxVideoParam *par2)
 {
     MSDK_CHECK_POINTER(par, MFX_ERR_NULL_PTR);
 
@@ -372,7 +376,8 @@ mfxStatus MFXVideoVPPPlugin::QueryIOSurf(mfxVideoParam *par, mfxFrameAllocReques
     return MFX_ERR_NONE;
 }
 
-mfxStatus MFXVideoVPPPlugin::Init(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::Init(mfxVideoParam *par) { return InitMulti(par); } 
+mfxStatus MFXVideoVPPPlugin::InitMulti(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
 {
     mfxStatus sts = MFX_ERR_NONE;
 
@@ -425,7 +430,8 @@ mfxStatus MFXVideoVPPPlugin::Init(mfxVideoParam *par, mfxVideoParam *par1, mfxVi
     return MFX_ERR_NONE;
 }
 
-mfxStatus MFXVideoVPPPlugin::Reset(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
+mfxStatus MFXVideoVPPPlugin::Reset(mfxVideoParam *par) { return ResetMulti(par); }
+mfxStatus MFXVideoVPPPlugin::ResetMulti(mfxVideoParam *par, mfxVideoParam *par1, mfxVideoParam *par2)
 {
     par;par1;par2;
     return MFX_ERR_UNSUPPORTED;


### PR DESCRIPTION
Building on clang-8 gives warnings:
```
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:35:23: error: 
 'MFXVideoMultiVPP::QueryIOSurf' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest reques...
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:129:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::QueryIOSurf' declared here: different number of
 parameters (2 vs 4)
 virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest reques...
 ^
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp:24:
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h:25:
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:38:23: error: 
 'MFXVideoMultiVPP::Init' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus Init(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVid...
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:130:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::Init' declared here: different number of parameters
 (1 vs 3)
 virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoVPP_Init(m_sessio...
 ^
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp:24:
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h:25:
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:41:23: error: 
 'MFXVideoMultiVPP::Reset' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus Reset(mfxVideoParam *par, mfxVideoParam *par1 = NULL, mfxVi...
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:131:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::Reset' declared here: different number of parameters
 (1 vs 3)
 virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoVPP_Reset(m_sess...
 ^
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp:24:
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h:25:
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:53:23: error: 
 'MFXVideoMultiVPP::Query' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out, mfxU8 componen...
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:128:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::Query' declared here: different number of parameters
 (2 vs 3)
 virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVi...
 ^
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp:24:
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h:25:
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:56:23: error: 
 'MFXVideoMultiVPP::GetVideoParam' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus GetVideoParam(mfxVideoParam *par, mfxU8 component_idx = 0)
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:134:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::GetVideoParam' declared here: different number of
 parameters (1 vs 2)
 virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoVPP_GetV...
 ^
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/src/mfx_vpp_plugin.cpp:24:
In file included from /home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_vpp_plugin.h:25:
/home/a/MSDKOpenSource/MediaSDK/samples/sample_plugins/vpp_plugin/include/mfx_multi_vpp.h:59:23: error: 
 'MFXVideoMultiVPP::GetVPPStat' hides overloaded virtual function
 [-Werror,-Woverloaded-virtual]
 virtual mfxStatus GetVPPStat(mfxVPPStat *stat, mfxU8 component_idx = 0)
 ^
/home/a/MSDKOpenSource/MediaSDK/api/include/mfxvideo++.h:135:23: note: hidden overloaded
 virtual function 'MFXVideoVPP::GetVPPStat' declared here: different number of
 parameters (1 vs 2)
 virtual mfxStatus GetVPPStat(mfxVPPStat *stat) { return MFXVideoVPP_GetVPPSta...
 ^
```
The child class contains overloaded methods with an extended number of parameters than the parent. 
I added to child class methods prefixes and creating new ones with old names that contain the right amount of parameters.
A similar solution was suggested there: #555