### PR TITLE
HEVCd: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -55,7 +55,7 @@ mfxU32 CalculateNumThread(mfxVideoParam *par, eMFXPlatform platform)
     if (!par->AsyncDepth)
         return numThread;
 
-    return MFX_MIN(par->AsyncDepth, numThread);
+    return std::min<mfxU32>(par->AsyncDepth, numThread);
 }
 
 inline
@@ -323,7 +323,7 @@ mfxStatus VideoDECODEH265::Init(mfxVideoParam *par)
     UMC::VideoDecoderParams umcVideoParams;
     ConvertMFXParamsToUMC(&m_vFirstPar, &umcVideoParams);
     umcVideoParams.numThreads = m_vPar.mfx.NumThread;
-    umcVideoParams.info.bitrate = MFX_MAX(asyncDepth - umcVideoParams.numThreads, 0); // buffered frames
+    umcVideoParams.info.bitrate = asyncDepth - umcVideoParams.numThreads; // buffered frames
 
     if (MFX_PLATFORM_SOFTWARE != m_platform)
     {

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
@@ -396,7 +396,7 @@ void H265HeadersBitstream::xDecodeScalingList(H265ScalingList *scalingList, unsi
 {
     VM_ASSERT(scalingList);
 
-    int32_t i,coefNum = MFX_MIN(MAX_MATRIX_COEF_NUM,(int32_t)g_scalingListSize[sizeId]);
+    int32_t i,coefNum = std::min(MAX_MATRIX_COEF_NUM,(int32_t)g_scalingListSize[sizeId]);
     int32_t nextCoef = SCALING_LIST_START_VALUE;
     const uint16_t *scan  = (sizeId == 0) ? ScanTableDiag4x4 : g_sigLastScanCG32x32;
     int32_t *dst = scalingList->getScalingListAddress(sizeId, listId);
@@ -728,7 +728,7 @@ UMC::Status H265HeadersBitstream::GetSequenceParamSet(H265SeqParamSet *pcSPS)
     pcSPS->m_maxTrSize = 1 << pcSPS->log2_max_transform_block_size;
 
     uint32_t CtbLog2SizeY = pcSPS->log2_max_luma_coding_block_size;
-    if (pcSPS->log2_max_transform_block_size > MFX_MIN(5, CtbLog2SizeY))
+    if (pcSPS->log2_max_transform_block_size > std::min(5u, CtbLog2SizeY))
         throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
 
     pcSPS->max_transform_hierarchy_depth_inter = GetVLCElementU();
@@ -775,12 +775,12 @@ UMC::Status H265HeadersBitstream::GetSequenceParamSet(H265SeqParamSet *pcSPS)
 
         pcSPS->log2_min_pcm_luma_coding_block_size = GetVLCElementU() + 3;
 
-        if (pcSPS->log2_min_pcm_luma_coding_block_size < MFX_MIN(MinCbLog2SizeY, 5) || pcSPS->log2_min_pcm_luma_coding_block_size > MFX_MIN(CtbLog2SizeY, 5))
+        if (pcSPS->log2_min_pcm_luma_coding_block_size < std::min(MinCbLog2SizeY, 5u) || pcSPS->log2_min_pcm_luma_coding_block_size > std::min(CtbLog2SizeY, 5u))
             throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
 
         pcSPS->log2_max_pcm_luma_coding_block_size = GetVLCElementU() + pcSPS->log2_min_pcm_luma_coding_block_size;
 
-        if (pcSPS->log2_max_pcm_luma_coding_block_size > MFX_MIN(CtbLog2SizeY, 5))
+        if (pcSPS->log2_max_pcm_luma_coding_block_size > std::min(CtbLog2SizeY, 5u))
             throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
 
         pcSPS->pcm_loop_filter_disabled_flag = Get1Bit();

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -241,7 +241,7 @@ mfxU32 CalculateFourcc(mfxU16 codecProfile, mfxFrameInfo const* frameInfo)
         return 0;
 
     mfxU16 bit_depth =
-       MFX_MAX(frameInfo->BitDepthLuma, frameInfo->BitDepthChroma);
+       std::max(frameInfo->BitDepthLuma, frameInfo->BitDepthChroma);
 
     //map chroma fmt & bit depth onto fourcc (NOTE: we currently don't support bit depth above 10 bit)
     mfxU32 const map[][4] =

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_nal_spl.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_nal_spl.cpp
@@ -325,7 +325,7 @@ private:
 
             if (zeroCount >= 2 && pb[0] == 1)
             {
-                startCodeSize = MFX_MIN(zeroCount + 1, 4);
+                startCodeSize = std::min(zeroCount + 1, 4u);
                 size -= i + 1;
                 pb++; // remove 0x01 symbol
                 if (size >= 1)
@@ -358,7 +358,7 @@ private:
             }
         }
 
-        zeroCount = MFX_MIN(zeroCount, 3);
+        zeroCount = std::min(zeroCount, 3u);
         pb -= zeroCount;
         size = zeroCount;
         startCodeSize = zeroCount;
@@ -386,7 +386,7 @@ public:
                     pRemovedOffsets);
 
         VM_ASSERT(pMemDst->GetSize() >= dstSize);
-        size_t tail_size = MFX_MIN(pMemDst->GetSize() - dstSize, DEFAULT_NU_TAIL_SIZE);
+        size_t tail_size = std::min<size_t>(pMemDst->GetSize() - dstSize, DEFAULT_NU_TAIL_SIZE);
         memset(pMemDst->GetPointer() + dstSize, DEFAULT_NU_TAIL_VALUE, tail_size);
         pMemDst->SetDataSize(dstSize);
         pMemDst->SetTime(pMemSrc->GetTime());
@@ -597,7 +597,7 @@ void SwapMemoryAndRemovePreventingBytes_H265(void *pDestination, size_t &nDstSiz
 
     // first two bytes
     i = 0;
-    while (i < (uint32_t) MFX_MIN(2, nSrcSize))
+    while (i < std::min<uint32_t>(2, nSrcSize))
     {
         pDst = (uint8_t) pSrc;
         ++pDst;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_scaling_list.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_scaling_list.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -89,13 +89,13 @@ void H265ScalingList::calculateDequantCoef(void)
             {
                 uint32_t width = g_scalingListSizeX[sizeId];
                 uint32_t height = g_scalingListSizeX[sizeId];
-                uint32_t ratio = g_scalingListSizeX[sizeId] / MFX_MIN(MAX_MATRIX_SIZE_NUM, (int32_t)g_scalingListSizeX[sizeId]);
+                uint32_t ratio = g_scalingListSizeX[sizeId] / std::min(MAX_MATRIX_SIZE_NUM, (int32_t)g_scalingListSizeX[sizeId]);
                 int16_t *dequantcoeff;
                 int32_t *coeff = getScalingListAddress(sizeId, listId);
 
                 dequantcoeff = getDequantCoeff(listId, qp, sizeId);
                 processScalingListDec(coeff, dequantcoeff, g_invQuantScales[qp], height, width, ratio,
-                    MFX_MIN(MAX_MATRIX_SIZE_NUM, (int32_t)g_scalingListSizeX[sizeId]), getScalingListDC(sizeId, listId));
+                    std::min(MAX_MATRIX_SIZE_NUM, (int32_t)g_scalingListSizeX[sizeId]), getScalingListDC(sizeId, listId));
             }
         }
     }
