### PR TITLE
mfx common: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -933,7 +933,7 @@ mfxU8* GetFramePointer(mfxU32 fourcc, mfxFrameData const& data)
         case MFX_FOURCC_RGBP:
 #endif
         case MFX_FOURCC_ARGB16:
-        case MFX_FOURCC_ABGR16:      return MFX_MIN(MFX_MIN(data.R, data.G), data.B); break;
+        case MFX_FOURCC_ABGR16:      return std::min({data.R, data.G, data.B}); break;
 #if defined (MFX_ENABLE_FOURCC_RGB565)
         case MFX_FOURCC_RGB565:      return data.R; break;
 #endif // MFX_ENABLE_FOURCC_RGB565

--- a/_studio/shared/src/cm_mem_copy.cpp
+++ b/_studio/shared/src/cm_mem_copy.cpp
@@ -295,8 +295,8 @@ mfxStatus CmCopyWrapper::EnqueueCopySwapRBGPUtoCPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -479,8 +479,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyGPUtoCPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -661,8 +661,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyShiftGPUtoCPU(CmSurface2D* pSurface,
     }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -843,8 +843,8 @@ mfxStatus CmCopyWrapper::EnqueueCopySwapRBCPUtoGPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -1030,8 +1030,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyCPUtoGPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -1215,8 +1215,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyShiftCPUtoGPU(CmSurface2D* pSurface,
     }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -1570,8 +1570,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyMirrorNV12GPUtoCPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -1753,8 +1753,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyNV12GPUtoCPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -1936,8 +1936,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyMirrorNV12CPUtoGPU(CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -2108,8 +2108,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyNV12CPUtoGPU(CmSurface2D* pSurface,
     }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -2290,8 +2290,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyShiftP010GPUtoCPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -2469,8 +2469,8 @@ mfxStatus CmCopyWrapper::EnqueueCopyShiftP010CPUtoGPU(   CmSurface2D* pSurface,
    }
 
     // the actual copy region
-    copy_width_byte = MFX_MIN(stride_in_bytes, width_byte);
-    copy_height_row = MFX_MIN(height_stride_in_rows, (UINT)height);
+    copy_width_byte = std::min      (stride_in_bytes, width_byte);
+    copy_height_row = std::min<UINT>(height_stride_in_rows, height);
 
     // Make sure stride and start address of system memory is 16-byte aligned.
     // if no padding in system memory , stride_in_bytes = width_byte.
@@ -3129,7 +3129,7 @@ mfxStatus CmCopyWrapper::CopyMirrorVideoToVideoMemory(void *pDst, void *pSrc, mf
 
 bool CmCopyWrapper::CanUseCmCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 {
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     mfxU8* srcPtr = GetFramePointer(pSrc->Info.FourCC, pSrc->Data);
     mfxU8* dstPtr = GetFramePointer(pDst->Info.FourCC, pDst->Data);
@@ -3186,7 +3186,7 @@ bool CmCopyWrapper::CanUseCmCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 
 mfxStatus CmCopyWrapper::CopyVideoToVideo(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 {
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     // check that region of interest is valid
     if (0 == roi.width || 0 == roi.height || m_HWType == MFX_HW_UNKNOWN)
@@ -3207,7 +3207,7 @@ mfxStatus CmCopyWrapper::CopyVideoToVideo(mfxFrameSurface1 *pDst, mfxFrameSurfac
 
 mfxStatus CmCopyWrapper::CopyVideoToSys(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 {
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     // check that region of interest is valid
     if (0 == roi.width || 0 == roi.height || m_HWType == MFX_HW_UNKNOWN)
@@ -3263,7 +3263,7 @@ mfxStatus CmCopyWrapper::CopyVideoToSys(mfxFrameSurface1 *pDst, mfxFrameSurface1
 
 mfxStatus CmCopyWrapper::CopySysToVideo(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 {
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     mfxU8* srcPtr = GetFramePointer(pSrc->Info.FourCC, pSrc->Data);
 

--- a/_studio/shared/src/libmfx_core.cpp
+++ b/_studio/shared/src/libmfx_core.cpp
@@ -1166,7 +1166,7 @@ mfxStatus CommonCORE::DoFastCopy(mfxFrameSurface1 *dst, mfxFrameSurface1 *src)
     mfxStatus sts;
     if (!dst || !src)
         return MFX_ERR_NULL_PTR;
-    mfxSize roi = { MFX_MIN(src->Info.Width, dst->Info.Width), MFX_MIN(src->Info.Height, dst->Info.Height) };
+    mfxSize roi = { std::min(src->Info.Width, dst->Info.Width), std::min(src->Info.Height, dst->Info.Height) };
     if (!roi.width || !roi.height)
     {
         return MFX_ERR_UNDEFINED_BEHAVIOR;
@@ -1273,7 +1273,7 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int c
 {
     mfxStatus sts;
 
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     // check that region of interest is valid
     if (0 == roi.width || 0 == roi.height)
@@ -1397,8 +1397,8 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int c
 
     case MFX_FOURCC_RGB3:
         {
-            mfxU8* ptrSrc = MFX_MIN(MFX_MIN(pSrc->Data.R, pSrc->Data.G), pSrc->Data.B);
-            mfxU8* ptrDst = MFX_MIN(MFX_MIN(pDst->Data.R, pDst->Data.G), pDst->Data.B);
+            mfxU8* ptrSrc = std::min({pSrc->Data.R, pSrc->Data.G, pSrc->Data.B});
+            mfxU8* ptrDst = std::min({pDst->Data.R, pDst->Data.G, pDst->Data.B});
 
             roi.width *= 3;
 
@@ -1487,8 +1487,8 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int c
     case MFX_FOURCC_BGR4:
     case MFX_FOURCC_A2RGB10:
         {
-            mfxU8* ptrSrc = MFX_MIN(MFX_MIN(pSrc->Data.R, pSrc->Data.G), pSrc->Data.B);
-            mfxU8* ptrDst = MFX_MIN( MFX_MIN(pDst->Data.R, pDst->Data.G), pDst->Data.B );
+            mfxU8* ptrSrc = std::min({pSrc->Data.R, pSrc->Data.G, pSrc->Data.B});
+            mfxU8* ptrDst = std::min({pDst->Data.R, pDst->Data.G, pDst->Data.B});
 
             roi.width *= 4;
 
@@ -1499,8 +1499,8 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int c
     case MFX_FOURCC_ARGB16:
     case MFX_FOURCC_ABGR16:
         {
-            mfxU8* ptrSrc = MFX_MIN(MFX_MIN(pSrc->Data.R, pSrc->Data.G), pSrc->Data.B);
-            mfxU8* ptrDst = MFX_MIN( MFX_MIN(pDst->Data.R, pDst->Data.G), pDst->Data.B );
+            mfxU8* ptrSrc = std::min({pSrc->Data.R, pSrc->Data.G, pSrc->Data.B});
+            mfxU8* ptrDst = std::min({pDst->Data.R, pDst->Data.G, pDst->Data.B});
 
             roi.width *= 8;
 

--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -1097,7 +1097,7 @@ VAAPIVideoCORE::DoFastCopyExtended(
         return MFX_ERR_UNDEFINED_BEHAVIOR;
     }
 
-    mfxSize roi = {MFX_MIN(pSrc->Info.Width, pDst->Info.Width), MFX_MIN(pSrc->Info.Height, pDst->Info.Height)};
+    mfxSize roi = {std::min(pSrc->Info.Width, pDst->Info.Width), std::min(pSrc->Info.Height, pDst->Info.Height)};
 
     // check that region of interest is valid
     if (0 == roi.width || 0 == roi.height)


### PR DESCRIPTION
Replaced with std::min/max