### PR TITLE
Updated sample_multi_transcode 'help' output for lookahead HEVC encode

### DIFF
--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -293,6 +293,12 @@ set -o::h265 /path/to/so/encoder_plugin.so
 
 ## Known Limitations
 
+-   To use lookahead for HEVC encode, we need to have h264 LA plugin and the HEVC HW encode plugin, run in separate sessions. Following par file is an example of lookahead bitrate for HEVC encode:
+    ```
+    -i::h265 input.h265 -o::sink  -hw -async 1 -la -la_ext -bpyr -dist 8 -join
+    -i::source -o::h265 output.h265 -u 4 -hw -b 500 -async 1 -bpyr -dist 8 -join
+    ```
+
 -   Configurations <multiple joined inter-session transcoding where one of the encoders is MPEG2\> are not supported when sample application uses platform-specific **SDK** implementation on systems with Intel® HD Graphics 3000/2000 and 4000/2500. Application can exit with error or hang. An example of a corresponding par file is given below:
 
     ```

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -348,6 +348,8 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("Examples:\n"));
     msdk_printf(MSDK_STRING("  sample_multi_transcode -i::mpeg2 in.mpeg2 -o::h264 out.h264\n"));
     msdk_printf(MSDK_STRING("  sample_multi_transcode -i::mvc in.mvc -o::mvc out.mvc -w 320 -h 240\n"));
+    msdk_printf(MSDK_STRING("\n"));
+    msdk_printf(MSDK_STRING("For more information on HOWTO usage of sample_multi_transcode, refer to readme document available at https://github.com/Intel-Media-SDK/MediaSDK/blob/master/doc/samples/readme-multi-transcode_linux.md\n"));
 }
 
 void TranscodingSample::PrintInfo(mfxU32 session_number, sInputParams* pParams, mfxVersion *pVer)


### PR DESCRIPTION
Updated sample_multi_transcode 'help' output on how to use lookahead plugin for HEVC encode. With reference to #1743 