### PR TITLE
Fix crash in dispatcher

### DIFF
--- a/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
+++ b/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
@@ -66,8 +66,8 @@ mfxStatus MFX_DISP_HANDLE::Close(void)
 
     mfxRes = UnLoadSelectedDLL();
 
-    // the library wasn't unloaded
-    if (MFX_ERR_NONE != mfxRes)
+    // need to reset dispatcher state after unloading dll
+    if (MFX_ERR_NONE == mfxRes)
     {
         implType = MFX_LIB_SOFTWARE;
         impl = MFX_IMPL_SOFTWARE;


### PR DESCRIPTION
When msdk dll is loaded, table of pointers to function implemented in this dll is filled.
The crash happens when: dll which implements MFXInitEx is loaded ->
pointer to MFXInitEx saved to the table -> dll is unloaded ->
table isn't cleaned -> dll which doesn't implement MFXInitEx is loaded ->
MFXInitEx called by the pointer that points to previous dll -> crash