### PR TITLE
[vpp] Removed shallow copy

### DIFF
--- a/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -116,8 +116,6 @@ private:
                 nativeSurface->Data.FrameOrder = surface->Data.FrameOrder;
                 nativeSurface->Data.TimeStamp = surface->Data.TimeStamp;
                 nativeSurface->Info = surface->Info;
-                nativeSurface->Data.ExtParam = surface->Data.ExtParam;
-                nativeSurface->Data.NumExtParam = surface->Data.NumExtParam;
             }
 
             return nativeSurface;


### PR DESCRIPTION
VPP shall not make shallow copy of ExtParam's from opaque
to native(real) surfaces. If app decides to change the opaque surface,
internal native surface can't be changed automatically.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>