@@ -114,7 +114,7 @@ void H265ScalingList::initFromDefaultScalingList()
         {
             MFX_INTERNAL_CPY(getScalingListAddress(sizeId, listId),
                 getScalingListDefaultAddress(sizeId, listId),
-                sizeof(int32_t) * MFX_MIN(MAX_MATRIX_COEF_NUM, (int32_t)g_scalingListSize[sizeId]));
+                sizeof(int32_t) * std::min(MAX_MATRIX_COEF_NUM, (int32_t)g_scalingListSize[sizeId]));
             setScalingListDC(sizeId, listId, SCALING_LIST_DC);
         }
     }
@@ -139,9 +139,9 @@ void H265ScalingList::processScalingListDec(int32_t *coeff, int16_t *dequantcoef
 }
 
 // Returns default scaling matrix for specified parameters
-const int* H265ScalingList::getScalingListDefaultAddress(unsigned sizeId, unsigned listId)
+const int32_t* H265ScalingList::getScalingListDefaultAddress(unsigned sizeId, unsigned listId)
 {
-    const int *src = 0;
+    const int32_t *src = 0;
     switch(sizeId)
     {
     case SCALING_LIST_4x4:
@@ -169,7 +169,7 @@ void H265ScalingList::processRefMatrix(unsigned sizeId, unsigned listId , unsign
 {
   MFX_INTERNAL_CPY(getScalingListAddress(sizeId, listId),
       ((listId == refListId) ? getScalingListDefaultAddress(sizeId, refListId) : getScalingListAddress(sizeId, refListId)),
-      sizeof(int)*MFX_MIN(MAX_MATRIX_COEF_NUM, (int)g_scalingListSize[sizeId]));
+      sizeof(int32_t)*std::min(MAX_MATRIX_COEF_NUM, (int32_t)g_scalingListSize[sizeId]));
 }
 
 } // end namespace UMC_HEVC_DECODER

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1454,7 +1454,7 @@ void TaskSupplier_H265::PostProcessDisplayFrame(H265DecoderFrame *pFrame)
 
     DEBUG_PRINT((VM_STRING("Outputted %s, pppp - %d\n"), GetFrameInfoString(pFrame), pppp++));
 
-    m_maxUIDWhenWasDisplayed = MFX_MAX(m_maxUIDWhenWasDisplayed, pFrame->m_maxUIDWhenWasDisplayed);
+    m_maxUIDWhenWasDisplayed = std::max(m_maxUIDWhenWasDisplayed, pFrame->m_maxUIDWhenWasDisplayed);
 }
 
 // Find a next frame ready to be output from decoder
