### PR TITLE
[HEVCe] Inherit LowPower parameter on reset

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1110,6 +1110,7 @@ void InheritDefaultValues(
     InheritOption(parInit.mfx.BufferSizeInKB,     parReset.mfx.BufferSizeInKB);
     InheritOption(parInit.mfx.NumSlice,           parReset.mfx.NumSlice);
     InheritOption(parInit.mfx.NumRefFrame,        parReset.mfx.NumRefFrame);
+    InheritOption(parInit.mfx.LowPower,           parReset.mfx.LowPower);
 
     if (parInit.mfx.RateControlMethod == MFX_RATECONTROL_CBR && parReset.mfx.RateControlMethod == MFX_RATECONTROL_CBR)
     {


### PR DESCRIPTION
Add copying of coding option value instead of leaving this 0(UNKNOWN) in reset.