### PR TITLE
A new approach of MFX_WRN_DEVICE_BUSY handling

### DIFF
--- a/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
+++ b/_studio/mfx_lib/scheduler/include/mfx_scheduler_core.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2018 Intel Corporation
-// 
+// Copyright (c) 2018-2019 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -143,6 +143,10 @@ public:
     // Add a new task to the scheduler. Threads start processing task immediately.
     virtual
     mfxStatus AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoint);
+
+    // Find the oldest active syncPoint for a specified owner
+    virtual
+    mfxStatus FindOldestActiveSyncPoint(const void *pOwner, mfxSyncPoint *pSyncPoint);
 
     // Make synchronization, wait until task is done.
     virtual
@@ -347,7 +351,7 @@ protected:
     bool m_bQuit;
     volatile
     bool m_bQuitWakeUpThread;
-    
+
     // Threads contexts
     MFX_SCHEDULER_THREAD_CONTEXT *m_pThreadCtx;
 

--- a/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
+++ b/_studio/mfx_lib/shared/include/mfx_interface_scheduler.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2018 Intel Corporation
-// 
+// Copyright (c) 2018-2019 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -87,6 +87,10 @@ public:
     // Add a new task to the scheduler. Threads start processing task immediately.
     virtual
     mfxStatus AddTask(const MFX_TASK &task, mfxSyncPoint *pSyncPoint) = 0;
+
+    // Find the oldest active syncPoint for a specified owner
+    virtual
+    mfxStatus FindOldestActiveSyncPoint(const void *pOwner, mfxSyncPoint *pSyncPoint) = 0;
 
     // Make synchronization, wait until task is done.
     virtual

--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -1188,7 +1188,7 @@ mfxStatus StrFormatToCodecFormatFourCC(msdk_char* strInput, mfxU32 &codecFormat)
 msdk_string StatusToString(mfxStatus sts);
 mfxI32 getMonitorType(msdk_char* str);
 
-void WaitForDeviceToBecomeFree(MFXVideoSession& session, mfxSyncPoint& syncPoint, mfxStatus& currentStatus);
+mfxStatus WaitOnWrnDeviceBusy(MFXVideoSession& session, mfxSyncPoint& syncPoint);
 
 mfxU16 FourCCToChroma(mfxU32 fourCC);
 

--- a/samples/sample_encode/src/pipeline_region_encode.cpp
+++ b/samples/sample_encode/src/pipeline_region_encode.cpp
@@ -593,12 +593,14 @@ mfxStatus CRegionEncodingPipeline::Run()
                     nEncSurfIdx++;
                 }
 
-                if (MFX_ERR_NONE < sts && !pCurrentTask->EncSyncP) // repeat the call if warning and no output
+                if (MFX_WRN_DEVICE_BUSY == sts)
                 {
-                    if (MFX_WRN_DEVICE_BUSY == sts)
-                        MSDK_SLEEP(1); // wait if device is busy
+                    mfxStatus sts1 = WaitOnWrnDeviceBusy(m_mfxSession, pCurrentTask->EncSyncP);
+                    MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                    continue;
                 }
