### PR TITLE
[sample_encode] Change membuf functionality

### DIFF
--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -161,7 +161,7 @@ struct sInputParams
     bool bSoftRobustFlag;
 
     mfxU32 nTimeout;
-    mfxU16 nMemBuf;
+    mfxU16 nPerfOpt; // size of pre-load buffer which used for loop encode
 
     mfxU16 nNumSlice;
     bool UseRegionEncode;
@@ -320,7 +320,7 @@ protected:
     MFXFrameAllocator* m_pMFXAllocator;
     mfxAllocatorParams* m_pmfxAllocatorParams;
     MemType m_memType;
-    mfxU16 m_nMemBuffer;
+    mfxU16 m_nPerfOpt; // size of pre-load buffer which used for loop encode
     bool m_bExternalAlloc; // use memory allocator as external for Media SDK
 
     mfxFrameSurface1* m_pEncSurfaces; // frames array for encoder input (vpp output)

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -882,7 +882,7 @@ mfxStatus CEncodingPipeline::AllocFrames()
 
     if (!m_pmfxVPP)
     {
-        EncRequest.NumFrameMin = EncRequest.NumFrameSuggested = MSDK_MAX(EncRequest.NumFrameSuggested, m_nMemBuffer);
+        EncRequest.NumFrameMin = EncRequest.NumFrameSuggested = MSDK_MAX(EncRequest.NumFrameSuggested, m_nPerfOpt);
     }
 
     if (EncRequest.NumFrameSuggested < m_mfxEncParams.AsyncDepth)
@@ -901,7 +901,7 @@ mfxStatus CEncodingPipeline::AllocFrames()
         sts = m_pmfxVPP->QueryIOSurf(&m_mfxVppParams, VppRequest);
         MSDK_CHECK_STATUS(sts, "m_pmfxVPP->QueryIOSurf failed");
 
-        VppRequest[0].NumFrameMin = VppRequest[0].NumFrameSuggested = MSDK_MAX(VppRequest[0].NumFrameSuggested, m_nMemBuffer);
+        VppRequest[0].NumFrameMin = VppRequest[0].NumFrameSuggested = MSDK_MAX(VppRequest[0].NumFrameSuggested, m_nPerfOpt);
         // The number of surfaces for vpp input - so that vpp can work at async depth = m_nAsyncDepth
         nVppSurfNum = VppRequest[0].NumFrameSuggested;
         // If surfaces are shared by 2 components, c1 and c2. NumSurf = c1_out + c2_in - AsyncDepth + 1
@@ -1157,7 +1157,7 @@ CEncodingPipeline::CEncodingPipeline()
     m_pVppSurfaces = NULL;
     m_InputFourCC = 0;
 
-    m_nMemBuffer = 0;
+    m_nPerfOpt = 0;
     m_nTimeout = 0;
 
     m_nFramesRead = 0;
@@ -1616,7 +1616,7 @@ mfxStatus CEncodingPipeline::Init(sInputParams *pParams)
 
     // set memory type
     m_memType = pParams->memType;
-    m_nMemBuffer = pParams->nMemBuf;
+    m_nPerfOpt = pParams->nPerfOpt;
 
     m_bSoftRobustFlag = pParams->bSoftRobustFlag;
 
