### PR TITLE
h264e: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils.cpp
@@ -67,7 +67,7 @@ namespace MfxHwH264Encode
             numFrameMin = numFrameMin + par.AsyncDepth - 1;
 
             mfxExtMVCSeqDesc & extMvc = GetExtBufferRef(par);
-            numFrameMin = mfxU16(MFX_MIN(0xffff, numFrameMin * extMvc.NumView));
+            numFrameMin = mfxU16(std::min(0xffffu, numFrameMin * extMvc.NumView));
         }
         if (IsAvcProfile(par.mfx.CodecProfile)) //AVC
         {
@@ -276,7 +276,7 @@ namespace MfxHwH264Encode
                 if (IsOn(par.mfx.LowPower) && ctrl.QP < 10)
                     return 10;
                 // get per frame qp
-                return mfxU8(MFX_MIN(ctrl.QP, 51));
+                return std::min<mfxU8>(ctrl.QP, 51);
             }
             else
             {
@@ -599,8 +599,8 @@ FrameTypeGenerator::FrameTypeGenerator()
 void FrameTypeGenerator::Init(MfxVideoParam const & video)
 {
     m_gopOptFlag = video.mfx.GopOptFlag;
-    m_gopPicSize = MFX_MAX(video.mfx.GopPicSize, 1);
-    m_gopRefDist = MFX_MAX(video.mfx.GopRefDist, 1);
+    m_gopPicSize = std::max<mfxU16>(video.mfx.GopPicSize, 1);
+    m_gopRefDist = std::max<mfxU16>(video.mfx.GopRefDist, 1);
     m_idrDist    = m_gopPicSize * (video.mfx.IdrInterval + 1);
 
     mfxExtCodingOption2 & extOpt2 = GetExtBufferRef(video);
@@ -896,7 +896,7 @@ mfxU32 MfxHwH264Encode::CalculateSeiSize(
         dataSizeInBits += 4; // msg.pic_struct;
 
         assert(msg.pic_struct <= 8);
-        mfxU32 numClockTS = NUM_CLOCK_TS[MFX_MIN(msg.pic_struct, 8)];
+        mfxU32 numClockTS = NUM_CLOCK_TS[std::min<mfxU8>(msg.pic_struct, 8)];
 
         dataSizeInBits += numClockTS; // clock_timestamp_flag[i]
         for (mfxU32 i = 0; i < numClockTS; i++)
@@ -1078,7 +1078,7 @@ namespace MfxHwH264EncodeHW
 {
     mfxF64 const INTRA_QSTEP_COEFF  = 2.0;
     mfxI32 const MAX_QP_CHANGE      = 2;
-    mfxF64 const LOG2_64            = 3;
+    mfxF64 const LOG2_64            = 3.0;
     mfxF64 const MIN_EST_RATE       = 0.3;
     mfxF64 const NORM_EST_RATE      = 100.0;
 
@@ -1110,11 +1110,11 @@ namespace MfxHwH264EncodeHW
         mfxF64 qoff = 1.0 / 6;
         mfxF64 norm = 0.1666;
 
-        mfxF64 qskip = MFX_MAX(MFX_MAX(MFX_MAX(
-            nzc[0] ? (sumc[0] * norm / nzc[0]) / (1 - qoff) * LOG2_64 : 0,
-            nzc[1] ? (sumc[1] * norm / nzc[1]) / (1 - qoff) * LOG2_64 : 0),
-            nzc[2] ? (sumc[2] * norm / nzc[2]) / (1 - qoff) * LOG2_64 : 0),
-            nzc[3] ? (sumc[3] * norm / nzc[3]) / (1 - qoff) * LOG2_64 : 0);
+        mfxF64 qskip = std::max({
+            nzc[0] ? (sumc[0] * norm / nzc[0]) / (1.0 - qoff) * LOG2_64 : 0.0,
+            nzc[1] ? (sumc[1] * norm / nzc[1]) / (1.0 - qoff) * LOG2_64 : 0.0,
+            nzc[2] ? (sumc[2] * norm / nzc[2]) / (1.0 - qoff) * LOG2_64 : 0.0,
+            nzc[3] ? (sumc[3] * norm / nzc[3]) / (1.0 - qoff) * LOG2_64 : 0.0});
 
         return QStep2QpCeil(qskip);
     }
@@ -1122,14 +1122,14 @@ namespace MfxHwH264EncodeHW
 using namespace MfxHwH264EncodeHW;
 inline void SetMinMaxQP(mfxExtCodingOption2 const &  extOpt2, mfxU8  QPMin[], mfxU8  QPMax[])
 {
-	// qp=0 doesn't supported
-	QPMin[0] = (extOpt2.MinQPI) ? extOpt2.MinQPI : 1;
-	QPMin[1] = (extOpt2.MinQPP) ? extOpt2.MinQPP : 1;
-	QPMin[2] = (extOpt2.MinQPB) ? extOpt2.MinQPB : 1;
+    // qp=0 doesn't supported
+    QPMin[0] = (extOpt2.MinQPI) ? extOpt2.MinQPI : 1;
+    QPMin[1] = (extOpt2.MinQPP) ? extOpt2.MinQPP : 1;
+    QPMin[2] = (extOpt2.MinQPB) ? extOpt2.MinQPB : 1;
 
-	QPMax[0] = (extOpt2.MaxQPI) ? extOpt2.MaxQPI : 51;
-	QPMax[1] = (extOpt2.MaxQPP) ? extOpt2.MaxQPP : 51;
-	QPMax[2] = (extOpt2.MaxQPB) ? extOpt2.MaxQPB : 51;
+    QPMax[0] = (extOpt2.MaxQPI) ? extOpt2.MaxQPI : 51;
+    QPMax[1] = (extOpt2.MaxQPP) ? extOpt2.MaxQPP : 51;
+    QPMax[2] = (extOpt2.MaxQPB) ? extOpt2.MaxQPB : 51;
 }
 
 mfxStatus LookAheadBrc2::Init(MfxVideoParam  & video)
@@ -1167,7 +1167,7 @@ mfxStatus LookAheadBrc2::Init(MfxVideoParam  & video)
 
     m_AvgBitrate = 0;
 
-	SetMinMaxQP(extOpt2, m_QPMin, m_QPMax);
+    SetMinMaxQP(extOpt2, m_QPMin, m_QPMax);
 
     if (extOpt3.WinBRCSize)
     {
@@ -1218,7 +1218,7 @@ mfxStatus VMEBrc::Init(MfxVideoParam  & video)
     m_curBaseQp = -1;
     m_skipped = 0;
     m_lookAhead = 0;
-	SetMinMaxQP(extOpt2, m_QPMin, m_QPMax);
+    SetMinMaxQP(extOpt2, m_QPMin, m_QPMax);
 
     m_AvgBitrate = 0;
     if (extOpt3.WinBRCSize)
@@ -1434,7 +1434,7 @@ void LookAheadBrc2::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
         mfxF64 rateCoeff = m_rateCoeffHistory[qp].GetCoeff();
         for (mfxU32 i = m_first; i < m_laData.size(); i++)
         {
-            m_laData[i].estRateTotal[qp] = MFX_MAX(MIN_EST_RATE, rateCoeff * m_laData[i].estRate[qp]);
+            m_laData[i].estRateTotal[qp] = std::max(MIN_EST_RATE, rateCoeff * m_laData[i].estRate[qp]);
             totalEstRate[qp] += m_laData[i].estRateTotal[qp];
         }
     }
@@ -1455,7 +1455,7 @@ void LookAheadBrc2::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
             m_laData[i].deltaQp = (interCost >= intraCost * 0.9)
                 ? -mfxI32(deltaQp * 2 * strength + 0.5)
                 : -mfxI32(deltaQp * 1 * strength + 0.5);
-            maxDeltaQp = MFX_MAX(maxDeltaQp, m_laData[i].deltaQp);
+            maxDeltaQp = std::max(maxDeltaQp, m_laData[i].deltaQp);
 
         }
     }
@@ -1466,7 +1466,7 @@ void LookAheadBrc2::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
             mfxU32 intraCost    = m_laData[i].intraCost;
             mfxU32 interCost    = m_laData[i].interCost;
             m_laData[i].deltaQp = (interCost >= intraCost * 0.9) ? -5 : m_laData[i].bframe ? 0 : -2;
-            maxDeltaQp = MFX_MAX(maxDeltaQp, m_laData[i].deltaQp);
+            maxDeltaQp = std::max(maxDeltaQp, m_laData[i].deltaQp);
         }
     }
 