-                else if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
+
+                if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
                 {
                     sts = MFX_ERR_NONE; // ignore warnings if output is available
                     break;
@@ -651,13 +653,14 @@ mfxStatus CRegionEncodingPipeline::Run()
 
                 sts = m_resources[regId].pEncoder->EncodeFrameAsync(&pCurrentTask->encCtrl, NULL, &pCurrentTask->mfxBS, &pCurrentTask->EncSyncP);
 
-
-                if (MFX_ERR_NONE < sts && !pCurrentTask->EncSyncP) // repeat the call if warning and no output
+                if (MFX_WRN_DEVICE_BUSY == sts)
                 {
-                    if (MFX_WRN_DEVICE_BUSY == sts)
-                        MSDK_SLEEP(1); // wait if device is busy
+                    mfxStatus sts1 = WaitOnWrnDeviceBusy(m_mfxSession, pCurrentTask->EncSyncP);
+                    MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                    continue;
                 }
-                else if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
+
+                if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
                 {
                     sts = MFX_ERR_NONE; // ignore warnings if output is available
                     break;

--- a/samples/sample_encode/src/pipeline_user.cpp
+++ b/samples/sample_encode/src/pipeline_user.cpp
@@ -365,12 +365,12 @@ mfxStatus CUserPipeline::Run()
 
             if (MFX_WRN_DEVICE_BUSY == sts)
             {
-                MSDK_SLEEP(1); // just wait and then repeat the same call
+                mfxStatus sts1 = WaitOnWrnDeviceBusy(m_mfxSession, RotateSyncPoint);
+                MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                continue;
             }
-            else
-            {
-                break;
-            }
+
+            break;
         }
         MSDK_BREAK_ON_ERROR(sts);
 
@@ -388,12 +388,14 @@ mfxStatus CUserPipeline::Run()
 
             sts = m_pmfxENC->EncodeFrameAsync(&pCurrentTask->encCtrl, &m_pEncSurfaces[nEncSurfIdx], &pCurrentTask->mfxBS, &pCurrentTask->EncSyncP);
 
-            if (MFX_ERR_NONE < sts && !pCurrentTask->EncSyncP) // repeat the call if warning and no output
+            if (MFX_WRN_DEVICE_BUSY == sts)
             {
-                if (MFX_WRN_DEVICE_BUSY == sts)
-                    MSDK_SLEEP(1); // wait if device is busy
+                mfxStatus sts1 = WaitOnWrnDeviceBusy(m_mfxSession, pCurrentTask->EncSyncP);
+                MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                continue;
             }
-            else if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
+
+            if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
             {
                 sts = MFX_ERR_NONE; // ignore warnings if output is available
                 break;
@@ -430,12 +432,14 @@ mfxStatus CUserPipeline::Run()
 
             sts = m_pmfxENC->EncodeFrameAsync(&pCurrentTask->encCtrl, NULL, &pCurrentTask->mfxBS, &pCurrentTask->EncSyncP);
 
-            if (MFX_ERR_NONE < sts && !pCurrentTask->EncSyncP) // repeat the call if warning and no output
+            if (MFX_WRN_DEVICE_BUSY == sts)
             {
-                if (MFX_WRN_DEVICE_BUSY == sts)
-                    MSDK_SLEEP(1); // wait if device is busy
+                mfxStatus sts1 = WaitOnWrnDeviceBusy(m_mfxSession, pCurrentTask->EncSyncP);
+                MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                continue;
             }
-            else if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
+
+            if (MFX_ERR_NONE < sts && pCurrentTask->EncSyncP)
             {
                 sts = MFX_ERR_NONE; // ignore warnings if output is available
                 break;

--- a/samples/sample_fei/src/fei_encode.cpp
+++ b/samples/sample_fei/src/fei_encode.cpp
@@ -724,14 +724,14 @@ mfxStatus FEI_EncodeInterface::EncodeOneFrame(iTask* eTask)
             sts = m_pmfxENCODE->EncodeFrameAsync(&m_encodeControl, encodeSurface, &m_mfxBS, &m_SyncPoint);
             MSDK_CHECK_WRN(sts, "WRN during EncodeFrameAsync");
 
-            if (MFX_ERR_NONE < sts && !m_SyncPoint) // repeat the call if warning and no output
+            if (MFX_WRN_DEVICE_BUSY == sts)
             {
-                if (MFX_WRN_DEVICE_BUSY == sts)
-                {
-                    WaitForDeviceToBecomeFree(*m_pmfxSession, m_SyncPoint, sts);
-                }
+                mfxStatus sts1 = WaitOnWrnDeviceBusy(*m_pmfxSession, m_SyncPoint);
+                MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                continue;
             }
-            else if (MFX_ERR_NONE < sts && m_SyncPoint)
+
+            if (MFX_ERR_NONE < sts && m_SyncPoint)
             {
                 sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
                 MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENCODE: SyncOperation failed");

--- a/samples/sample_fei/src/fei_encpak.cpp
+++ b/samples/sample_fei/src/fei_encpak.cpp
@@ -1067,15 +1067,14 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                 sts = m_pmfxENC->ProcessFrameAsync(&eTask->ENC_in, &eTask->ENC_out, &m_SyncPoint);
                 MSDK_CHECK_WRN(sts, "WRN during ProcessFrameAsync");
 
-                if (MFX_ERR_NONE < sts && !m_SyncPoint)
+                if (MFX_WRN_DEVICE_BUSY == sts)
                 {
-                    // Repeat the call if warning and no output
-
-                    if (MFX_WRN_DEVICE_BUSY == sts){
-                        WaitForDeviceToBecomeFree(*m_pmfxSession, m_SyncPoint, sts);
-                    }
+                    mfxStatus sts1 = WaitOnWrnDeviceBusy(*m_pmfxSession, m_SyncPoint);
+                    MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                    continue;
                 }
-                else if (MFX_ERR_NONE < sts && m_SyncPoint)
+
+                if (MFX_ERR_NONE < sts && m_SyncPoint)
                 {
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);
                     MSDK_CHECK_ERR_NONE_STATUS(sts, MFX_ERR_ABORTED, "FEI ENC: SyncOperation failed");
@@ -1133,15 +1132,14 @@ mfxStatus FEI_EncPakInterface::EncPakOneFrame(iTask* eTask)
                 sts = m_pmfxPAK->ProcessFrameAsync(&eTask->PAK_in, &eTask->PAK_out, &m_SyncPoint);
                 MSDK_CHECK_WRN(sts, "WRN during ProcessFrameAsync");
 
-                if (MFX_ERR_NONE < sts && !m_SyncPoint)
+                if (MFX_WRN_DEVICE_BUSY == sts)
                 {
-                    // Repeat the call if warning and no output
-
-                    if (MFX_WRN_DEVICE_BUSY == sts){
-                        WaitForDeviceToBecomeFree(*m_pmfxSession, m_SyncPoint, sts);
-                    }
+                    mfxStatus sts1 = WaitOnWrnDeviceBusy(*m_pmfxSession, m_SyncPoint);
+                    MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                    continue;
                 }
-                else if (MFX_ERR_NONE < sts && m_SyncPoint)
+
+                if (MFX_ERR_NONE < sts && m_SyncPoint)
                 {
                     // Ignore warnings if output is available
                     sts = m_pmfxSession->SyncOperation(m_SyncPoint, MSDK_WAIT_INTERVAL);

--- a/samples/sample_hevc_fei/include/fei_utils.h
+++ b/samples/sample_hevc_fei/include/fei_utils.h
@@ -130,7 +130,6 @@ public:
     Decoder(const SourceFrameInfo& inPars, SurfacesPool* sp, MFXVideoSession* session)
         : IYUVSource(inPars, sp)
         , m_session(session)
-        , m_LastSyncp(0)
     {
         m_Bitstream.TimeStamp=(mfxU64)-1;
     }
@@ -159,8 +158,6 @@ protected:
     std::unique_ptr<MFXVideoDECODE>  m_DEC;
     MfxVideoParamsWrapper            m_par;
 
-    mfxSyncPoint                     m_LastSyncp;
-
 private:
     DISALLOW_COPY_AND_ASSIGN(Decoder);
 };
@@ -173,7 +170,6 @@ public:
         , m_pTarget(pTarget)
         , m_parentSession(parentSession)
         , m_pInSurface(NULL)
-        , m_LastSyncp(0)
     {
     }
     virtual ~FieldSplitter()
@@ -203,7 +199,6 @@ protected:
     MfxVideoParamsWrapper         m_par;
 
     mfxFrameSurface1 *            m_pInSurface;
-    mfxSyncPoint                  m_LastSyncp;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(FieldSplitter);

--- a/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
+++ b/samples/sample_hevc_fei/src/hevc_fei_encode.cpp
@@ -317,12 +317,10 @@ mfxStatus FEI_Encode::EncodeFrame(mfxFrameSurface1* pSurf)
         sts = m_mfxENCODE.EncodeFrameAsync(&m_encodeCtrl, pSurf, &m_bitstream, &m_syncPoint);
         MSDK_CHECK_WRN(sts, "FEI EncodeFrameAsync");
 
-        if (MFX_ERR_NONE < sts && !m_syncPoint) // repeat the call if warning and no output
+        if (MFX_WRN_DEVICE_BUSY == sts)
         {
-            if (MFX_WRN_DEVICE_BUSY == sts)
-            {
-                WaitForDeviceToBecomeFree(*m_pmfxSession, m_syncPoint, sts);
-            }
+            auto sts1 = WaitOnWrnDeviceBusy(*m_pmfxSession, m_syncPoint);
+            MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
             continue;
         }
 

--- a/samples/sample_hevc_fei_abr/include/fei_utils.h
+++ b/samples/sample_hevc_fei_abr/include/fei_utils.h
@@ -104,7 +104,6 @@ public:
     Decoder(const SourceFrameInfo& inPars, SurfacesPool* sp, MFXVideoSession* session)
         : IYUVSource(inPars, sp)
         , m_session(session)
-        , m_LastSyncp(0)
     {
         m_Bitstream.TimeStamp=(mfxU64)-1;
     }
@@ -131,8 +130,6 @@ protected:
     MFXVideoSession*               m_session;
     std::unique_ptr<MFXVideoDECODE>  m_DEC;
     MfxVideoParamsWrapper          m_par;
-
-    mfxSyncPoint                   m_LastSyncp;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Decoder);

--- a/samples/sample_hevc_fei_abr/src/hevc_fei_encode.cpp
+++ b/samples/sample_hevc_fei_abr/src/hevc_fei_encode.cpp
@@ -153,12 +153,10 @@ mfxStatus FEI_Encode::EncodeFrame(mfxFrameSurface1* pSurf)
         sts = m_mfxENCODE.EncodeFrameAsync(&m_encodeCtrl, pSurf, &m_bitstream, &m_syncPoint);
         MSDK_CHECK_WRN(sts, "FEI EncodeFrameAsync");
 
-        if (MFX_ERR_NONE < sts && !m_syncPoint) // repeat the call if warning and no output
+        if (MFX_WRN_DEVICE_BUSY == sts)
         {
-            if (MFX_WRN_DEVICE_BUSY == sts)
-            {
-                WaitForDeviceToBecomeFree(*m_pmfxSession, m_syncPoint, sts);
-            }
+            auto sts1 = WaitOnWrnDeviceBusy(*m_pmfxSession, m_syncPoint);
+            MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
             continue;
         }
 

--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -827,8 +827,6 @@ namespace TranscodingSample
 
         bool           m_bUseOpaqueMemory; // indicates if opaque memory is used in the pipeline
 
-        mfxSyncPoint   m_LastDecSyncPoint;
-
         SafetySurfaceBuffer   *m_pBuffer;
         CTranscodingPipeline  *m_pParentPipeline;
 

--- a/samples/sample_vpp/src/sample_vpp.cpp
+++ b/samples/sample_vpp/src/sample_vpp.cpp
@@ -713,24 +713,24 @@ int main(int argc, msdk_char *argv[])
             if ( Params.use_extapi )
             {
                 mfxFrameSurface1 * out_surface = nullptr;
-                sts = frameProcessor.pmfxVPP->RunFrameVPPAsyncEx(
-                    pInSurf[nInStreamInd],
-                    pWorkSurf,
-                    //pExtData,
-                    &out_surface,
-                    &syncPoint);
-
-                while(MFX_WRN_DEVICE_BUSY == sts)
+                for (;;)
                 {
-                    MSDK_SLEEP(500);
                     sts = frameProcessor.pmfxVPP->RunFrameVPPAsyncEx(
                         pInSurf[nInStreamInd],
                         pWorkSurf,
                         //pExtData,
                         &out_surface,
                         &syncPoint);
+
+                    if (MFX_WRN_DEVICE_BUSY == sts)
+                    {
+                        mfxStatus sts1 = WaitOnWrnDeviceBusy(Resources.pProcessor->mfxSession, syncPoint);
+                        MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                        continue;
+                    }
+                    break;
                 }
-                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(pOutSurf);
+                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(out_surface);
                 if(MFX_ERR_MORE_DATA != sts)
                     bDoNotUpdateIn = true;
             }
@@ -894,21 +894,24 @@ int main(int argc, msdk_char *argv[])
             if ( Params.use_extapi )
             {
                 mfxFrameSurface1 * out_surface = nullptr;
-                sts = frameProcessor.pmfxVPP->RunFrameVPPAsyncEx(
-                    NULL,
-                    pWorkSurf,
-                    &out_surface,
-                    &syncPoint );
-                while(MFX_WRN_DEVICE_BUSY == sts)
+                for (;;)
                 {
-                    MSDK_SLEEP(500);
                     sts = frameProcessor.pmfxVPP->RunFrameVPPAsyncEx(
                         NULL,
                         pWorkSurf,
                         &out_surface,
                         &syncPoint );
+
+                    if (MFX_WRN_DEVICE_BUSY == sts)
+                    {
+                        mfxStatus sts1 = WaitOnWrnDeviceBusy(Resources.pProcessor->mfxSession, syncPoint);
+                        MSDK_CHECK_STATUS(sts1, "WaitOnWrnDeviceBusy failed");
+                        continue;
+                    }
+
+                    break;
                 }
-                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(pOutSurf);
+                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(out_surface);
             }
             else
             {


### PR DESCRIPTION
If MFX_WRN_DEVICE_BUSY is returned, it shall be paired with a valid syncPoint.
That syncPoint is not necessarily binded with actuall output data.
The purpose of the syncPoint is provide applications a way to make polling-free waiting.
Applications, of course, can choose either to wait or perform some different job.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>