### PR TITLE
mfx_h265_encode_hw_par: Resize default slice number according to Tiles

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -495,15 +495,12 @@ mfxU16 MakeSlices(MfxVideoParam& par, mfxU32 SliceStructure)
 #if (MFX_VERSION >= 1027)
     /*
         A tile must wholly contain all the slices within it. Slices cannot cross tile boundaries.
-        If a slice contains more than one tile, it must contain all the tiles in the frame, i.e. there can only be one slice in the frame. (Upto Gen12, Intel HW does not support this scenario.)
+        If a slice contains more than one tile, it must contain all the tiles in the frame, i.e. there can only be one slice in the frame.
         Normally, each tile will contain a single slice. So  2x2 and 4 slices is normal.
         Fewer slices than tiles is illegal (e.g. 3 slice, 2x2 tiles)
         More slices than tiles is legal as long as the slices do not cross tile boundaries; the app needs to use the slice segment address and number of LCUs in the slice to define the slices within the tiles.
     */
-    if (par.m_platform <= MFX_HW_ICL)
-    {
-        nSlice = std::max(nSlice, nTile);
-    }
+    nSlice = std::max(nSlice, nTile);
 
     if (par.m_platform >= MFX_HW_ICL && IsOn(par.mfx.LowPower)) {
         if (nTile == 1)


### PR DESCRIPTION
Fix #1772.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>