### PR TITLE
[AVCe] Remove unnecesary condition on reset with CBR and HRDConformance

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -1318,10 +1318,6 @@ mfxStatus ImplementationAvc::ProcessAndCheckNewParameters(
         m_video.calcParam.targetKbps != newPar.calcParam.targetKbps ||
         m_video.calcParam.maxKbps    != newPar.calcParam.maxKbps;
 
-    if (brcReset && IsOn(extOptNew.NalHrdConformance) &&
-        m_video.mfx.RateControlMethod == MFX_RATECONTROL_CBR)
-        return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
-
     MFX_CHECK(
         IsAvcProfile(newPar.mfx.CodecProfile)                                   &&
         m_video.AsyncDepth                 == newPar.AsyncDepth                 &&


### PR DESCRIPTION
Encoder checks CBR and NalHRDConformance case and without idr
inserting on reset encoder return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM.
This condition is reduntant. It was removed.