### PR TITLE
[H265] Don't change CF, if profile/entrypoint unsupported

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
@@ -240,7 +240,7 @@ mfxStatus MFXVideoENCODEH265_HW::InitImpl(mfxVideoParam *par)
         encoder_guid,
         m_vpar);
 
-    MFX_CHECK(sts != MFX_ERR_INVALID_VIDEO_PARAM, sts);
+    MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM); // MFX_ERR_UNSUPPORTED is unavailable for Init
     MFX_CHECK(MFX_SUCCEEDED(sts), MFX_ERR_DEVICE_FAILED);
 
     sts = m_ddi->QueryEncodeCaps(m_caps);
@@ -274,6 +274,8 @@ mfxStatus MFXVideoENCODEH265_HW::InitImpl(mfxVideoParam *par)
     m_hrd.Init(m_vpar.m_sps, m_vpar.InitialDelayInKB);
 
     sts = m_ddi->CreateAccelerationService(m_vpar);
+
+    MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM); // MFX_ERR_UNSUPPORTED is unavailable for Init
     MFX_CHECK(MFX_SUCCEEDED(sts), MFX_ERR_DEVICE_FAILED);
 
     mfxFrameAllocRequest request = {};

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -35,8 +35,6 @@ GUID GetGUID(MfxVideoParam const & par)
 {
     GUID guid = DXVA2_Intel_Encode_HEVC_Main;
 
-    mfxU16 cFamily = IsOn(par.mfx.LowPower);
-
     mfxU16 bdId = 0, cfId = 0;
 
 #if (MFX_VERSION >= 1027)
@@ -45,22 +43,18 @@ GUID GetGUID(MfxVideoParam const & par)
 
     cfId = mfx::clamp<mfxU16>(par.m_ext.CO3.TargetChromaFormatPlus1 - 1, MFX_CHROMAFORMAT_YUV420, MFX_CHROMAFORMAT_YUV444) - MFX_CHROMAFORMAT_YUV420;
 
-    if (par.m_platform && par.m_platform < MFX_HW_ICL)
-        cfId = 0; // platforms below ICL do not support Main422/Main444 profile, using Main instead.
-    else if (par.m_platform && par.m_platform == MFX_HW_ICL_LP
-            && !cFamily
-            && cfId > 1)
-        cfId = 1; // ICL does not support Main444 profile without VDEnc
 #else
     if (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAIN10 || par.mfx.FrameInfo.BitDepthLuma == 10 || par.mfx.FrameInfo.FourCC == MFX_FOURCC_P010)
         bdId = 1;
 
-     cfId = 0;
+    cfId = 0;
 #endif
     if (par.m_platform && par.m_platform < MFX_HW_KBL)
         bdId = 0;
 
-    guid = GuidTable[cFamily][bdId] [cfId];
+    mfxU16 cFamily = IsOn(par.mfx.LowPower);
+
+    guid = GuidTable[cFamily][bdId][cfId];
     DDITracer::TraceGUID(guid, stdout);
     return guid;
 }

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -1071,6 +1071,11 @@ mfxStatus VAAPIEncoder::CreateAccelerationService(MfxVideoParam const & par)
                           vaParams.profile,
                           vaParams.entrypoint,
                           attrib.data(), (mfxI32)attrib.size());
+
+    MFX_CHECK(!(VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT == vaSts ||
+                VA_STATUS_ERROR_UNSUPPORTED_PROFILE == vaSts),
+                MFX_ERR_UNSUPPORTED);
+
     MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
     if (   (attrib[0].value & VA_RT_FORMAT_YUV420) == 0


### PR DESCRIPTION
Return MFX_ERR_INVALID_VIDEO_PARAM status, if profile/entrypoint unsupported
instead of replacing requested color format to get supported guid. Return
MFX_ERR_INVALID_VIDEO_PARAM because it is called in Init.