### PR TITLE
AVCd: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -57,7 +57,7 @@ mfxU32 CalculateNumThread(eMFXPlatform platform, mfxVideoParam *par)
     if (!par->AsyncDepth)
         return numThread;
 
-    return MFX_MIN(par->AsyncDepth, numThread);
+    return std::min<mfxU32>(par->AsyncDepth, numThread);
 }
 
 inline bool IsNeedToUseHWBuffering(eMFXHWType /*type*/)
@@ -435,8 +435,8 @@ mfxStatus VideoDECODEH264::Init(mfxVideoParam *par)
 
     UMC::H264VideoDecoderParams umcVideoParams;
     ConvertMFXParamsToUMC(&m_vFirstPar, &umcVideoParams);
-    umcVideoParams.numThreads = m_vPar.mfx.NumThread;
-    umcVideoParams.m_bufferedFrames = MFX_MAX(asyncDepth - umcVideoParams.numThreads, 0);
+    umcVideoParams.numThreads       = m_vPar.mfx.NumThread;
+    umcVideoParams.m_bufferedFrames = asyncDepth - umcVideoParams.numThreads;
 
     if (MFX_PLATFORM_SOFTWARE != m_platform)
     {
@@ -957,7 +957,7 @@ mfxStatus VideoDECODEH264::QueryIOSurfInternal(eMFXPlatform platform, eMFXHWType
 
     if (IsMVCProfile(par->mfx.CodecProfile) && points && points->OP)
     {
-        level_idc = mfxU8 (MFX_MAX(level_idc, points->OP->LevelIdc));
+        level_idc = std::max<mfxU8>(level_idc, points->OP->LevelIdc);
     }
 
     mfxU32 asyncDepth = CalculateAsyncDepth(platform, par);

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -237,7 +237,7 @@ public:
     {
         if ((m_PictureStructureForRef >= FRM_STRUCTURE && force==0) || force==3)
         {
-            return MFX_MIN(m_PicNum[0],m_PicNum[1]);
+            return std::min(m_PicNum[0],m_PicNum[1]);
         }
 
         return m_PicNum[f];
@@ -308,12 +308,12 @@ public:
     {
         if ((m_PictureStructureForRef>=FRM_STRUCTURE && force==0) || force==3)
         {
-            return MFX_MIN(m_PicOrderCnt[0],m_PicOrderCnt[1]);
+            return std::min(m_PicOrderCnt[0],m_PicOrderCnt[1]);
         }
         else if (force==2)
         {
             if (isShortTermRef(0) && isShortTermRef(1))
-                return MFX_MIN(m_PicOrderCnt[0],m_PicOrderCnt[1]);
+                return std::min(m_PicOrderCnt[0],m_PicOrderCnt[1]);
             else if (isShortTermRef(0))
                 return m_PicOrderCnt[0];
             else
@@ -347,12 +347,12 @@ public:
     {
         if ((m_PictureStructureForRef>=FRM_STRUCTURE && force==0) || force==3)
         {
-            return MFX_MIN(m_LongTermPicNum[0],m_LongTermPicNum[1]);
+            return std::min(m_LongTermPicNum[0],m_LongTermPicNum[1]);
         }
         else if (force==2)
         {
             if (isLongTermRef(0) && isLongTermRef(1))
-                return MFX_MIN(m_LongTermPicNum[0],m_LongTermPicNum[1]);
+                return std::min(m_LongTermPicNum[0],m_LongTermPicNum[1]);
             else if (isLongTermRef(0))
                 return m_LongTermPicNum[0];
             else return m_LongTermPicNum[1];
@@ -401,7 +401,7 @@ public:
     uint32_t RefPicListResetCount(int32_t f) const
     {
         if (m_PictureStructureForRef >= FRM_STRUCTURE)
-            return MFX_MAX(m_RefPicListResetCount[0], m_RefPicListResetCount[1]);
+            return std::max(m_RefPicListResetCount[0], m_RefPicListResetCount[1]);
         else
             return m_RefPicListResetCount[f];
     }

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_slice_decoding.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_slice_decoding.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -275,7 +275,7 @@ bool IsPictureTheSame(H264Slice *pSliceOne, H264Slice *pSliceTwo)
         return false;
 
     if ((pOne->nal_ref_idc != pTwo->nal_ref_idc) &&
-        (0 == MFX_MIN(pOne->nal_ref_idc, pTwo->nal_ref_idc)))
+        (0 == std::min(pOne->nal_ref_idc, pTwo->nal_ref_idc)))
         return false;
 
     if (0 == pSliceTwo->GetSeqParam()->pic_order_cnt_type)

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -676,7 +676,7 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
     uint32_t dpbSize;
     auto constexpr INTERNAL_MAX_LEVEL = H264VideoDecoderParams::H264_LEVEL_MAX + 1;
 
-    num_ref_frames = MFX_MIN(16, num_ref_frames);
+    num_ref_frames = std::min(16u, num_ref_frames);
 
     for (;;)
     {
@@ -739,7 +739,7 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         }
 
         uint32_t dpbLevel = MaxDPBMbs*256 / (width * height);
-        dpbSize = MFX_MIN(16, dpbLevel);
+        dpbSize = std::min(16u, dpbLevel);
 
         if (num_ref_frames <= dpbSize || level_idc == INTERNAL_MAX_LEVEL)
             break;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1292,7 +1292,7 @@ Status H264HeadersBitstream::GetPictureParamSetPart2(H264PicParamSet  *pps, H264
                 if (pps->SliceGroupInfo.t3.pic_size_in_map_units != PicSizeInMapUnits)
                     return UMC_ERR_INVALID_STREAM;
 
-                uint32_t const len = MFX_MAX(1, pps->SliceGroupInfo.t3.pic_size_in_map_units);
+                uint32_t const len = std::max(1u, pps->SliceGroupInfo.t3.pic_size_in_map_units);
 
                 pps->SliceGroupInfo.pSliceGroupIDMap.resize(len);
 

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_defs_yuv.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_defs_yuv.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -78,7 +78,7 @@ void H264DecYUVBufferPadded::Init(const VideoDataInfo *info)
     if (info->GetNumPlanes() == 0)
         throw h264_exception(UMC_ERR_NULL_PTR);
 
-    m_bpp = MFX_MAX(info->GetPlaneBitDepth(0), info->GetPlaneBitDepth(1));
+    m_bpp = std::max(info->GetPlaneBitDepth(0), info->GetPlaneBitDepth(1));
 
     m_color_format = info->GetColorFormat();
     m_chroma_format = GetH264ColorFormat(info->GetColorFormat());
@@ -112,7 +112,7 @@ void H264DecYUVBufferPadded::allocate(const FrameData * frameData, const VideoDa
         m_frameData.m_locked = true;
 
     m_color_format = info->GetColorFormat();
-    m_bpp = MFX_MAX(info->GetPlaneBitDepth(0), info->GetPlaneBitDepth(1));
+    m_bpp = std::max(info->GetPlaneBitDepth(0), info->GetPlaneBitDepth(1));
 
     m_chroma_format = GetH264ColorFormat(info->GetColorFormat());
 

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
@@ -961,7 +961,7 @@ UMC::Status MFX_Utility::FillVideoParamMVCEx(UMC::TaskSupplier * supplier, ::mfx
     par->mfx.CodecLevel = (mfxU16)supplier->GetLevelIDC();
     mfxU16 maxDecPicBuffering = seqMVC->vui.bitstream_restriction_flag ? seqMVC->vui.max_dec_frame_buffering : 0;;
     if (par->mfx.MaxDecFrameBuffering && maxDecPicBuffering)
-        par->mfx.MaxDecFrameBuffering = MFX_MAX(maxDecPicBuffering, par->mfx.MaxDecFrameBuffering);
+        par->mfx.MaxDecFrameBuffering = std::max(maxDecPicBuffering, par->mfx.MaxDecFrameBuffering);
 
     if (!points)
         return UMC::UMC_OK;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_nal_spl.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_nal_spl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -159,7 +159,7 @@ public:
                 if (m_prev.size() + sz >  m_suggestedSize)
                 {
                     m_prev.clear();
-                    sz = MFX_MIN(sz, m_suggestedSize);
+                    sz = std::min(sz, m_suggestedSize);
                 }
 
                 m_prev.insert(m_prev.end(), (uint8_t *)pSource->GetDataPointer(), (uint8_t *)pSource->GetDataPointer() + sz);
@@ -310,7 +310,7 @@ private:
 
             if (zeroCount >= 2 && pb[0] == 1)
             {
-                startCodeSize = MFX_MIN(zeroCount + 1, 4);
+                startCodeSize = std::min(zeroCount + 1, 4u);
                 size -= i + 1;
                 pb++; // remove 0x01 symbol
                 zeroCount = 0;
@@ -344,7 +344,7 @@ private:
             }
         }
 
-        zeroCount = MFX_MIN(zeroCount, 3);
+        zeroCount = std::min(zeroCount, 3u);
         pb -= zeroCount;
         size = zeroCount;
         zeroCount = 0;
@@ -581,7 +581,7 @@ void SwapMemoryAndRemovePreventingBytes(void *pDestination, size_t &nDstSize, vo
 
     // first two bytes
     i = 0;
-    while (i < (uint32_t) MFX_MIN(2, nSrcSize))
+    while (i < std::min(size_t(2), nSrcSize))
     {
         pDst = (uint8_t) pSrc;
         ++pDst;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
@@ -193,10 +193,7 @@ void SVC_Extension::ChooseLevelIdc(const H264SeqParamSetSVCExtension * extension
     if (m_level_idc)
         return;
 
-    m_level_idc = extension->level_idc;
-
-    uint8_t maxLevel = MFX_MAX(baseViewLevelIDC, extensionLevelIdc);
-    m_level_idc = MFX_MAX(maxLevel, m_level_idc);
+    m_level_idc = std::max({baseViewLevelIDC, extensionLevelIdc, extension->level_idc});
 
     assert(m_level_idc != 0);
 }
@@ -1237,8 +1234,7 @@ void MVC_Extension::ChooseLevelIdc(const H264SeqParamSetMVCExtension * extension
         }
     }
 
-    uint8_t maxLevel = MFX_MAX(baseViewLevelIDC, extensionLevelIdc);
-    m_level_idc = MFX_MAX(maxLevel, m_level_idc);
+    m_level_idc = std::max({baseViewLevelIDC, extensionLevelIdc, m_level_idc});
 
     assert(m_level_idc != 0);
 }
@@ -3951,7 +3947,7 @@ void TaskSupplier::InitFreeFrame(H264DecoderFrame * pFrame, const H264Slice *pSl
     uint8_t bit_depth_luma = pSeqParam->bit_depth_luma;
     uint8_t bit_depth_chroma = pSeqParam->bit_depth_chroma;
 
-    int32_t bit_depth = MFX_MAX(bit_depth_luma, bit_depth_chroma);
+    int32_t bit_depth = std::max(bit_depth_luma, bit_depth_chroma);
 
     int32_t iMBWidth = pSeqParam->frame_width_in_mbs;
     int32_t iMBHeight = pSeqParam->frame_height_in_mbs;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_supplier.cpp
@@ -387,7 +387,7 @@ Status VATaskSupplier::AllocateFrameData(H264DecoderFrame * pFrame)
 H264Slice * VATaskSupplier::DecodeSliceHeader(NalUnit *nalUnit)
 {
     size_t dataSize = nalUnit->GetDataSize();
-    nalUnit->SetDataSize(MFX_MIN(1024, dataSize));
+    nalUnit->SetDataSize(std::min<size_t>(1024, dataSize));
 
     H264Slice * slice = TaskSupplier::DecodeSliceHeader(nalUnit);
 


### PR DESCRIPTION
Replaced with std::min/max