### PR TITLE
[SW BRC][HEVCe] Disable unnecessary checking in HDRConformance case

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_brc_common.h
+++ b/_studio/mfx_lib/shared/include/mfx_brc_common.h
@@ -160,6 +160,21 @@ protected:
 #define MAX_RACA 361.0
 #define RACA_SCALE 128.0
 
+/*
+NalHrdConformance | VuiNalHrdParameters   |  Result
+--------------------------------------------------------------
+    off                  any                => MFX_BRC_NO_HRD
+    default              off                => MFX_BRC_NO_HRD
+    on                   off                => MFX_BRC_HRD_WEAK
+    on (or default)      on (or default)    => MFX_BRC_HRD_STRONG
+--------------------------------------------------------------
+*/
+enum : mfxU16
+{
+    MFX_BRC_NO_HRD = 0,
+    MFX_BRC_HRD_WEAK,  // IF HRD CALCULATION IS REQUIRED, BUT NOT WRITTEN TO THE STREAM
+    MFX_BRC_HRD_STRONG
+};
 
 namespace MfxHwH265EncodeBRC
 {
@@ -168,7 +183,7 @@ class cBRCParams
 public:
     mfxU16 rateControlMethod; // CBR or VBR
 
-    mfxU16 bHRDConformance;  // is HRD compliance  needed
+    mfxU16 HRDConformance;   // is HRD compliance  needed
     mfxU16 bRec;             // is Recoding possible
     mfxU16 bPanic;           // is Panic mode possible
 
@@ -228,7 +243,7 @@ public:
 public:
     cBRCParams() :
         rateControlMethod(0),
-        bHRDConformance(0),
+        HRDConformance(MFX_BRC_NO_HRD),
         bRec(0),
         bPanic(0),
         bufferSizeInBytes(0),

--- a/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
@@ -153,14 +153,21 @@ mfxStatus cBRCParams::Init(mfxVideoParam* par, bool fieldMode)
 
     mfxExtCodingOption * pExtCO = (mfxExtCodingOption*)Hevc_GetExtBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_CODING_OPTION);
 