@@ -1817,9 +1817,9 @@ void CEncodingPipeline::FreeFileWriters()
 
 mfxStatus CEncodingPipeline::FillBuffers()
 {
-    if (m_nMemBuffer)
+    if (m_nPerfOpt)
     {
-        for (mfxU32 i = 0; i < m_nMemBuffer; i++)
+        for (mfxU32 i = 0; i < m_nPerfOpt; i++)
         {
             mfxFrameSurface1* surface = m_pmfxVPP ? &m_pVppSurfaces[i] : &m_pEncSurfaces[i];
 
@@ -2048,9 +2048,9 @@ mfxStatus CEncodingPipeline::Run()
         MSDK_BREAK_ON_ERROR(sts);
 
         // find free surface for encoder input
-        if (m_nMemBuffer && !m_pmfxVPP)
+        if (m_nPerfOpt && !m_pmfxVPP)
         {
-            nEncSurfIdx %= m_nMemBuffer;
+            nEncSurfIdx %= m_nPerfOpt;
         }
         else
         {
@@ -2073,9 +2073,9 @@ mfxStatus CEncodingPipeline::Run()
                         nVppSurfIdx = v4l2Pipeline.GetOffQ();
                     }
 #else
-                    if (m_nMemBuffer)
+                    if (m_nPerfOpt)
                     {
-                        nVppSurfIdx = nVppSurfIdx % m_nMemBuffer;
+                        nVppSurfIdx = nVppSurfIdx % m_nPerfOpt;
                     }
                     else
                     {
@@ -2115,7 +2115,7 @@ mfxStatus CEncodingPipeline::Run()
                                                   &m_pEncSurfaces[nEncSurfIdx],
                     NULL, &VppSyncPoint);
 
-                if (m_nMemBuffer)
+                if (m_nPerfOpt)
                 {
                    // increment buffer index
                    nVppSurfIdx++;
@@ -2170,7 +2170,7 @@ mfxStatus CEncodingPipeline::Run()
             sts = m_pmfxENC->EncodeFrameAsync(&pCurrentTask->encCtrl, &m_pEncSurfaces[nEncSurfIdx], &pCurrentTask->mfxBS, &pCurrentTask->EncSyncP);
 
 
-            if (m_nMemBuffer)
+            if (m_nPerfOpt)
             {
                 // increment buffer index
                 nEncSurfIdx++;
@@ -2369,18 +2369,18 @@ mfxStatus CEncodingPipeline::LoadNextFrame(mfxFrameSurface1* pSurf)
 
     m_bTimeOutExceed = (m_nTimeout < m_statOverall.GetDeltaTime()) ? true : false;
 
-    if (m_nMemBuffer)
+    if (m_nPerfOpt)
     {
-        // memoty buffer mode. No file reading required
-        bool bMemBufExceed = !(m_nFramesRead % m_nMemBuffer) && m_nFramesRead;
-        if (m_bTimeOutExceed && bMemBufExceed )
+        // memory buffer mode. No file reading required
+        bool bPerfOptExceed = !(m_nFramesRead % m_nPerfOpt) && m_nFramesRead;
+        if (m_nPerfOpt == m_nFramesRead && m_nFramesToProcess == 0)
         {
             sts = MFX_ERR_MORE_DATA;
-        }
-        else if (bMemBufExceed)
-        {
-            // Rewrite outupt file and insert idr frame
             m_bFileWriterReset = m_bCutOutput;
+        }
+        else if (bPerfOptExceed)
+        {
+            // insert idr frame
             m_bInsertIDR = m_bCutOutput;
         }
     }

--- a/samples/sample_encode/src/pipeline_region_encode.cpp
+++ b/samples/sample_encode/src/pipeline_region_encode.cpp
@@ -401,7 +401,7 @@ mfxStatus CRegionEncodingPipeline::Init(sInputParams *pParams)
 
     // set memory type
     m_memType = pParams->memType;
-    m_nMemBuffer = pParams->nMemBuf;
+    m_nPerfOpt = pParams->nPerfOpt;
     m_nTimeout = pParams->nTimeout;
 
     // If output isn't specified work in performance mode and do not insert idr
@@ -531,9 +531,9 @@ mfxStatus CRegionEncodingPipeline::Run()
     while (MFX_ERR_NONE <= sts || MFX_ERR_MORE_DATA == sts)
     {
         // find free surface for encoder input
-        if (m_nMemBuffer)
+        if (m_nPerfOpt)
         {
-            nEncSurfIdx %= m_nMemBuffer;
+            nEncSurfIdx %= m_nPerfOpt;
         }
         else
         {
@@ -588,7 +588,7 @@ mfxStatus CRegionEncodingPipeline::Run()
                 sts = m_resources[regId].pEncoder->EncodeFrameAsync(&pCurrentTask->encCtrl, &m_pEncSurfaces[nEncSurfIdx], &pCurrentTask->mfxBS, &pCurrentTask->EncSyncP);
 
 
-                if ((sts != MFX_ERR_NOT_ENOUGH_BUFFER) && m_nMemBuffer)
+                if ((sts != MFX_ERR_NOT_ENOUGH_BUFFER) && m_nPerfOpt)
                 {
                     nEncSurfIdx++;
                 }

--- a/samples/sample_encode/src/pipeline_user.cpp
+++ b/samples/sample_encode/src/pipeline_user.cpp
@@ -68,7 +68,7 @@ mfxStatus CUserPipeline::AllocFrames()
     nEncSurfNum = EncRequest.NumFrameSuggested;
 
     // The number of surfaces for plugin input - so that plugin can work at async depth = m_nAsyncDepth
-    nRotateSurfNum = MSDK_MAX(m_mfxEncParams.AsyncDepth, m_nMemBuffer);
+    nRotateSurfNum = MSDK_MAX(m_mfxEncParams.AsyncDepth, m_nPerfOpt);
 
     // If surfaces are shared by 2 components, c1 and c2. NumSurf = c1_out + c2_in - AsyncDepth + 1
     nEncSurfNum += nRotateSurfNum - m_mfxEncParams.AsyncDepth + 1;
@@ -185,7 +185,7 @@ mfxStatus CUserPipeline::Init(sInputParams *pParams)
 
     // set memory type
     m_memType = pParams->memType;
-    m_nMemBuffer = pParams->nMemBuf;
+    m_nPerfOpt = pParams->nPerfOpt;
     m_nTimeout = pParams->nTimeout;
     m_bCutOutput = !pParams->bUncut;
 
@@ -334,9 +334,9 @@ mfxStatus CUserPipeline::Run()
         sts = GetFreeTask(&pCurrentTask);
         MSDK_BREAK_ON_ERROR(sts);
 
-        if (m_nMemBuffer)
+        if (m_nPerfOpt)
         {
-            nRotateSurfIdx = m_nFramesRead % m_nMemBuffer;
+            nRotateSurfIdx = m_nFramesRead % m_nPerfOpt;
         }
         else
         {
@@ -476,9 +476,9 @@ mfxStatus CUserPipeline::Run()
 
 mfxStatus CUserPipeline::FillBuffers()
 {
-    if (m_nMemBuffer)
+    if (m_nPerfOpt)
     {
-        for (mfxU32 i = 0; i < m_nMemBuffer; i++)
+        for (mfxU32 i = 0; i < m_nPerfOpt; i++)
         {
             mfxFrameSurface1* surface = &m_pPluginSurfaces[i];
 

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -160,7 +160,7 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-WeightedPred:default|implicit ]   - enables weighted prediction mode\n"));
     msdk_printf(MSDK_STRING("   [-WeightedBiPred:default|implicit ] - enables weighted bi-prediction mode\n"));
     msdk_printf(MSDK_STRING("   [-timeout]               - encoding in cycle not less than specific time in seconds\n"));
-    msdk_printf(MSDK_STRING("   [-membuf]                - size of memory buffer in frames\n"));
+    msdk_printf(MSDK_STRING("   [-perf_opt n]            - sets number of prefetched frames. In performance mode app preallocates buffer and load first n frames\n"));
     msdk_printf(MSDK_STRING("   [-uncut]                 - do not cut output file in looped mode (in case of -timeout option)\n"));
     msdk_printf(MSDK_STRING("   [-dump fileName]         - dump MSDK components configuration to the file in text form\n"));
     msdk_printf(MSDK_STRING("   [-usei]                  - insert user data unregistered SEI. eg: 7fc92488825d11e7bb31be2e44b06b34:0:MSDK (uuid:type<0-preifx/1-suffix>:message)\n"));
@@ -780,13 +780,13 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
                 return MFX_ERR_UNSUPPORTED;
             }
         }
-        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-membuf")))
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-perf_opt")))
         {
             VAL_CHECK(i+1 >= nArgNum, i, strInput[i]);
 
-            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nMemBuf))
+            if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->nPerfOpt))
             {
-                PrintHelp(strInput[0], MSDK_STRING("membuf is invalid"));
+                PrintHelp(strInput[0], MSDK_STRING("perf_opt is invalid"));
                 return MFX_ERR_UNSUPPORTED;
             }
         }


### PR DESCRIPTION
1) Option renamed to perf_opt
2) Preload buffer use until -n frames run out or if -n not specified,
until buffer ends.