### PR TITLE
samples: Change LADepth checking condition

### DIFF
--- a/doc/samples/readme-encode_linux.md
+++ b/doc/samples/readme-encode_linux.md
@@ -74,7 +74,7 @@ The following command-line switches are optional:
   | [-num_active_BL0 numRefs] | number of maximum allowed references for B frames in L0 (for HEVC only)|
  |  [-num_active_BL1 numRefs] | number of maximum allowed references for B frames in L1 (for HEVC only)|
   | [-la] | use the look ahead bitrate control algorithm (LA BRC) (by default constant bitrate control method is used) <br> for H.264, H.265 encoder. Supported only with -hw option on 4th Generation Intel Core processors <br>if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algotithm will be used.
- |[-lad depth] | depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range[1,100]. <br>may be 1 in the case when -mss option is specified <br>if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algorithm will be used.|
+ |[-lad depth] | depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [0,100].<br>If `depth` is `0` then the encoder forces the value to Max(10, 2\*`GopRefDist`) for LA_ICQ, and to Max(40, 2\*`GopRefDist`) otherwise.<br>If `depth` is in range [1,100] then the encoder forces the value to Max(2\*`GopRefDist`,2\*`NumRefFrame`,`depth`).<br>may be 1 in the case when -mss option is specified <br>if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algorithm will be used.|
  |  [-dstw width] | destination picture width, invokes VPP resizing|
   | [-dsth height] | destination picture height, invokes VPP resizing|
   | [-hw] | use platform specific SDK implementation (default)|

--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -103,7 +103,7 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
 |-l <numSlices\>|  Number of slices for encoder; default value 0|
 |-mss <maxSliceSize\>|Maximum slice size in bytes. Supported only with -hw and h264 codec. This option is not compatible with -l option.|
 |-la|Use the look ahead bitrate control algorithm (LA BRC) for H.264 encoder. Supported only with -hw option on 4th Generation Intel Core processors.|
-| -lad <depth\>|Depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range[1,100].<br>May be 1 in the case when -mss option is specified|
+| -lad <depth\>|Depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [0,100].<br>If `depth` is `0` then the encoder forces the value to Max(10, 2\*`GopRefDist`) for LA_ICQ, and to Max(40, 2\*`GopRefDist`) otherwise.<br>If `depth` is in range [1,100] then the encoder forces the value to Max(2\*`GopRefDist`,2\*`NumRefFrame`,`depth`).<br>May be 1 in the case when -mss option is specified|
 |  -la_ext| Use external LA plugin (compatible with h264 & hevc encoders)|
 |-vbr| Variable bitrate control|
 | -hrd <KBytes\> |Maximum possible size of any compressed frames|

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -87,7 +87,7 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-la] - use the look ahead bitrate control algorithm (LA BRC) (by default constant bitrate control method is used)\n"));
     msdk_printf(MSDK_STRING("           for H.264, H.265 encoder. Supported only with -hw option on 4th Generation Intel Core processors. \n"));
     msdk_printf(MSDK_STRING("           if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algotithm will be used. \n"));
-    msdk_printf(MSDK_STRING("   [-lad depth] - depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [1,100].\n"));
+    msdk_printf(MSDK_STRING("   [-lad depth] - depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [0,100] (0 - default: auto-select by mediasdk library).\n"));
     msdk_printf(MSDK_STRING("            may be 1 in the case when -mss option is specified \n"));
     msdk_printf(MSDK_STRING("            if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algotithm will be used. \n"));
     msdk_printf(MSDK_STRING("   [-dstw width] - destination picture width, invokes VPP resizing\n"));
@@ -1415,9 +1415,9 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
         pParams->nRateControlMethod == MFX_RATECONTROL_LA_EXT ||
         pParams->nRateControlMethod == MFX_RATECONTROL_LA_ICQ ||
         pParams->nRateControlMethod == MFX_RATECONTROL_LA_HRD) &&
-        (!pParams->nLADepth || pParams->nLADepth > 100) )
+        pParams->nLADepth > 100 )
     {
-        PrintHelp(strInput[0], MSDK_STRING("Unsupported value of -lad parameter, must be in range [1,100]"));
+        PrintHelp(strInput[0], MSDK_STRING("Unsupported value of -lad parameter, must be in range [1,100] or 0 for automatic selection"));
         return MFX_ERR_UNSUPPORTED;
     }
 

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -228,7 +228,7 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("  -mss maxSliceSize \n"));
     msdk_printf(MSDK_STRING("                Maximum slice size in bytes. Supported only with -hw and h264 codec. This option is not compatible with -l option.\n"));
     msdk_printf(MSDK_STRING("  -la           Use the look ahead bitrate control algorithm (LA BRC) for H.264 encoder. Supported only with -hw option on 4th Generation Intel Core processors. \n"));
-    msdk_printf(MSDK_STRING("  -lad depth    Depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [1,100]. \n"));
+    msdk_printf(MSDK_STRING("  -lad depth    Depth parameter for the LA BRC, the number of frames to be analyzed before encoding. In range [0,100] (0 - default: auto-select by mediasdk library). \n"));
     msdk_printf(MSDK_STRING("                May be 1 in the case when -mss option is specified \n"));
     msdk_printf(MSDK_STRING("  -la_ext       Use external LA plugin (compatible with h264 & hevc encoders)\n"));
     msdk_printf(MSDK_STRING("  -vbr          Variable bitrate control\n"));
@@ -2612,9 +2612,9 @@ mfxStatus CmdProcessor::VerifyAndCorrectInputParams(TranscodingSample::sInputPar
         InputParams.nRateControlMethod == MFX_RATECONTROL_LA_EXT ||
         InputParams.nRateControlMethod == MFX_RATECONTROL_LA_ICQ ||
         InputParams.nRateControlMethod == MFX_RATECONTROL_LA_HRD) &&
-        (!InputParams.nLADepth || InputParams.nLADepth > 100) )
+        InputParams.nLADepth > 100 )
     {
-        PrintError(MSDK_STRING("Unsupported value of -lad parameter, must be in range [1,100]"));
+        PrintError(MSDK_STRING("Unsupported value of -lad parameter, must be in range [1,100] or 0 for automatic selection"));
         return MFX_ERR_UNSUPPORTED;
     }
 


### PR DESCRIPTION
After this PR: https://github.com/Intel-Media-SDK/MediaSDK/pull/1668
sample_encode and sample_multi_transcode check -LADepth 0 and report error.
There is no need to check 0, it is default value,
in this case encoder will choose the value on his own.