-    bHRDConformance =  (pExtCO && pExtCO->NalHrdConformance == MFX_CODINGOPTION_OFF) ? 0 : 1;
-
-    if (bHRDConformance)
+    HRDConformance = MFX_BRC_NO_HRD;
+    if (pExtCO)
     {
-        bufferSizeInBytes  = ((k*par->mfx.BufferSizeInKB*1000) >> 3) << 3;
-        initialDelayInBytes =((k*par->mfx.InitialDelayInKB*1000) >> 3) << 3;
+        if (!IsOff(pExtCO->NalHrdConformance) && !IsOff(pExtCO->VuiNalHrdParameters))
+            HRDConformance = MFX_BRC_HRD_STRONG;
+        else if (IsOn(pExtCO->NalHrdConformance) && IsOff(pExtCO->VuiNalHrdParameters))
+            HRDConformance = MFX_BRC_HRD_WEAK;
+    }
+
+    if (HRDConformance != MFX_BRC_NO_HRD)
+    {
+        bufferSizeInBytes   = ((k*par->mfx.BufferSizeInKB*1000) >> 3) << 3;
+        initialDelayInBytes = ((k*par->mfx.InitialDelayInKB*1000) >> 3) << 3;
         bRec = 1;
-        bPanic = 1;
+        bPanic = (HRDConformance == MFX_BRC_HRD_STRONG) ? 1 : 0;
     }
     MFX_CHECK (par->mfx.FrameInfo.FrameRateExtD != 0 &&
                par->mfx.FrameInfo.FrameRateExtN != 0,
@@ -237,7 +244,7 @@ mfxStatus cBRCParams::Init(mfxVideoParam* par, bool fieldMode)
     if (maxFrameSizeInBits) {
         maxFrameSize = std::min<mfxF64>(maxFrameSize, maxFrameSizeInBits);
     }
-    if (bHRDConformance) {
+    if (HRDConformance != MFX_BRC_NO_HRD) {
         mfxF64 bufOccupy = LTR_BUF(MFX_FRAMETYPE_IDR, 1, mIntraBoost, 1, 0);
         maxFrameSize = std::min(maxFrameSize, bufOccupy / 9.* (initialDelayInBytes * 8.0) + (9.0 - bufOccupy) / 9.*inputBitsPerFrame);
     }
@@ -270,27 +277,23 @@ mfxStatus   cBRCParams::GetBRCResetType(mfxVideoParam* par, bool bNewSequence, b
     MFX_CHECK_STS(sts);
 
     MFX_CHECK(new_par.rateControlMethod == rateControlMethod, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
-    MFX_CHECK(new_par.bHRDConformance == bHRDConformance, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
+    MFX_CHECK(new_par.HRDConformance == HRDConformance, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
     MFX_CHECK(new_par.frameRate == frameRate, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.width == width, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.height == height, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.chromaFormat == chromaFormat, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.bitDepthLuma == bitDepthLuma, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
 
-    if (bHRDConformance)
+    if (HRDConformance == MFX_BRC_HRD_STRONG)
     {
         MFX_CHECK(new_par.bufferSizeInBytes   == bufferSizeInBytes, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.initialDelayInBytes == initialDelayInBytes, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.targetbps == targetbps, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.maxbps == maxbps, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     }
-    else
-    {
-        if (new_par.targetbps != targetbps || new_par.maxbps != maxbps)
-        {
-            MFX_CHECK(new_par.rateControlMethod == MFX_RATECONTROL_VBR, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
-            bBRCReset = true;
-        }
+    else if (new_par.targetbps != targetbps || new_par.maxbps != maxbps)
+    {  
+        bBRCReset = true;
     }
 
     if (new_par.WinBRCMaxAvgKbps != WinBRCMaxAvgKbps)
@@ -555,7 +558,7 @@ mfxStatus ExtBRC::Init (mfxVideoParam* par)
     sts = m_par.Init(par, isFieldMode(par));
     MFX_CHECK_STS(sts);
 
-    if (m_par.bHRDConformance)
+    if (m_par.HRDConformance != MFX_BRC_NO_HRD)
     {
         m_hrd.Init(m_par.bufferSizeInBytes, m_par.initialDelayInBytes, m_par.maxInputBitsPerFrame, m_par.rateControlMethod == MFX_RATECONTROL_CBR);
     }
@@ -834,10 +837,10 @@ mfxF64 ExtBRC::ResetQuantAb(mfxI32 qp, mfxU32 type, mfxI32 layer, mfxU16 isRef, 
     mfxF64 bAbPreriod = m_par.bAbPeriod;
 
     mfxF64 totDiv = m_ctx.totalDiviation;
-    const mfxF64 factor = m_par.bHRDConformance ? m_hrd.GetBufferDiviationFactor() : 0.0;
+    const mfxF64 factor = m_par.HRDConformance != MFX_BRC_NO_HRD ? m_hrd.GetBufferDiviationFactor() : 0.0;
     mfxF64 lf = 1.0 / pow(m_par.inputBitsPerFrame / fAbLong, 1.0 + factor);
 
-    if (m_par.bHRDConformance && totDiv > 0)
+    if (m_par.HRDConformance != MFX_BRC_NO_HRD && totDiv > 0)
     {
         if (m_par.rateControlMethod == MFX_RATECONTROL_VBR)
         {
@@ -997,7 +1000,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
 
         //printf("m_ctx.SceneChange %d, m_ctx.poc %d, m_ctx.SChPoc, m_ctx.poc %d \n", m_ctx.SceneChange, m_ctx.poc, m_ctx.SChPoc, m_ctx.poc);
     }
-    if (m_par.bHRDConformance)
+    if (m_par.HRDConformance != MFX_BRC_NO_HRD)
     {
         //check hrd
         brcSts = m_hrd.UpdateAndCheckHRD(bitsEncoded, frame_par->NumRecode, m_ctx.QuantMin, m_ctx.QuantMax);
@@ -1051,7 +1054,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
         mfxF64 targetFrameSize = std::max<mfxF64>(m_par.inputBitsPerFrame, fAbLong);
         mfxF64 dqf = (m_par.bFieldMode) ? 1.0 : DQF(picType, m_par.iDQp, ((picType == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), (ParSceneChange || m_ctx.encOrder == 0));
         mfxF64 maxFrameSizeByRatio = dqf * FRM_RATIO(picType, m_ctx.encOrder, bSHStart, m_par.bPyr) * targetFrameSize;
-        if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.bHRDConformance) {
+        if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.HRDConformance != MFX_BRC_NO_HRD) {
             mfxF64 dev = -1.0*maxFrameSizeByRatio - m_hrd.GetBufferDiviation();
             if (dev > 0) maxFrameSizeByRatio += std::min(maxFrameSizeByRatio, (dev / (IS_IFRAME(picType) ? 2.0 : 4.0)));
         }
@@ -1062,7 +1065,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
 
         mfxF64 maxFrameSize = std::min<mfxF64>(maxFrameSizeByRatio, frameSizeLim);
 
-        if (m_par.bHRDConformance)
+        if (m_par.HRDConformance != MFX_BRC_NO_HRD)
         {
             mfxF64 bufOccupy = LTR_BUF(picType, m_par.iDQp, ((picType == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), ParSceneChange, bSHStart);
             mfxF64 maxFrameSizeHRD = bufOccupy / 9.* m_hrd.GetMaxFrameSize() + (9.0 - bufOccupy) / 9.*targetFrameSize;
@@ -1141,7 +1144,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             SetRecodeParams(MFX_BRC_PANIC_BIG_FRAME,quant,quant, quantMin ,quantMax, m_ctx, status);
             return sts;
         }
-        if (m_par.bHRDConformance && frame_par->NumRecode == 0 && (quant < quantMax))
+        if (m_par.HRDConformance != MFX_BRC_NO_HRD && frame_par->NumRecode == 0 && (quant < quantMax))
         {
             mfxF64 FAMax = 1./9. * m_hrd.GetMaxFrameSize() + 8./9. * fAbLong;
 
@@ -1167,9 +1170,9 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
                     }
                 } //quant_new > quant
             }
-        }//m_par.bHRDConformance
+        }//m_par.HRDConformance
     }
-    if (((m_par.bHRDConformance && brcSts != MFX_BRC_OK) || (bitsEncoded > (mfxI32)frameSizeLim)) && m_par.bRec)
+    if (((m_par.HRDConformance != MFX_BRC_NO_HRD && brcSts != MFX_BRC_OK) || (bitsEncoded > (mfxI32)frameSizeLim)) && m_par.bRec)
     {
         mfxI32 quant = qpY;
         mfxI32 quant_new = quant;
@@ -1264,12 +1267,12 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
 
             mfxF64 totDiv = m_ctx.totalDiviation;
 
-            const mfxF64 factor = m_par.bHRDConformance ? m_hrd.GetBufferDiviationFactor() : 0.0;
+            const mfxF64 factor = m_par.HRDConformance != MFX_BRC_NO_HRD ? m_hrd.GetBufferDiviationFactor() : 0.0;
             mfxF64 dequant_new = m_ctx.dQuantAb*pow(m_par.inputBitsPerFrame / m_ctx.fAbLong, 1.0 + factor);
 
             mfxF64 bAbPreriod = m_par.bAbPeriod;
 
-            if (m_par.bHRDConformance && totDiv > 0)
+            if (m_par.HRDConformance != MFX_BRC_NO_HRD && totDiv > 0)
             {
                 if (m_par.rateControlMethod == MFX_RATECONTROL_VBR)
                 {
@@ -1404,7 +1407,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
                 if (m_par.maxFrameSizeInBits) {
                     maxFrameSize = std::min<mfxF64>(maxFrameSize, m_par.maxFrameSizeInBits);
                 }
-                if (m_par.bHRDConformance) {
+                if (m_par.HRDConformance != MFX_BRC_NO_HRD) {
                     mfxF64 bufOccupy = LTR_BUF(type, m_par.iDQp, m_par.mIntraBoost, 1, 0);
                     maxFrameSize = std::min(maxFrameSize, (bufOccupy / 9.* (m_par.initialDelayInBytes * 8.0) + (9.0 - bufOccupy) / 9.*m_par.inputBitsPerFrame));
                 }
@@ -1445,7 +1448,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
             if (m_par.maxFrameSizeInBits) {
                 maxFrameSize = std::min<mfxF64>(maxFrameSize, m_par.maxFrameSizeInBits);
             }
-            if (m_par.bHRDConformance) {
+            if (m_par.HRDConformance != MFX_BRC_NO_HRD) {
                 mfxF64 hrdMaxFrameSize = m_par.initialDelayInBytes * 8;
                 if (m_hrd.GetMaxFrameSize() > 0) hrdMaxFrameSize = std::min<mfxF64>(hrdMaxFrameSize, m_hrd.GetMaxFrameSize());
                 mfxF64 bufOccupy = LTR_BUF(type, m_par.iDQp, ((type == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), (ParSceneChange || (m_ctx.LastIQpSet && m_ctx.QuantP > ((mfxI32)m_ctx.LastIQpSet + (mfxI32)m_par.iDQp + 1))), 0);
@@ -1484,7 +1487,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
                 mfxF64 raca = (mfxF64)ParFrameCmplx / RACA_SCALE;
                 mfxF64 dqf = DQF(type, m_par.iDQp, ((type == MFX_FRAMETYPE_IDR) ? m_par.mIntraBoost : false), ParSceneChange);
                 mfxF64 targetFrameSize = dqf * FRM_RATIO(type, par->EncodedOrder, 0, m_par.bPyr) * m_par.inputBitsPerFrame;
-                if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.bHRDConformance) {
+                if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.HRDConformance != MFX_BRC_NO_HRD) {
                     // CBR HRD Buffer over flow has priority
                     mfxF64 dev = -1.0*targetFrameSize - m_hrd.GetBufferDiviation();
                     if (dev > 0) targetFrameSize += std::min(targetFrameSize, (dev/2.0));
@@ -1515,7 +1518,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
             if (m_par.maxFrameSizeInBits) {
                 maxFrameSize = std::min<mfxF64>(maxFrameSize, m_par.maxFrameSizeInBits);
             }
-            if (m_par.bHRDConformance) {
+            if (m_par.HRDConformance != MFX_BRC_NO_HRD) {
                 mfxF64 hrdMaxFrameSize = m_par.initialDelayInBytes * 8;
                 if (m_hrd.GetMaxFrameSize() > 0) hrdMaxFrameSize = std::min(hrdMaxFrameSize, (mfxF64)m_hrd.GetMaxFrameSize());
 
@@ -1524,7 +1527,7 @@ mfxStatus ExtBRC::GetFrameCtrl (mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
             }
 
             mfxF64 targetFrameSize = FRM_RATIO(ltype, par->EncodedOrder, 0, m_par.bPyr) * m_par.inputBitsPerFrame;
-            if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.bHRDConformance) {
+            if (m_par.rateControlMethod == MFX_RATECONTROL_CBR && m_par.HRDConformance != MFX_BRC_NO_HRD) {
                 mfxF64 dev = -1.0*targetFrameSize - m_hrd.GetBufferDiviation();
                 if (dev > 0) targetFrameSize += std::min(targetFrameSize, (dev/4.0));
             }

--- a/samples/sample_common/include/brc_routines.h
+++ b/samples/sample_common/include/brc_routines.h
@@ -43,12 +43,28 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #define MFX_CHECK_STS(sts) MFX_CHECK(sts == MFX_ERR_NONE, sts)
 
 
+/*
+NalHrdConformance | VuiNalHrdParameters   |  Result
+--------------------------------------------------------------
+    off                  any                => MFX_BRC_NO_HRD
+    default              off                => MFX_BRC_NO_HRD
+    on                   off                => MFX_BRC_HRD_WEAK
+    on (or default)      on (or default)    => MFX_BRC_HRD_STRONG
+--------------------------------------------------------------
+*/
+enum : mfxU16
+{
+    MFX_BRC_NO_HRD = 0,
+    MFX_BRC_HRD_WEAK,  // IF HRD CALCULATION IS REQUIRED, BUT NOT WRITTEN TO THE STREAM
+    MFX_BRC_HRD_STRONG
+};
+
 class cBRCParams
 {
 public:
     mfxU16 rateControlMethod; // CBR or VBR
 
-    mfxU16 bHRDConformance;  // is HRD compliance  needed
+    mfxU16 HRDConformance;   // is HRD compliance  needed
     mfxU16 bRec;             // is Recoding possible
     mfxU16 bPanic;           // is Panic mode possible
 
@@ -97,7 +113,7 @@ public:
 public:
     cBRCParams():
         rateControlMethod(0),
-        bHRDConformance(0),
+        HRDConformance(MFX_BRC_NO_HRD),
         bRec(0),
         bPanic(0),
         bufferSizeInBytes(0),

--- a/samples/sample_common/src/brc_routines.cpp
+++ b/samples/sample_common/src/brc_routines.cpp
@@ -64,14 +64,21 @@ mfxStatus cBRCParams::Init(mfxVideoParam* par, bool bFielMode)
         targetbps : ((maxbps >= targetbps) ? maxbps : targetbps);
     mfxExtCodingOption * pExtCO = (mfxExtCodingOption*)Hevc_GetExtBuffer(par->ExtParam, par->NumExtParam, MFX_EXTBUFF_CODING_OPTION);
 
-    bHRDConformance =  (pExtCO && pExtCO->NalHrdConformance == MFX_CODINGOPTION_OFF) ? 0 : 1;
+    HRDConformance = MFX_BRC_NO_HRD;
+    if (pExtCO)
+    {
+        if ((MFX_CODINGOPTION_OFF != pExtCO->NalHrdConformance) && (MFX_CODINGOPTION_OFF != pExtCO->VuiNalHrdParameters))
+            HRDConformance = MFX_BRC_HRD_STRONG;
+        else if ((MFX_CODINGOPTION_ON == pExtCO->NalHrdConformance) && (MFX_CODINGOPTION_OFF == pExtCO->VuiNalHrdParameters))
+            HRDConformance = MFX_BRC_HRD_WEAK;
+    }
 
-    if (bHRDConformance)
+    if (HRDConformance != MFX_BRC_NO_HRD)
     {
         bufferSizeInBytes   = ((k*par->mfx.BufferSizeInKB  *1000) >> 3) << 3;
         initialDelayInBytes = ((k*par->mfx.InitialDelayInKB*1000) >> 3) << 3;
         bRec = 1;
-        bPanic = 1;
+        bPanic = (HRDConformance == MFX_BRC_HRD_STRONG) ? 1 : 0;
     }
     MFX_CHECK (par->mfx.FrameInfo.FrameRateExtD != 0 &&
                par->mfx.FrameInfo.FrameRateExtN != 0,
@@ -145,27 +152,23 @@ mfxStatus   cBRCParams::GetBRCResetType(mfxVideoParam* par, bool bNewSequence, b
     MFX_CHECK_STS(sts);
 
     MFX_CHECK(new_par.rateControlMethod == rateControlMethod, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
-    MFX_CHECK(new_par.bHRDConformance == bHRDConformance, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
+    MFX_CHECK(new_par.HRDConformance == HRDConformance, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM) ;
     MFX_CHECK(new_par.frameRate == frameRate, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.width == width, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.height == height, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.chromaFormat == chromaFormat, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     MFX_CHECK(new_par.bitDepthLuma == bitDepthLuma, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
 
-    if (bHRDConformance)
+    if (HRDConformance == MFX_BRC_HRD_STRONG)
     {
         MFX_CHECK(new_par.bufferSizeInBytes   == bufferSizeInBytes, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.initialDelayInBytes == initialDelayInBytes, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.targetbps == targetbps, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
         MFX_CHECK(new_par.maxbps == maxbps, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
     }
-    else
+    else if (new_par.targetbps != targetbps || new_par.maxbps != maxbps)
     {
-        if (new_par.targetbps != targetbps || new_par.maxbps != maxbps)
-        {
-            MFX_CHECK(new_par.rateControlMethod == MFX_RATECONTROL_VBR, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
-            bBRCReset = true;
-        }
+        bBRCReset = true;
     }
 
     if (new_par.WinBRCMaxAvgKbps != WinBRCMaxAvgKbps)
@@ -411,7 +414,7 @@ mfxStatus ExtBRC::Init (mfxVideoParam* par)
     sts = m_par.Init(par);
     MFX_CHECK_STS(sts);
 
-    if (m_par.bHRDConformance)
+    if (m_par.HRDConformance != MFX_BRC_NO_HRD)
     {
         m_hrd.Init(m_par.bufferSizeInBytes, m_par.initialDelayInBytes, m_par.maxInputBitsPerFrame, m_par.rateControlMethod == MFX_RATECONTROL_CBR);
     }
@@ -699,9 +702,9 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
         }
 
     }
-    if (m_par.bHRDConformance)
+    if (m_par.HRDConformance != MFX_BRC_NO_HRD)
     {
-       //check hrd
+        //check hrd
         brcSts = m_hrd.UpdateAndCheckHRD(bitsEncoded,frame_par->NumRecode, m_ctx.QuantMin,m_ctx.QuantMax);
         //printf("--UpdateAndCheckHRD (%d) brcSts %d, panic %d\n", frame_par->EncodedOrder,brcSts, m_ctx.bPanic);
         MFX_CHECK(brcSts ==  MFX_BRC_OK || (!m_ctx.bPanic), MFX_ERR_NOT_ENOUGH_BUFFER);
@@ -733,7 +736,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
 
         maxFrameSize = std::min<mfxF64>(maxFrameSize, frameSizeLim);
 
-        if (m_par.bHRDConformance)
+        if (m_par.HRDConformance != MFX_BRC_NO_HRD)
         {
             if (bSHStart || picType == MFX_FRAMETYPE_I)
                 maxFrameSize = std::min(maxFrameSize, 3.5/9. * m_hrd.GetMaxFrameSize() + 5.5/9. * targetFrameSize);
@@ -777,7 +780,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             SetRecodeParams(MFX_BRC_PANIC_BIG_FRAME,quant,quant, quantMin ,quantMax, m_ctx, status);
             return sts;
         }
-        if (m_par.bHRDConformance && frame_par->NumRecode == 0 && (quant < quantMax))
+        if (m_par.HRDConformance != MFX_BRC_NO_HRD && frame_par->NumRecode == 0 && (quant < quantMax))
         {
             mfxF64 FAMax = 1./9. * m_hrd.GetMaxFrameSize() + 8./9. * fAbLong;
 
@@ -803,9 +806,9 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
                     }
                 }//quant_new > quant
             }
-        }//m_par.bHRDConformance
+        }//m_par.HRDConformance
     }
-    if (((m_par.bHRDConformance && brcSts != MFX_BRC_OK) || (bitsEncoded > (mfxI32)frameSizeLim)) && m_par.bRec)
+    if (((m_par.HRDConformance != MFX_BRC_NO_HRD && brcSts != MFX_BRC_OK) || (bitsEncoded > (mfxI32)frameSizeLim)) && m_par.bRec)
     {
         mfxI32 quant = m_ctx.Quant;
         mfxI32 quant_new = quant;
@@ -885,7 +888,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             mfxF64 dequant_new = m_ctx.dQuantAb*pow(m_par.inputBitsPerFrame/m_ctx.fAbLong, 1.2);
             mfxF64 bAbPreriod = m_par.bAbPeriod;
 
-            if (m_par.bHRDConformance && totDiv > 0 )
+            if (m_par.HRDConformance != MFX_BRC_NO_HRD && totDiv > 0 )
             {
                 if (m_par.rateControlMethod == MFX_RATECONTROL_VBR)
                 {


### PR DESCRIPTION
if NalHrdConformance is on and VuiNalHrdParameters is off (MFX_BRC_HRD_WEAK)
then there is no need to check some hrd parameters.
This checking was disabled for this case.