### PR TITLE
mjpege: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/encode/mjpeg/src/mfx_mjpeg_encode.cpp
+++ b/_studio/mfx_lib/encode/mjpeg/src/mfx_mjpeg_encode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1948,9 +1948,8 @@ mfxStatus MFXVideoENCODEMJPEG::EncodeFrameCheck(mfxEncodeCtrl *ctrl, mfxFrameSur
             pTask = m_freeTasks.front();
         }
 
-        pEntryPoint->requiredNumThreads = MFX_MIN(pTask->m_pMJPEGVideoEncoder->NumEncodersAllocated(),
-                                                  MFX_MIN(m_vParam.mfx.NumThread,
-                                                          pTask->CalculateNumPieces(pOriginalSurface, &(m_vParam.mfx.FrameInfo))));
+        pEntryPoint->requiredNumThreads = std::min<mfxU32>( { pTask->m_pMJPEGVideoEncoder->NumEncodersAllocated(), m_vParam.mfx.NumThread,
+                                                      pTask->CalculateNumPieces(pOriginalSurface, &(m_vParam.mfx.FrameInfo)) } );
 
         pTask->bs           = bs;
         pTask->ctrl         = ctrl;

--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw.cpp
@@ -516,7 +516,7 @@ mfxStatus MFXVideoENCODEMJPEG_HW::QueryIOSurf(VideoCORE * core, mfxVideoParam *p
             ? MFX_MEMTYPE_OPAQUE_FRAME
             : MFX_MEMTYPE_EXTERNAL_FRAME;
     }
-    request->NumFrameSuggested = MFX_MAX( request->NumFrameMin,par->AsyncDepth);
+    request->NumFrameSuggested = std::max(request->NumFrameMin, par->AsyncDepth);
 
     return MFX_ERR_NONE;
 }
@@ -699,8 +699,8 @@ mfxStatus MFXVideoENCODEMJPEG_HW::Init(mfxVideoParam *par)
             doubleBytesPerPx = 8;
             break;
     }
-    request.Info.Width  = MFX_MAX(request.Info.Width,  m_vParam.mfx.FrameInfo.Width);
-    request.Info.Height = MFX_MAX(request.Info.Height, m_vParam.mfx.FrameInfo.Height * doubleBytesPerPx / 2);
+    request.Info.Width  = std::max        (request.Info.Width,  m_vParam.mfx.FrameInfo.Width);
+    request.Info.Height = std::max<mfxU16>(request.Info.Height, m_vParam.mfx.FrameInfo.Height * doubleBytesPerPx / 2);
 
     sts = m_bitstream.Alloc(m_pCore, request);
     MFX_CHECK(


### PR DESCRIPTION
Replaced with std::min/max