### PR TITLE
mpeg2e: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
@@ -1883,7 +1883,7 @@ namespace MPEG2EncoderHW
             sts = ConvertVideoParam_Brc(par, &brcParams);
             MFX_CHECK_STS(sts);
             if (brcParams.HRDBufferSizeBytes == 0)
-                brcParams.HRDBufferSizeBytes = MFX_MIN(65535000, brcParams.targetBitrate / 4); // limit buffer size with 2 seconds
+                brcParams.HRDBufferSizeBytes = std::min(65535000, brcParams.targetBitrate / 4); // limit buffer size with 2 seconds
             if (brcParams.maxBitrate == 0)
                 brcParams.maxBitrate = brcParams.targetBitrate;
 
@@ -1922,13 +1922,11 @@ namespace MPEG2EncoderHW
             m_bufferSizeInKB = (mfxU32)(brcParams.HRDBufferSizeBytes / 1000);
             m_InputBitsPerFrame = (mfxI32)(brcParams.targetBitrate / brcParams.info.framerate);
 
-            mfxU32 maxVal32 = MFX_MAX(
-                MFX_MAX(
-                (mfxU32)brcParams.HRDInitialDelayBytes / 1000,
-                (mfxU32)brcParams.HRDBufferSizeBytes / 1000),
-                MFX_MAX(
-                (mfxU32)brcParams.targetBitrate / 1000,
-                (mfxU32)brcParams.maxBitrate / 1000));
+            mfxU32 maxVal32 = std::max<mfxU32>({
+                mfxU32(brcParams.HRDInitialDelayBytes / 1000),
+                mfxU32(brcParams.HRDBufferSizeBytes   / 1000),
+                mfxU32(brcParams.targetBitrate        / 1000),
+                mfxU32(brcParams.maxBitrate           / 1000)});
 
             par->mfx.BRCParamMultiplier = (mfxU16)((maxVal32 + 0x10000) / 0x10000);
             par->mfx.BufferSizeInKB     = (mfxU16)(m_bufferSizeInKB                      / par->mfx.BRCParamMultiplier);

--- a/_studio/mfx_lib/shared/include/mfx_mpeg2_enc_common.h
+++ b/_studio/mfx_lib/shared/include/mfx_mpeg2_enc_common.h
@@ -363,7 +363,7 @@ protected:
 
         _GetBits (8,temp); // vbv_buffer_size_ext
         vbv_buffer_size |= (temp << 10);
-        par->mfx.BufferSizeInKB = mfxU16(MFX_MIN(0xffff, 2 * vbv_buffer_size));
+        par->mfx.BufferSizeInKB = mfxU16(std::min<mfxU32>(0xffff, 2 * vbv_buffer_size));
 
         _GetBits (1,temp); //low delay
         if (temp == 1)

--- a/_studio/mfx_lib/shared/src/mfx_mpeg2_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_mpeg2_enc_common_hw.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -186,7 +186,7 @@ mfxStatus ExecuteBuffers::Init(const mfxVideoParamEx_MPEG2* par, mfxU32 funcId, 
         m_sps.FrameRateExtD = (USHORT) fr_codeD;
         m_sps.FrameRateExtN = (USHORT) fr_codeN;
 
-        mfxU32 multiplier = MFX_MAX(par->mfxVideoParams.mfx.BRCParamMultiplier, 1);
+        mfxU32 multiplier = std::max<mfxU32>(par->mfxVideoParams.mfx.BRCParamMultiplier, 1);
 
         m_sps.bit_rate = (par->mfxVideoParams.mfx.RateControlMethod != MFX_RATECONTROL_CQP) ?
                                                             par->mfxVideoParams.mfx.TargetKbps * multiplier : 0;

--- a/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
@@ -597,13 +597,13 @@ mfxStatus VAAPIEncoder::QueryCompBufferInfo(D3DDDIFORMAT type, mfxFrameAllocRequ
 {
     if (type == D3DDDIFMT_INTELENCODE_MBDATA)
     {
-        pRequest->Info.Width = MFX_MAX(pRequest->Info.Width, pExecuteBuffers->m_sps.FrameWidth);
-        pRequest->Info.Height = MFX_MAX(pRequest->Info.Height, pExecuteBuffers->m_sps.FrameHeight);
+        pRequest->Info.Width  = std::max(pRequest->Info.Width,  pExecuteBuffers->m_sps.FrameWidth);
+        pRequest->Info.Height = std::max(pRequest->Info.Height, pExecuteBuffers->m_sps.FrameHeight);
     }
     else if (type == D3DDDIFMT_INTELENCODE_BITSTREAMDATA)
     {
-        pRequest->Info.Width = MFX_MAX(pRequest->Info.Width, pExecuteBuffers->m_sps.FrameWidth);
-        pRequest->Info.Height = MFX_MAX(pRequest->Info.Height, pExecuteBuffers->m_sps.FrameHeight);
+        pRequest->Info.Width  = std::max(pRequest->Info.Width,  pExecuteBuffers->m_sps.FrameWidth);
+        pRequest->Info.Height = std::max(pRequest->Info.Height, pExecuteBuffers->m_sps.FrameHeight);
     }
     else
     {
@@ -943,7 +943,7 @@ mfxStatus VAAPIEncoder::FillUserDataBuffer(mfxU8 *pUserData, mfxU32 userDataLen)
     VAEncPackedHeaderParameterBuffer packedParamsBuffer = {};
     packedParamsBuffer.type = VAEncPackedHeaderRawData;
     packedParamsBuffer.has_emulation_bytes = false;
-    mfxU32 correctedLength = MFX_MIN(userDataLen, UINT_MAX/8); // keep start code
+    mfxU32 correctedLength = std::min(userDataLen, UINT_MAX/8); // keep start code
     packedParamsBuffer.bit_length = correctedLength * 8;
 
     mfxStatus sts = CheckAndDestroyVAbuffer(m_vaDisplay, m_packedUserDataParamsId);

--- a/_studio/shared/umc/codec/brc/src/umc_mpeg2_brc.cpp
+++ b/_studio/shared/umc/codec/brc/src/umc_mpeg2_brc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -706,9 +706,9 @@ Status MPEG2BRC::PreEncFrameFallBack(FrameType frameType, int32_t recode)
     q2--;
 
   if (rc_dev > 0) {
-    q2 = MFX_MAX(q0,q2);
+    q2 = std::max(q0,q2);
   } else {
-    q2 = MFX_MIN(q0,q2);
+    q2 = std::min(q0,q2);
   }
   // this call is used to accept small changes in value, which are mapped to the same code
   // changeQuant bothers about changing scale code if value changes


### PR DESCRIPTION
Replaced with std::min/max