### PR TITLE
vp9e: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -1484,7 +1484,7 @@ mfxStatus CheckParameters(VP9MfxVideoParam &par, ENCODE_CAPS_VP9 const &caps)
     if (rows && height)
     {
         mfxU16 heightInSBs = static_cast<mfxU16>(CeilDiv(height, SB_SIZE));
-        mfxU16 maxPossibleRows = MFX_MIN(heightInSBs, MAX_NUM_TILE_ROWS);
+        mfxU16 maxPossibleRows = std::min<mfxU16>(heightInSBs, MAX_NUM_TILE_ROWS);
         if (rows > maxPossibleRows)
         {
             rows = maxPossibleRows;
@@ -1504,7 +1504,7 @@ mfxStatus CheckParameters(VP9MfxVideoParam &par, ENCODE_CAPS_VP9 const &caps)
     if (cols && width)
     {
         mfxU16 widthInMinTileCols = static_cast<mfxU16>(CeilDiv(width, MIN_TILE_WIDTH));
-        mfxU16 maxPossibleCols = MFX_MIN(widthInMinTileCols, MAX_NUM_TILES);
+        mfxU16 maxPossibleCols = std::min<mfxU16>(widthInMinTileCols, MAX_NUM_TILES);
         if (cols > maxPossibleCols)
         {
             cols = maxPossibleCols;
@@ -1674,7 +1674,7 @@ mfxStatus SetDefaults(
     mfxExtVP9Param& extPar = GetExtBufferRef(par);
     if (extPar.FrameWidth)
     {
-        SetDefault(fi.CropW, MFX_MIN(fi.Width, extPar.FrameWidth));
+        SetDefault(fi.CropW, std::min(fi.Width, extPar.FrameWidth));
     }
     else
     {
@@ -1683,7 +1683,7 @@ mfxStatus SetDefaults(
     }
     if (extPar.FrameHeight)
     {
-        SetDefault(fi.CropH, MFX_MIN(fi.Height, extPar.FrameHeight));
+        SetDefault(fi.CropH, std::min(fi.Height, extPar.FrameHeight));
     }
     else
     {

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_utils.cpp
@@ -83,7 +83,7 @@ void VP9MfxVideoParam::CalculateInternalParams()
     }
 
     m_targetKbps = m_maxKbps = m_bufferSizeInKb = m_initialDelayInKb = 0;
-    mfxU16 mult = MFX_MAX(mfx.BRCParamMultiplier, 1);
+    mfxU16 mult = std::max<mfxU16>(mfx.BRCParamMultiplier, 1);
 
     //"RateControlMethod == 0" always maps to CBR or VBR depending on TargetKbps and MaxKbps
     if (IsBitrateBasedBRC(mfx.RateControlMethod) || mfx.RateControlMethod == 0)
@@ -116,20 +116,20 @@ void VP9MfxVideoParam::SyncInternalParamToExternal()
 
     if (IsBitrateBasedBRC(mfx.RateControlMethod))
     {
-        maxBrcVal32 = MFX_MAX(m_maxKbps, MFX_MAX(maxBrcVal32, m_targetKbps));
+        maxBrcVal32 = std::max({m_maxKbps, maxBrcVal32, m_targetKbps});
 
         if (IsBufferBasedBRC(mfx.RateControlMethod))
         {
-            maxBrcVal32 = MFX_MAX(maxBrcVal32, m_initialDelayInKb);
+            maxBrcVal32 = std::max(maxBrcVal32, m_initialDelayInKb);
         }
 
         for (mfxU16 i = 0; i < MAX_NUM_TEMP_LAYERS; i++)
         {
-            maxBrcVal32 = MFX_MAX(maxBrcVal32, m_layerParam[i].targetKbps);
+            maxBrcVal32 = std::max(maxBrcVal32, m_layerParam[i].targetKbps);
         }
     }
 
-    mfxU16 mult = MFX_MAX(mfx.BRCParamMultiplier, 1);
+    mfxU16 mult = std::max<mfxU16>(mfx.BRCParamMultiplier, 1);
 
     if (maxBrcVal32)
     {


### PR DESCRIPTION
Replaced with std::min/max