@@ -1614,7 +1614,7 @@ mfxU32 LookAheadBrc2::Report(const BRCFrameParams& par, mfxU32 /* userDataLength
     m_skipped = (par.NumRecode < 100) ? 0 : 1;  //frame was skipped (panic mode)
                                          //we will skip all frames until next reference]
     if (m_AvgBitrate)
-        maxFS = MFX_MIN(maxFS, m_AvgBitrate->GetMaxFrameSize(m_skipped>0, (par.FrameType & MFX_FRAMETYPE_I)!=0, par.NumRecode));
+        maxFS = std::min(maxFS, m_AvgBitrate->GetMaxFrameSize(m_skipped > 0, (par.FrameType & MFX_FRAMETYPE_I) != 0, par.NumRecode));
 
     if ((8 * par.CodedFrameSize + 24) > maxFS)
     {
@@ -1627,7 +1627,7 @@ mfxU32 LookAheadBrc2::Report(const BRCFrameParams& par, mfxU32 /* userDataLength
 
     m_framesBehind++;
     m_bitsBehind += realRatePerMb;
-    mfxF64 framesBeyond = (mfxF64)(MFX_MAX(2, m_laData.size()) - 1 - m_first);
+    mfxF64 framesBeyond = mfxF64(std::max<mfxI32>(2, m_laData.size()) - 1 - m_first);
 
     m_targetRateMax = (m_initTargetRate * (m_framesBehind + (m_lookAhead - 1)) - m_bitsBehind) / framesBeyond;
     m_targetRateMin = (m_initTargetRate * (m_framesBehind + (framesBeyond   )) - m_bitsBehind) / framesBeyond;
@@ -1645,7 +1645,7 @@ mfxU32 LookAheadBrc2::Report(const BRCFrameParams& par, mfxU32 /* userDataLength
 
 
     mfxF64 oldCoeff = m_rateCoeffHistory[qp].GetCoeff();
-    mfxF64 y = MFX_MAX(0.0, realRatePerMb);
+    mfxF64 y = std::max(0.0, realRatePerMb);
     mfxF64 x = m_laData[0].estRate[qp];
     mfxF64 minY = NORM_EST_RATE * INIT_RATE_COEFF[qp] * MIN_RATE_COEFF_CHANGE;
     mfxF64 maxY = NORM_EST_RATE * INIT_RATE_COEFF[qp] * MAX_RATE_COEFF_CHANGE;
@@ -1680,7 +1680,7 @@ mfxU32 VMEBrc::Report(const BRCFrameParams& par, mfxU32 /*userDataLength*/, mfxU
     m_skipped = (par.NumRecode < 100) ? 0 : 1;  //frame was skipped (panic mode)
                                                 //we will skip all frames until next reference
     if (m_AvgBitrate)
-        maxFS = MFX_MIN(maxFS, m_AvgBitrate->GetMaxFrameSize(m_skipped>0, (par.FrameType & MFX_FRAMETYPE_I)!=0, par.NumRecode));
+        maxFS = std::min(maxFS, m_AvgBitrate->GetMaxFrameSize(m_skipped > 0, (par.FrameType & MFX_FRAMETYPE_I) != 0, par.NumRecode));
 
     if ((8 * par.CodedFrameSize + 24) > maxFS)
     {
@@ -1704,13 +1704,12 @@ mfxU32 VMEBrc::Report(const BRCFrameParams& par, mfxU32 /*userDataLength*/, mfxU
     for (std::list<LaFrameData>::iterator it = start; it != m_laData.end(); ++it)
         numFrames++;
 
-    numFrames = MFX_MIN(numFrames, m_lookAhead);
+    numFrames = std::min(numFrames, m_lookAhead);
 
     if (start != m_laData.end())
     {
 
-        mfxF64 framesBeyond = (mfxF64)(MFX_MAX(2, numFrames - 1) - 1);
-
+        mfxF64 framesBeyond = mfxF64(std::max(2u, numFrames - 1) - 1);
 
         m_targetRateMax = (m_initTargetRate * (m_framesBehind + (m_lookAhead - 1)) - m_bitsBehind) / framesBeyond;
         m_targetRateMin = (m_initTargetRate * (m_framesBehind + (framesBeyond   )) - m_bitsBehind) / framesBeyond;
@@ -1718,7 +1717,7 @@ mfxU32 VMEBrc::Report(const BRCFrameParams& par, mfxU32 /*userDataLength*/, mfxU
         //printf("Target: Max %f, Min %f, framesBeyond %f, m_framesBehind %d, m_bitsBehind %f, m_lookAhead %d, picOrder %d, m_laData[0] %d, delta %d, qp %d \n", m_targetRateMax, m_targetRateMin, framesBeyond, m_framesBehind, m_bitsBehind, m_lookAhead, picOrder, (*start).encOrder, (*start).deltaQp, qp);
 
         mfxF64 oldCoeff = m_rateCoeffHistory[qp].GetCoeff();
-        mfxF64 y = MFX_MAX(0.0, realRatePerMb);
+        mfxF64 y = std::max(0.0, realRatePerMb);
         mfxF64 x = (*start).estRate[qp];
         mfxF64 minY = NORM_EST_RATE * INIT_RATE_COEFF[qp] * MIN_RATE_COEFF_CHANGE;
         mfxF64 maxY = NORM_EST_RATE * INIT_RATE_COEFF[qp] * MAX_RATE_COEFF_CHANGE;
@@ -1776,7 +1775,7 @@ void VMEBrc::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
     for(it = start;it != m_laData.end(); ++it)
         numberOfFrames++;
 
-    numberOfFrames = MFX_MIN( numberOfFrames, m_lookAhead);
+    numberOfFrames = std::min(numberOfFrames, m_lookAhead);
 
 
     // fill totalEstRate
@@ -1786,7 +1785,7 @@ void VMEBrc::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
         for (mfxU32 qp = 0; qp < 52; qp++)
         {
 
-            (*it).estRateTotal[qp] = MFX_MAX(MIN_EST_RATE, m_rateCoeffHistory[qp].GetCoeff() * (*it).estRate[qp]);
+            (*it).estRateTotal[qp] = std::max(MIN_EST_RATE, m_rateCoeffHistory[qp].GetCoeff() * (*it).estRate[qp]);
             totalEstRate[qp] += (*it).estRateTotal[qp];
         }
         ++it;
@@ -1809,7 +1808,7 @@ void VMEBrc::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
             (*it).deltaQp = (interCost >= intraCost * 0.9)
                 ? -mfxI32(deltaQp * 2 * strength + 0.5)
                 : -mfxI32(deltaQp * 1 * strength + 0.5);
-            maxDeltaQp = MFX_MAX(maxDeltaQp, (*it).deltaQp);
+            maxDeltaQp = std::max(maxDeltaQp, it->deltaQp);
             //printf("%d intra %d inter %d prop %d currQP %d delta %f(%d)\n", (*it).encOrder, intraCost/4, interCost/4, propCost/4, curQp, deltaQp, (*it).deltaQp );
             ++it;
         }
@@ -1822,7 +1821,8 @@ void VMEBrc::GetQp(const BRCFrameParams& par, mfxBRCFrameCtrl &frameCtrl)
             mfxU32 intraCost    = (*it).intraCost;
             mfxU32 interCost    = (*it).interCost;
             (*it).deltaQp = (interCost >= intraCost * 0.9) ? -5 : (*it).bframe ? 0 : -2;
-            maxDeltaQp = MFX_MAX(maxDeltaQp, (*it).deltaQp);
+
+            maxDeltaQp = std::max(maxDeltaQp, it->deltaQp);
             ++it;
         }
     }
@@ -2018,7 +2018,7 @@ void Hrd::RemoveAccessUnit(mfxU32 size, mfxU32 interlace, mfxU32 bufferingPeriod
         : m_trn_cur - (m_hrdIn90k / 90000.0);
 
     double tai_cur = (m_rcMethod == MFX_RATECONTROL_VBR)
-        ? MFX_MAX(m_taf_prv, tai_earliest)
+        ? std::max(m_taf_prv, tai_earliest)
         : m_taf_prv;
 
     m_taf_prv = tai_cur + double(8) * size / m_bitrate;
@@ -2030,7 +2030,7 @@ mfxU32 Hrd::GetInitCpbRemovalDelay() const
     if (m_bIsHrdRequired == false)
         return 0;
 
-    double delay = MFX_MAX(0.0, m_trn_cur - m_taf_prv);
+    double delay = std::max(0.0, m_trn_cur - m_taf_prv);
     mfxU32 initialCpbRemovalDelay = mfxU32(90000 * delay + 0.5);
 
     return initialCpbRemovalDelay == 0
@@ -2060,7 +2060,7 @@ mfxU32 Hrd::GetMaxFrameSize(mfxU32 bufferingPeriod) const
         : m_trn_cur - (m_hrdIn90k / 90000.0);
 
     double tai_cur = (m_rcMethod == MFX_RATECONTROL_VBR)
-        ? MFX_MAX(m_taf_prv, tai_earliest)
+        ? std::max(m_taf_prv, tai_earliest)
         : m_taf_prv;
 
     mfxU32 maxFrameSize = (mfxU32)((m_trn_cur - tai_cur)*m_bitrate);
@@ -2354,7 +2354,7 @@ void MfxHwH264Encode::PutSeiMessage(
     if (msg.pic_struct_present_flag)
     {
         assert(msg.pic_struct <= 8);
-        mfxU32 numClockTS = NUM_CLOCK_TS[MFX_MIN(msg.pic_struct, 8)];
+        mfxU32 numClockTS = NUM_CLOCK_TS[std::min<mfxU8>(msg.pic_struct, 8)];
 
         bs.PutBits(msg.pic_struct, 4);
         for (mfxU32 i = 0; i < numClockTS; i ++)
@@ -4185,11 +4185,11 @@ namespace
         mfxU32 pocL0,
         mfxU32 pocL1)
     {
-        mfxI32 tb = MFX_MIN(MFX_MAX(-128, mfxI32(pocCur - pocL0)), 127);
-        mfxI32 td = MFX_MIN(MFX_MAX(-128, mfxI32(pocL1  - pocL0)), 127);
+        mfxI32 tb = mfx::clamp(mfxI32(pocCur - pocL0), -128, 127);
+        mfxI32 td = mfx::clamp(mfxI32(pocL1  - pocL0), -128, 127);
         mfxI32 tx = (16384 + abs(td/2)) / td;
-        mfxI32 distScaleFactor = MFX_MIN(MFX_MAX(-1024, (tb * tx + 32) >> 6), 1023);
-        return distScaleFactor;
+
+        return mfx::clamp((tb * tx + 32) >> 6, -1024, 1023);
     }
 
     mfxI32 CalcDistScaleFactor(

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
@@ -719,7 +719,7 @@ void MfxHwH264Encode::ModifyRefPicLists(
         mfxExtCodingOptionDDI const & extDdi  = GetExtBufferRef(video);
         mfxExtCodingOption2 const   & extOpt2 = GetExtBufferRef(video);
         const mfxU32 numMaxActiveRefL1 = GetMaxNumRefActiveBL1(video.mfx.TargetUsage, isField);
-        mfxU32 numActiveRefL1 = MFX_MIN(extDdi.NumActiveRefBL1, numMaxActiveRefL1);
+        mfxU32 numActiveRefL1 = std::min<mfxU32>(extDdi.NumActiveRefBL1, numMaxActiveRefL1);
         mfxU32 numActiveRefL0 = (task.m_type[fieldId] & MFX_FRAMETYPE_P)
             ? extDdi.NumActiveRefP
             : extDdi.NumActiveRefBL0;
@@ -748,12 +748,12 @@ void MfxHwH264Encode::ModifyRefPicLists(
             {
                 if (advCtrl) // advanced ref list control has priority
                 {
-                    mfxU32 numActiveRefL0Final = advCtrl->NumRefIdxL0Active ? MFX_MIN(advCtrl->NumRefIdxL0Active,numActiveRefL0) : numActiveRefL0;
+                    mfxU32 numActiveRefL0Final = advCtrl->NumRefIdxL0Active ? std::min<mfxU32>(advCtrl->NumRefIdxL0Active, numActiveRefL0) : numActiveRefL0;
                     ReorderRefPicList(list0, dpb, (mfxRefPic*)(&advCtrl->RefPicList0[0]), numActiveRefL0Final);
                 }
                 else
                 {
-                    mfxU32 numActiveRefL0Final = ctrl->NumRefIdxL0Active ? MFX_MIN(ctrl->NumRefIdxL0Active,numActiveRefL0) : numActiveRefL0;
+                    mfxU32 numActiveRefL0Final = ctrl->NumRefIdxL0Active ? std::min<mfxU32>(ctrl->NumRefIdxL0Active, numActiveRefL0) : numActiveRefL0;
                     ReorderRefPicList(list0, dpb, *ctrl, numActiveRefL0Final);
                 }
             }
@@ -762,12 +762,12 @@ void MfxHwH264Encode::ModifyRefPicLists(
             {
                 if (advCtrl) // advanced ref list control has priority
                 {
-                    numActiveRefL1 = advCtrl->NumRefIdxL1Active ? MFX_MIN(advCtrl->NumRefIdxL1Active,numMaxActiveRefL1) : numActiveRefL1;
+                    numActiveRefL1 = advCtrl->NumRefIdxL1Active ? std::min<mfxU32>(advCtrl->NumRefIdxL1Active,numMaxActiveRefL1) : numActiveRefL1;
                     ReorderRefPicList(list1, dpb, (mfxRefPic*)(&advCtrl->RefPicList1[0]), numActiveRefL1);
                 }
                 else
                 {
-                    numActiveRefL1 = ctrl->NumRefIdxL1Active ? MFX_MIN(ctrl->NumRefIdxL1Active,numMaxActiveRefL1) : numActiveRefL1;
+                    numActiveRefL1 = ctrl->NumRefIdxL1Active ? std::min<mfxU32>(ctrl->NumRefIdxL1Active,numMaxActiveRefL1) : numActiveRefL1;
                     ReorderRefPicList(list1, dpb, *ctrl, numActiveRefL1);
                 }
             }
@@ -876,8 +876,8 @@ void MfxHwH264Encode::ModifyRefPicLists(
 
                 if (video.calcParam.tempScalabilityMode)
                 { // cut lists to 1 element for tempScalabilityMode
-                    list0.Resize(MFX_MIN(list0.Size(), 1));
-                    list1.Resize(MFX_MIN(list1.Size(), 1));
+                    list0.Resize(std::min(list0.Size(), 1u));
+                    list1.Resize(std::min(list1.Size(), 1u));
                 }
             }
             else if (extOpt2.BRefType == MFX_B_REF_PYRAMID && (task.m_type[0] & MFX_FRAMETYPE_P))
@@ -2158,7 +2158,7 @@ void MfxHwH264Encode::ConfigureTask(
     }
     else
     {
-        task.m_ctrl.SkipFrame = MFX_MIN(0xFF, task.m_ctrl.SkipFrame);
+        task.m_ctrl.SkipFrame = std::min<mfxU16>(0xFF, task.m_ctrl.SkipFrame);
     }
 
     task.m_reference[ffid]  = !!(task.m_type[ffid] & MFX_FRAMETYPE_REF);
@@ -2352,7 +2352,7 @@ void MfxHwH264Encode::ConfigureTask(
 #if defined(MFX_ENABLE_MFE)
     //if previous frame finished later than current submitted(e.g. reordering or async) - use sync-sync time for counting timeout for better performance
     //otherwise if current frame submitted later than previous finished - use submit->sync time for better performance handling
-    task.m_beginTime = MFX_MAX(task.m_beginTime, prevTask.m_endTime);
+    task.m_beginTime = std::max(task.m_beginTime, prevTask.m_endTime);
 #endif
     const mfxExtCodingOption2* extOpt2Cur = (extOpt2Runtime ? extOpt2Runtime : &extOpt2);
 
@@ -2868,7 +2868,7 @@ namespace FadeDetectionHistLSE
         AveSampleDiff = AveSampleDiff > 0 ? ((AveSampleDiff + numSegments / 2) / numSegments) : -((abs(AveSampleDiff) + numSegments / 2) / numSegments);
         CheckRange = y[numSegments - 1] - y[0];
 
-        Weight = mfxI16(((sxy - ((sx * sy + numSegments / 2) / numSegments)) << logWDc) / MFX_MAX(1, (sxx - ((sx * sx + numSegments / 2) / numSegments))));
+        Weight = mfxI16(((sxy - ((sx * sy + numSegments / 2) / numSegments)) << logWDc) / std::max(1, (sxx - ((sx * sx + numSegments / 2) / numSegments))));
         Offset = mfxI16(sy - ((Weight * sx + rounding) >> logWDc));
         Offset = (Offset + (Offset > 0 ? numSegments / 2 : -numSegments / 2)) / numSegments;
 
@@ -2882,7 +2882,7 @@ namespace FadeDetectionHistLSE
         }
         else
         {
-            mfxI16 Weight1 = mfxI16(((sxy - ((sx * sy + numSegments / 2) / numSegments)) << logWDc) / MFX_MAX(1, (syy - ((sy * sy + numSegments / 2) / numSegments))));
+            mfxI16 Weight1 = mfxI16(((sxy - ((sx * sy + numSegments / 2) / numSegments)) << logWDc) / std::max(1, (syy - ((sy * sy + numSegments / 2) / numSegments))));
             mfxI16 Offset1 = mfxI16(sx - ((Weight1 * sy + rounding) >> logWDc));
             Offset1 = (Offset1 + (Offset1 > 0 ? numSegments / 2 : -numSegments / 2)) / numSegments;
 
@@ -2938,7 +2938,7 @@ namespace FadeDetectionHistLSE
         {
             mfxI16 transformedClosedPixel = (((x[i] * Weight + rounding) >> logWDc) + Offset);
 
-            transformedClosedPixel = MFX_MAX(0, MFX_MIN(range - 1, transformedClosedPixel));
+            transformedClosedPixel = mfx::clamp<mfxI16>(transformedClosedPixel, 0, range - 1);
 
             if (i < numClosedPixels)
             {
@@ -2967,7 +2967,7 @@ namespace FadeDetectionHistLSE
             || ((CheckRange > 35) && Weight != (1 << logWDc) && abs(AveSampleDiff) <= 1 && VarSampleDiff == 0)
             || ((CheckRange > 25) && abs(RefPeakPos - CurPeakPos) <= 1 && abs(TransformedPeakPos - CurPeakPos) > abs(RefPeakPos - CurPeakPos) + 2)
             || (numClosedPixels >= (numSegments / 2) && (CheckRange > 35) && (transformedClosedPixelsDiff - sumClosedPixelsDiff > 2 || transformMaxDiff >= 2))
-            || (Weight == (1 << logWDc) && ((abs(AveSampleDiff) <= 2 && AveDiff > 1) || (AveDiff * AveDiff) > MFX_MAX(1, VarSampleDiff / 2)))
+            || (Weight == (1 << logWDc) && ((abs(AveSampleDiff) <= 2 && AveDiff > 1) || (AveDiff * AveDiff) > std::max(1u, VarSampleDiff / 2)))
             || (Weight != (1 << logWDc) && (maxdiff > 3 * abs(AveSampleDiff) || sumdiff >= 8 * abs(AveSampleDiff))))
         {
             pwt.LumaWeightFlag[list][idx] = 0;

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1108,8 +1108,8 @@ void FillPWT(
 
             slice[i].direct_spatial_mv_pred_flag = 1;
 
-            slice[i].num_ref_idx_l0_active_minus1 = mfxU8(MFX_MAX(1, task.m_list0[fieldId].Size()) - 1);
-            slice[i].num_ref_idx_l1_active_minus1 = mfxU8(MFX_MAX(1, task.m_list1[fieldId].Size()) - 1);
+            slice[i].num_ref_idx_l0_active_minus1 = std::max<mfxU8>(1, task.m_list0[fieldId].Size()) - 1;
+            slice[i].num_ref_idx_l1_active_minus1 = std::max<mfxU8>(1, task.m_list1[fieldId].Size()) - 1;
             slice[i].num_ref_idx_active_override_flag   =
                         slice[i].num_ref_idx_l0_active_minus1 != pps.num_ref_idx_l0_active_minus1 ||
                         slice[i].num_ref_idx_l1_active_minus1 != pps.num_ref_idx_l1_active_minus1;
@@ -1211,8 +1211,8 @@ void UpdateSliceSizeLimited(
 
         slice[i].direct_spatial_mv_pred_flag = 1;
 
-        slice[i].num_ref_idx_l0_active_minus1 = mfxU8(MFX_MAX(1, task.m_list0[fieldId].Size()) - 1);
-        slice[i].num_ref_idx_l1_active_minus1 = mfxU8(MFX_MAX(1, task.m_list1[fieldId].Size()) - 1);
+        slice[i].num_ref_idx_l0_active_minus1 = std::max<mfxU8>(1, task.m_list0[fieldId].Size()) - 1;
+        slice[i].num_ref_idx_l1_active_minus1 = std::max<mfxU8>(1, task.m_list1[fieldId].Size()) - 1;
         slice[i].num_ref_idx_active_override_flag   =
                     slice[i].num_ref_idx_l0_active_minus1 != pps.num_ref_idx_l0_active_minus1 ||
                     slice[i].num_ref_idx_l1_active_minus1 != pps.num_ref_idx_l1_active_minus1;


### PR DESCRIPTION
Replaced with std::min/max