### PR TITLE
umc common: remove MFX_MIN/MAX macro

### DIFF
--- a/_studio/shared/umc/core/umc/include/umc_defs.h
+++ b/_studio/shared/umc/core/umc/include/umc_defs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -54,9 +54,6 @@ namespace UMC
 #endif //__cplusplus
 
 #define MFX_INTERNAL_CPY(dst, src, size) std::copy((const uint8_t *)(src), (const uint8_t *)(src) + (int)(size), (uint8_t *)(dst))
-
-#define MFX_MAX( a, b ) ( ((a) > (b)) ? (a) : (b) )
-#define MFX_MIN( a, b ) ( ((a) < (b)) ? (a) : (b) )
 
 #define MFX_MAX_32S    ( 2147483647 )
 #define MFX_MAXABS_64F ( 1.7976931348623158e+308 )

--- a/_studio/shared/umc/core/umc/src/umc_media_data.cpp
+++ b/_studio/shared/umc/core/umc/src/umc_media_data.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -270,7 +270,7 @@ Status MediaData::MoveDataTo(MediaData* dst)
     src = this;
     pDataEnd = dst->m_pDataPointer + dst->m_nDataSize;
     pBufferEnd = dst->m_pBufferPointer + dst->m_nBufferSize;
-    size = MFX_MIN(src->m_nDataSize, (size_t) (pBufferEnd - pDataEnd));
+    size = std::min<size_t>(src->m_nDataSize, pBufferEnd - pDataEnd);
 
     if (size)
     {

--- a/_studio/shared/umc/core/umc/src/umc_video_data.cpp
+++ b/_studio/shared/umc/core/umc/src/umc_video_data.cpp
@@ -287,10 +287,10 @@ Status VideoData::SetColorFormat(ColorFormat cFormat)
             m_pPlaneData[i].m_ippSize.height = m_ippSize.height;
         }
         bpp = m_pPlaneData[i].m_iSampleSize * m_pPlaneData[i].m_iSamples;
-        align = MFX_MAX(m_iAlignment, bpp);
+        align = std::max(m_iAlignment, bpp);
         if (i < pFormat->m_iPlanes) {
             // sometimes dimension of image may be not aligned to native size
-            align = MFX_MAX(align, pFormat->m_iMinAlign);
+            align = std::max(align, pFormat->m_iMinAlign);
             align *= pFormat->m_PlaneFormatInfo[i].m_iAlignMult;
         }
         m_pPlaneData[i].m_nPitch =


### PR DESCRIPTION
Replaced with std::min/max