### PR TITLE
[sample_vpp] Fixes regressions after recent refactoring 

### DIFF
--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -992,7 +992,26 @@ private:
 
 mfxStatus ConvertFrameRate(mfxF64 dFrameRate, mfxU32* pnFrameRateExtN, mfxU32* pnFrameRateExtD);
 mfxF64 CalculateFrameRate(mfxU32 nFrameRateExtN, mfxU32 nFrameRateExtD);
-mfxU16 GetFreeSurfaceIndex(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize);
+
+template <class T>
+mfxU16 GetFreeSurfaceIndex(T* pSurfacesPool, mfxU16 nPoolSize)
+{
+    constexpr mfxU16 MSDK_INVALID_SURF_IDX = 0xffff;
+
+    if (pSurfacesPool)
+    {
+        for (mfxU16 i = 0; i < nPoolSize; i++)
+        {
+            if (0 == pSurfacesPool[i].Data.Locked)
+            {
+                return i;
+            }
+        }
+    }
+
+    return MSDK_INVALID_SURF_IDX;
+}
+
 mfxU16 GetFreeSurface(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize);
 void FreeSurfacePool(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize);
 

--- a/samples/sample_common/src/sample_utils.cpp
+++ b/samples/sample_common/src/sample_utils.cpp
@@ -1267,22 +1267,6 @@ mfxF64 CalculateFrameRate(mfxU32 nFrameRateExtN, mfxU32 nFrameRateExtD)
         return 0;
 }
 
-mfxU16 GetFreeSurfaceIndex(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize)
-{
-    if (pSurfacesPool)
-    {
-        for (mfxU16 i = 0; i < nPoolSize; i++)
-        {
-            if (0 == pSurfacesPool[i].Data.Locked)
-            {
-                return i;
-            }
-        }
-    }
-
-    return MSDK_INVALID_SURF_IDX;
-}
-
 void FreeSurfacePool(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize)
 {
     if (pSurfacesPool)

--- a/samples/sample_vpp/include/sample_vpp_utils.h
+++ b/samples/sample_vpp/include/sample_vpp_utils.h
@@ -489,7 +489,7 @@ void PrintInfo(
 void PrintDllInfo();
 
 mfxStatus InitParamsVPP(
-    mfxVideoParam* pMFXParams,
+    MfxVideoParamsWrapper* pMFXParams,
     sInputParams* pInParams,
     mfxU32 paramID);
 

--- a/samples/sample_vpp/src/sample_vpp.cpp
+++ b/samples/sample_vpp/src/sample_vpp.cpp
@@ -730,7 +730,7 @@ int main(int argc, msdk_char *argv[])
                         &out_surface,
                         &syncPoint);
                 }
-                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(pOutSurf);
+                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(out_surface);
                 if(MFX_ERR_MORE_DATA != sts)
                     bDoNotUpdateIn = true;
             }
@@ -908,7 +908,7 @@ int main(int argc, msdk_char *argv[])
                         &out_surface,
                         &syncPoint );
                 }
-                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(pOutSurf);
+                pOutSurf = static_cast<mfxFrameSurfaceWrap*>(out_surface);
             }
             else
             {

--- a/samples/sample_vpp/src/sample_vpp_utils.cpp
+++ b/samples/sample_vpp/src/sample_vpp_utils.cpp
@@ -307,7 +307,7 @@ mfxStatus ParseGUID(msdk_char strPlgGuid[MSDK_MAX_FILENAME_LEN], mfxU8 DataGUID[
     return MFX_ERR_NONE;
 }
 
-mfxStatus InitParamsVPP(mfxVideoParam* pParams, sInputParams* pInParams, mfxU32 paramID)
+mfxStatus InitParamsVPP(MfxVideoParamsWrapper* pParams, sInputParams* pInParams, mfxU32 paramID)
 {
     MSDK_CHECK_POINTER(pParams,    MFX_ERR_NULL_PTR);
     MSDK_CHECK_POINTER(pInParams,  MFX_ERR_NULL_PTR);
@@ -320,9 +320,7 @@ mfxStatus InitParamsVPP(mfxVideoParam* pParams, sInputParams* pInParams, mfxU32 
         vppPrintHelp(MSDK_STRING("sample_vpp"), MSDK_STRING("ERROR: Source height is not defined.\n"));
         return MFX_ERR_UNSUPPORTED;
     }
-
-    memset(pParams, 0, sizeof(mfxVideoParam));
-
+    *pParams = MfxVideoParamsWrapper();
     /* input data */
     pParams->vpp.In.Shift           = pInParams->frameInfoIn[paramID].Shift;
     pParams->vpp.In.BitDepthLuma    = pInParams->frameInfoIn[paramID].BitDepthLuma;


### PR DESCRIPTION
1) Wrong variable usage;
2) Change InitParamsVPP signature
3) When we use mfxFrameSurfaceWrap and pass them to common function, we lose information about free surfaces, so change source to template
