### PR TITLE
h265_dec/umc_h264_task_supplier: Compare aligned width/height

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -200,10 +200,10 @@ bool IsNeedSPSInvalidate(const H265SeqParamSet *old_sps, const H265SeqParamSet *
     //if (new_sps->no_output_of_prior_pics_flag)
       //  return true;
 
-    if (old_sps->pic_width_in_luma_samples != new_sps->pic_width_in_luma_samples)
+    if (mfx::align2_value(old_sps->pic_width_in_luma_samples, 16) != mfx::align2_value(new_sps->pic_width_in_luma_samples, 16))
         return true;
 
-    if (old_sps->pic_height_in_luma_samples != new_sps->pic_height_in_luma_samples)
+    if (mfx::align2_value(old_sps->pic_height_in_luma_samples, 16) != mfx::align2_value(new_sps->pic_height_in_luma_samples, 16))
         return true;
 
     if (old_sps->bit_depth_luma != new_sps->bit_depth_luma)


### PR DESCRIPTION
Tiny resolution change wouldn't modify mfxFrameInfo.Width/Height
since they are 16 aligned, and there is no need for surface
reallocation.

Compare aligned width/height to cover tiny resolution change cases,
otherwise it would report an error of UMC_NTF_NEW_RESOLUTION then
MFX_ERR_INCOMPATIBLE_VIDEO_PARAM in AddSource.

Fix #916.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>