@@ -2109,7 +2109,7 @@ void TaskSupplier_H265::CheckCRAOrBLA(const H265Slice *pSlice)
         {
             if (pCurr->isDisplayable() && !pCurr->wasOutputted())
             {
-                minRefPicResetCount = MFX_MIN(minRefPicResetCount, pCurr->RefPicListResetCount());
+                minRefPicResetCount = std::min(minRefPicResetCount, pCurr->RefPicListResetCount());
             }
         }
 
@@ -2362,7 +2362,7 @@ UMC::Status TaskSupplier_H265::InitFreeFrame(H265DecoderFrame * pFrame, const H2
     bit_depth_luma = (uint8_t) pSeqParam->bit_depth_luma;
     bit_depth_chroma = (uint8_t) pSeqParam->bit_depth_chroma;
 
-    int32_t bit_depth = MFX_MAX(bit_depth_luma, bit_depth_chroma);
+    int32_t bit_depth = std::max(bit_depth_luma, bit_depth_chroma);
 
 //    int32_t iMBWidth = pSeqParam->frame_width_in_mbs;
     //int32_t iCUWidth = pSeqParam->WidthInCU;
@@ -2431,7 +2431,7 @@ H265DecoderFrame * TaskSupplier_H265::AllocateNewFrame(const H265Slice *pSlice)
                                     pSlice->GetSeqParam()->sps_max_dec_pic_buffering[pSlice->GetSliceHeader()->nuh_temporal_id] :
                                     view.dpbSize;
 
-    view.sps_max_num_reorder_pics = MFX_MIN(pSlice->GetSeqParam()->sps_max_num_reorder_pics[HighestTid], view.sps_max_dec_pic_buffering);
+    view.sps_max_num_reorder_pics = std::min(pSlice->GetSeqParam()->sps_max_num_reorder_pics[HighestTid], view.sps_max_dec_pic_buffering);
 
     DPBUpdate(pSlice);
 
@@ -2632,11 +2632,11 @@ int32_t CalculateDPBSize(uint32_t /*profile_idc*/, uint32_t &level_idc, int32_t 
         uint32_t PicSizeInSamplesY = width * height;
 
         if (PicSizeInSamplesY  <=  (MaxLumaPs  >>  2 ))
-            MaxDpbSize = MFX_MIN(4 * maxDpbPicBuf, 16);
+            MaxDpbSize = std::min(4 * maxDpbPicBuf, 16u);
         else if (PicSizeInSamplesY  <=  (MaxLumaPs  >>  1 ))
-            MaxDpbSize = MFX_MIN(2 * maxDpbPicBuf, 16);
+            MaxDpbSize = std::min(2 * maxDpbPicBuf, 16u);
         else if (PicSizeInSamplesY  <=  ((3 * MaxLumaPs)  >>  2 ))
-            MaxDpbSize = MFX_MIN((4 * maxDpbPicBuf) / 3, 16);
+            MaxDpbSize = std::min((4 * maxDpbPicBuf) / 3, 16u);
         else
             MaxDpbSize = maxDpbPicBuf;
 

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer.cpp
@@ -282,11 +282,8 @@ void PackerVA::PackPicParams(const H265DecoderFrame *pCurrentFrame, TaskSupplier
 
     if (pPicParamSet->tiles_enabled_flag)
     {
-        picParam->num_tile_columns_minus1 = (uint8_t)(pPicParamSet->num_tile_columns - 1);
-        picParam->num_tile_rows_minus1 = (uint8_t)(pPicParamSet->num_tile_rows - 1);
-
-        picParam->num_tile_columns_minus1 = MFX_MIN(sizeof(picParam->column_width_minus1)/sizeof(picParam->column_width_minus1[0]) - 1, picParam->num_tile_columns_minus1);
-        picParam->num_tile_rows_minus1 = MFX_MIN(sizeof(picParam->row_height_minus1)/sizeof(picParam->row_height_minus1[0]) - 1, picParam->num_tile_rows_minus1);
+        picParam->num_tile_columns_minus1 = std::min<uint8_t>(sizeof(picParam->column_width_minus1)/sizeof(picParam->column_width_minus1[0]) - 1, pPicParamSet->num_tile_columns - 1);
+        picParam->num_tile_rows_minus1    = std::min<uint8_t>(sizeof(picParam->row_height_minus1)  /sizeof(picParam->row_height_minus1[0])   - 1, pPicParamSet->num_tile_rows    - 1);
 
         for (uint32_t i = 0; i <= picParam->num_tile_columns_minus1; i++)
             picParam->column_width_minus1[i] = (uint16_t)(pPicParamSet->column_width[i] - 1);
@@ -689,7 +686,7 @@ void PackerVA::PackQmatrix(const H265Slice *pSlice)
                 {
                     const int *src = getDefaultScalingList(sizeId, listId);
                           int *dst = sl.getScalingListAddress(sizeId, listId);
-                    int count = MFX_MIN(MAX_MATRIX_COEF_NUM, (int32_t)g_scalingListSize[sizeId]);
+                    int count = std::min(MAX_MATRIX_COEF_NUM, (int32_t)g_scalingListSize[sizeId]);
                     ::MFX_INTERNAL_CPY(dst, src, sizeof(int32_t) * count);
                     sl.setScalingListDC(sizeId, listId, SCALING_LIST_DC);
                 }

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -174,7 +174,7 @@ UMC::Status VATaskSupplier::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize
 H265Slice * VATaskSupplier::DecodeSliceHeader(UMC::MediaDataEx *nalUnit)
 {
     size_t dataSize = nalUnit->GetDataSize();
-    nalUnit->SetDataSize(MFX_MIN(1024, dataSize));
+    nalUnit->SetDataSize(std::min<size_t>(1024, dataSize));
 
     H265Slice * slice = TaskSupplier_H265::DecodeSliceHeader(nalUnit);
 


### PR DESCRIPTION
Replaced with std::min/max