### PR TITLE
[mpeg2d] fix regression in slice handling

### DIFF
--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_bitstream.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_bitstream.cpp
@@ -300,7 +300,7 @@ namespace UMC_MPEG2_DECODER
         uint32_t height_in_MBs = mfx::align2_value<uint32_t>(slice.GetSeqHeader().vertical_size_value, 16) / 16u;
 
         // invalid slice - skipping it
-        if (slice.sliceHeader.slice_vertical_position >= height_in_MBs)
+        if (slice.sliceHeader.slice_vertical_position > height_in_MBs)
             throw mpeg2_exception(UMC::UMC_ERR_INVALID_PARAMS);
 
         slice.sliceHeader.numberMBsInSlice = width_in_MBs - slice.sliceHeader.macroblockAddressIncrement;


### PR DESCRIPTION
Fix a regression introduced in commit 4f328187b7cf
(pull-request #1619) that caused output artifacts
in bottom row of decoded mpeg2 files.