### PR TITLE
vp8e: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -118,7 +118,7 @@ public:
 
     void init(uint8_t *pBitStream, int32_t dataSize)
     {
-        dataSize = MFX_MIN(dataSize, 2);
+        dataSize = std::min(dataSize, 2);
         m_range = 255;
         m_bitcount = 8;
         m_pos = 0;

--- a/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
+++ b/_studio/mfx_lib/decode/vp8/src/mfx_vp8_dec_decode_hw.cpp
@@ -241,7 +241,7 @@ static bool IsSameVideoParam(mfxVideoParam *newPar, mfxVideoParam *oldPar)
     if (newPar->Protected != oldPar->Protected)
         return false;
 
-    int32_t asyncDepth = MFX_MIN(newPar->AsyncDepth, MFX_MAX_ASYNC_DEPTH_VALUE);
+    int32_t asyncDepth = std::min<int32_t>(newPar->AsyncDepth, MFX_MAX_ASYNC_DEPTH_VALUE);
     if (asyncDepth != oldPar->AsyncDepth)
         return false;
 


### PR DESCRIPTION
Replaced with std::min/max