### PR TITLE
HEVC encoder refactoring

### DIFF
--- a/_studio/mfx_lib/CMakeLists.txt
+++ b/_studio/mfx_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -81,6 +81,7 @@ include_directories( ${MSDK_LIB_ROOT}/fei/h264_common )
 include_directories( ${MSDK_LIB_ROOT}/fei/h264_preenc )
 include_directories( ${MSDK_LIB_ROOT}/fei/h264_pak )
 include_directories( ${MSDK_LIB_ROOT}/fei/h264_enc )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc )
 foreach( dir ${mdirs} )
   include_directories( ${MSDK_LIB_ROOT}/${dir}/include )
 endforeach()

--- a/_studio/mfx_lib/encode_hw/CMakeLists.txt
+++ b/_studio/mfx_lib/encode_hw/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,14 @@ foreach( dir ${Encoders} )
   include_directories( ${MSDK_LIB_ROOT}/encode_hw/${dir}/include )
 endforeach()
 
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/agnostic )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/agnostic/g11 )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/agnostic/g12 )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/linux )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/linux/g11 )
+include_directories( ${MSDK_LIB_ROOT}/encode_hw/hevc/linux/g12 )
+include_directories( ${MSDK_LIB_ROOT}/shared/include)
 include_directories( ${MSDK_LIB_ROOT}/cmrt_cross_platform/include )
 include_directories( ${MSDK_LIB_ROOT}/enc_hw/mpeg2/include )
 include_directories( ${MSDK_LIB_ROOT}/pak/mpeg2/include )
@@ -57,6 +65,40 @@ foreach( prefix ${MSDK_LIB_ROOT}/shared/src )
     ${prefix}/mfx_mpeg2_encode_vaapi.cpp
     )
 endforeach()
+
+list( APPEND sources
+    hevc/hevcehw_disp.cpp
+    hevc/agnostic/hevcehw_base.cpp
+    hevc/agnostic/g11/hevcehw_g11.cpp
+    hevc/agnostic/g11/hevcehw_g11_alloc.cpp
+    hevc/agnostic/g11/hevcehw_g11_constraints.cpp
+    hevc/agnostic/g11/hevcehw_g11_dirty_rect.cpp
+    hevc/agnostic/g11/hevcehw_g11_dpb_report.cpp
+    hevc/agnostic/g11/hevcehw_g11_encoded_frame_info.cpp
+    hevc/agnostic/g11/hevcehw_g11_ext_brc.cpp
+    hevc/agnostic/g11/hevcehw_g11_hdr_sei.cpp
+    hevc/agnostic/g11/hevcehw_g11_hrd.cpp
+    hevc/agnostic/g11/hevcehw_g11_interlace.cpp
+    hevc/agnostic/g11/hevcehw_g11_legacy.cpp
+    hevc/agnostic/g11/hevcehw_g11_legacy_defaults.cpp
+    hevc/agnostic/g11/hevcehw_g11_max_frame_size.cpp
+    hevc/agnostic/g11/hevcehw_g11_packer.cpp
+    hevc/agnostic/g11/hevcehw_g11_parser.cpp
+    hevc/agnostic/g11/hevcehw_g11_roi.cpp
+    hevc/agnostic/g11/hevcehw_g11_task.cpp
+    hevc/agnostic/g11/hevcehw_g11_weighted_prediction.cpp
+    hevc/agnostic/g12/hevcehw_g12_caps.cpp
+    hevc/agnostic/g12/hevcehw_g12_rext.cpp
+    hevc/linux/g11/hevcehw_g11_fei_lin.cpp
+    hevc/linux/g11/hevcehw_g11_interlace_lin.cpp
+    hevc/linux/g11/hevcehw_g11_lin.cpp
+    hevc/linux/g11/hevcehw_g11_roi_lin.cpp
+    hevc/linux/g11/hevcehw_g11_va_lin.cpp
+    hevc/linux/g11/hevcehw_g11_va_packer_lin.cpp
+    hevc/linux/g11/hevcehw_g11_weighted_prediction_lin.cpp
+    hevc/linux/g12/hevcehw_g12_lin.cpp
+    hevc/linux/g12/hevcehw_g12_rext_lin.cpp
+)
 
 make_library( encode hw static )
 

--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw.h
@@ -35,7 +35,7 @@
 namespace MfxHwH265Encode
 {
 
-class MFXVideoENCODEH265_HW : public VideoENCODE
+class MFXVideoENCODEH265_HW : virtual public VideoENCODE
 {
 public:
     MFXVideoENCODEH265_HW(VideoCORE *core, mfxStatus *status)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_legacy.h"
+#include "hevcehw_g11_parser.h"
+#include "hevcehw_g11_packer.h"
+#include "hevcehw_g11_hrd.h"
+#include "hevcehw_g11_alloc.h"
+#include "hevcehw_g11_task.h"
+#include "hevcehw_g11_ext_brc.h"
+#include "hevcehw_g11_dirty_rect.h"
+#include "hevcehw_g11_hdr_sei.h"
+#include "hevcehw_g11_iddi.h"
+#include "hevcehw_g11_iddi_packer.h"
+#include "hevcehw_g11_roi.h"
+#include "hevcehw_g11_interlace.h"
+#if defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+#include "hevcehw_g11_weighted_prediction.h"
+#endif
+#include <algorithm>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+MFXVideoENCODEH265_HW::MFXVideoENCODEH265_HW(VideoCORE& core)
+    : m_core(core)
+    , m_runtimeErr(MFX_ERR_NONE)
+{
+}
+
+void MFXVideoENCODEH265_HW::InternalInitFeatures(
+    mfxStatus& status
+    , eFeatureMode mode)
+{
+    status = MFX_ERR_UNKNOWN;
+
+    for (auto& pFeature : m_features)
+        pFeature->Init(mode, *this);
+
+    if (mode & INIT)
+    {
+        Reorder(
+            BQ<BQ_InitExternal>::Get(*this)
+            , { FEATURE_DDI, IDDI::BLK_CreateDevice }
+            , { FEATURE_LEGACY, Legacy::BLK_SetGUID });
+
+        auto& qII = BQ<BQ_InitInternal>::Get(*this);
+        Reorder(qII
+            , { FEATURE_LEGACY, Legacy::BLK_SetReorder }
+            , { FEATURE_INTERLACE, Interlace::BLK_SetReorder }
+        , PLACE_AFTER);
+        Reorder(qII
+            , { FEATURE_LEGACY, Legacy::BLK_SetRecInfo }
+            , { FEATURE_INTERLACE, Interlace::BLK_PatchRawInfo }
+        , PLACE_AFTER);
+
+        auto& qIA = BQ<BQ_InitAlloc>::Get(*this);
+        Reorder(qIA
+            , { FEATURE_LEGACY, Legacy::BLK_AllocRec }
+            , { FEATURE_DDI, IDDI::BLK_CreateService }
+            , PLACE_AFTER);
+        qIA.splice(qIA.end(), qIA, Get(qIA, { FEATURE_DDI_PACKER, IDDIPacker::BLK_Init }));
+        qIA.splice(qIA.end(), qIA, Get(qIA, { FEATURE_DDI, IDDI::BLK_Register }));
+
+    }
+
+    status = MFX_ERR_NONE;
+}
+
+mfxStatus MFXVideoENCODEH265_HW::InternalQuery(
+    VideoCORE& core
+    , mfxVideoParam *in
+    , mfxVideoParam& out)
+{
+
+    if (!in)
+    {
+        return RunBlocks(IgnoreSts, BQ<BQ_Query0>::Get(*this), out);
+    }
+
+    mfxStatus
+        sts = MFX_ERR_NONE
+        , wrn = MFX_ERR_NONE;
+    StorageRW& strg = m_storage;
+    strg.Insert(Glob::VideoCore::Key, new StorableRef<VideoCORE>(core));
+
+    sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_Query1NoCaps>::Get(*this), *in, out, strg);
+    MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+    wrn = sts;
+
+    sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_Query1WithCaps>::Get(*this), *in, out, strg);
+
+    if (sts == MFX_ERR_INVALID_VIDEO_PARAM)
+        sts = MFX_ERR_UNSUPPORTED;
+
+    return GetWorstSts(wrn, sts);
+}
+
+mfxStatus MFXVideoENCODEH265_HW::InternalQueryIOSurf(
+    VideoCORE& core
+    , mfxVideoParam& par
+    , mfxFrameAllocRequest& request)
+{
+    StorageRW& strg = m_storage;
+    strg.Insert(Glob::VideoCore::Key, new StorableRef<VideoCORE>(core));
+    return RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_QueryIOSurf>::Get(*this), par, request, strg);
+}
+
+mfxStatus MFXVideoENCODEH265_HW::Init(mfxVideoParam *par)
+{
+    MFX_CHECK_NULL_PTR1(par);
+    MFX_CHECK(m_storage.Empty(), MFX_ERR_UNDEFINED_BEHAVIOR);
+    mfxStatus sts = MFX_ERR_NONE, wrn = MFX_ERR_NONE;
+    StorageRW local, global;
+
+    global.Insert(Glob::VideoCore::Key, new StorableRef<VideoCORE>(m_core));
+    global.Insert(Glob::RTErr::Key, new StorableRef<mfxStatus>(m_runtimeErr));
+
+    wrn = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_InitExternal>::Get(*this), *par, global, local);
+    MFX_CHECK(wrn >= MFX_ERR_NONE, wrn);
+
+    sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_InitInternal>::Get(*this), global, local);
+    MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+    wrn = GetWorstSts(sts, wrn);
+
+    sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_InitAlloc>::Get(*this), global, local);
+    MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+    wrn = GetWorstSts(sts, wrn);
+
+    m_storage = std::move(global);
+    m_runtimeErr = MFX_ERR_NONE;
+
+    for (auto& pFeature : m_features)
+        pFeature->Init(RUNTIME, *this);
+
+    {
+        auto& queue = BQ<BQ_ResetState>::Get(*this);
+
+        auto it = Find(queue, { FEATURE_DDI, IDDI::BLK_Reset });
+        if (it != queue.end())
+            queue.splice(queue.end(), queue, it);
+    }
+
+    {
+        auto& queue = BQ<BQ_SubmitTask>::Get(*this);
+        queue.splice(queue.end(), queue, Get(queue, { FEATURE_DDI_PACKER, IDDIPacker::BLK_SubmitTask }));
+        queue.splice(queue.end(), queue, Get(queue, { FEATURE_DDI, IDDI::BLK_SubmitTask }));
+        Reorder(queue, { FEATURE_PACKER, Packer::BLK_SubmitTask }, { FEATURE_HDR_SEI, HdrSei::BLK_InsertPayloads });
+        Reorder(queue, { FEATURE_PACKER, Packer::BLK_SubmitTask }, { FEATURE_INTERLACE, Interlace::BLK_InsertPTSEI });
+        Reorder(queue, { FEATURE_DDI, IDDI::BLK_SubmitTask }, { FEATURE_INTERLACE, Interlace::BLK_PatchDDITask });
+#if defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+        Reorder(queue, { FEATURE_DDI, IDDI::BLK_SubmitTask }, { FEATURE_WEIGHTPRED, WeightPred::BLK_PatchDDITask });
+#endif
+        //update slice qp before packing
+        Reorder(queue, { FEATURE_PACKER, Packer::BLK_SubmitTask }, { FEATURE_EXT_BRC, ExtBRC::BLK_GetFrameCtrl });
+    }
+
+    {
+        auto& queue = BQ<BQ_QueryTask>::Get(*this);
+        Reorder(queue
+            , { FEATURE_LEGACY, Legacy::BLK_DoPadding }
+            , { FEATURE_PACKER, Packer::BLK_InsertSuffixSEI });
+        Reorder(queue
+            , { FEATURE_DDI_PACKER, IDDIPacker::BLK_QueryTask }
+            , { FEATURE_EXT_BRC, ExtBRC::BLK_Update }
+            , PLACE_AFTER);
+    }
+
+    return wrn;
+}
+
+mfxStatus MFXVideoENCODEH265_HW::EncodeFrameCheck(
+    mfxEncodeCtrl *ctrl
+    , mfxFrameSurface1 *surface
+    , mfxBitstream *bs
+    , mfxFrameSurface1 ** /*reordered_surface*/
+    , mfxEncodeInternalParams * /*pInternalParams*/
+    , MFX_ENTRY_POINT *pEntryPoint)
+{
+    MFX_CHECK(!m_storage.Empty(), MFX_ERR_NOT_INITIALIZED);
+    MFX_CHECK_NULL_PTR2(bs, pEntryPoint);
+    MFX_CHECK_STS(m_runtimeErr);
+
+    mfxStatus sts = MFX_ERR_NONE;
+    StorageRW local;
+
+    auto BreakAtSts = [](mfxStatus x)
+    {
+        return
+            (x < MFX_ERR_NONE && x != MFX_ERR_MORE_DATA_SUBMIT_TASK)
+            || x == MFX_WRN_DEVICE_BUSY;
+    };
+    sts = RunBlocks(BreakAtSts, BQ<BQ_FrameSubmit>::Get(*this), ctrl, surface, *bs, m_storage, local);
+    MFX_CHECK(!BreakAtSts(sts), sts);
+
+    pEntryPoint->pState = this;
+    pEntryPoint->pRoutine = Execute;
+    pEntryPoint->pCompleteProc = FreeResources;
+    pEntryPoint->requiredNumThreads = 1;
+    pEntryPoint->pParam = &Tmp::CurrTask::Get(local);
+
+    return sts;
+}
+
+mfxStatus MFXVideoENCODEH265_HW::Execute(mfxThreadTask ptask, mfxU32 /*uid_p*/, mfxU32 /*uid_a*/)
+{
+    MFX_CHECK(!m_storage.Empty(), MFX_ERR_NOT_INITIALIZED);
+    MFX_CHECK_NULL_PTR1(ptask);
+    MFX_CHECK_STS(m_runtimeErr);
+
+    auto& task = *(StorageRW*)ptask;
+
+    return RunBlocks(Check<mfxStatus, MFX_ERR_NONE>, BQ<BQ_AsyncRoutine>::Get(*this), m_storage, task);
+}
+
+mfxStatus MFXVideoENCODEH265_HW::FreeResources(mfxThreadTask /*task*/, mfxStatus /*sts*/)
+{
+    return MFX_ERR_NONE;
+}
+
+mfxStatus MFXVideoENCODEH265_HW::Close(void)
+{
+    MFX_CHECK(!m_storage.Empty(), MFX_ERR_NOT_INITIALIZED);
+
+    auto sts = RunBlocks(IgnoreSts, BQ<BQ_Close>::Get(*this), m_storage);
+
+    m_storage.Clear();
+
+    return sts;
+}
+
+mfxStatus MFXVideoENCODEH265_HW::Reset(mfxVideoParam* par)
+{
+    MFX_CHECK(!m_storage.Empty(), MFX_ERR_NOT_INITIALIZED);
+    MFX_CHECK_NULL_PTR1(par);
+
+    mfxStatus sts = MFX_ERR_NONE, wrn = MFX_ERR_NONE;
+    StorageRW global, local;
+
+    global.Insert(Glob::VideoCore::Key, new StorableRef<VideoCORE>(m_core));
+    global.Insert(Glob::RealState::Key, new StorableRef<StorageW>(m_storage));
+
+    wrn = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_Reset>::Get(*this), *par, global, local);
+    MFX_CHECK(wrn >= MFX_ERR_NONE, wrn);
+
+    sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, BQ<BQ_ResetState>::Get(*this), global, local);
+
+    return GetWorstSts(wrn, sts);
+}
+
+mfxStatus MFXVideoENCODEH265_HW::GetVideoParam(mfxVideoParam* par)
+{
+    MFX_CHECK(!m_storage.Empty(), MFX_ERR_NOT_INITIALIZED);
+    MFX_CHECK_NULL_PTR1(par);
+
+    return RunBlocks(IgnoreSts, BQ<BQ_GetVideoParam>::Get(*this), *par, m_storage);
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11.h
@@ -1,0 +1,157 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "mfx_task.h"
+#include "hevcehw_base.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class MFXVideoENCODEH265_HW
+        : public ImplBase
+        , virtual protected FeatureBlocks
+    {
+    public:
+        MFXVideoENCODEH265_HW(VideoCORE& core);
+
+        virtual ~MFXVideoENCODEH265_HW()
+        {
+            Close();
+        }
+
+        void InternalInitFeatures(
+            mfxStatus& status
+            , eFeatureMode mode);
+
+        virtual mfxStatus Init(mfxVideoParam *par) override;
+
+        virtual mfxStatus Reset(mfxVideoParam *par) override;
+
+        virtual mfxStatus Close(void) override;
+
+        virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
+
+        virtual mfxStatus GetFrameParam(mfxFrameParam * /*par*/) override
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+        virtual mfxStatus GetEncodeStat(mfxEncodeStat* /*stat*/) override
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+
+        virtual mfxStatus EncodeFrameCheck(
+            mfxEncodeCtrl * /*ctrl*/
+            , mfxFrameSurface1 * /*surface*/
+            , mfxBitstream * /*bs*/
+            , mfxFrameSurface1 ** /*reordered_surface*/
+            , mfxEncodeInternalParams * /*pInternalParams*/
+            , MFX_ENTRY_POINT * /*pEntryPoint*/) override;
+
+        virtual mfxStatus EncodeFrame(
+            mfxEncodeCtrl * /*ctrl*/
+            , mfxEncodeInternalParams * /*pInternalParams*/
+            , mfxFrameSurface1 * /*surface*/
+            , mfxBitstream * /*bs*/) override
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+
+        virtual mfxStatus EncodeFrameCheck(
+            mfxEncodeCtrl * /*ctrl*/
+            , mfxFrameSurface1 * /*surface*/
+            , mfxBitstream * /*bs*/
+            , mfxFrameSurface1 ** /*reordered_surface*/
+            , mfxEncodeInternalParams * /*pInternalParams*/) override
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+
+        virtual mfxStatus CancelFrame(
+            mfxEncodeCtrl * /*ctrl*/
+            , mfxEncodeInternalParams * /*pInternalParams*/
+            , mfxFrameSurface1 * /*surface*/
+            , mfxBitstream * /*bs*/) override
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+
+        virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override
+        {
+            return MFX_TASK_THREADING_INTRA;
+        }
+
+        virtual mfxStatus InternalQuery(
+            VideoCORE& core
+            , mfxVideoParam *in
+            , mfxVideoParam& out) override;
+
+        virtual mfxStatus InternalQueryIOSurf(
+            VideoCORE& core
+            , mfxVideoParam& par
+            , mfxFrameAllocRequest& request) override;
+
+    protected:
+        using TFeatureList = std::list<std::unique_ptr<FeatureBase>>;
+        VideoCORE& m_core;
+        TFeatureList m_features;
+        StorageRW m_storage;
+        mfxStatus m_runtimeErr;
+
+        mfxStatus Execute(mfxThreadTask task, mfxU32 uid_p, mfxU32 uid_a);
+        mfxStatus FreeResources(mfxThreadTask task, mfxStatus sts);
+
+        static mfxStatus Execute(void *pState, void *task, mfxU32 uid_p, mfxU32 uid_a)
+        {
+            if (pState)
+                return ((MFXVideoENCODEH265_HW*)pState)->Execute(task, uid_p, uid_a);
+            else
+                return MFX_ERR_UNDEFINED_BEHAVIOR;
+        }
+
+        static mfxStatus FreeResources(void *pState, void *task, mfxStatus sts)
+        {
+            if (pState)
+                return ((MFXVideoENCODEH265_HW*)pState)->FreeResources(task, sts);
+            else
+                return MFX_ERR_UNDEFINED_BEHAVIOR;
+        }
+
+        template<class T>
+        T& GetFeature(mfxU32 id)
+        {
+            using TRFeature = decltype(m_features.front());
+            auto it = std::find_if(m_features.begin(), m_features.end()
+                , [id](TRFeature pFeature) { return pFeature->GetID() == id; });
+            ThrowAssert(it == m_features.end(), "Feature not found");
+            return dynamic_cast<T&>(*it->get());
+        }
+    };
+
+} //Gen11
+}// namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_alloc.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_alloc.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_alloc.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Allocator::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_Init
+        , [](StorageRW&, StorageRW& local) -> mfxStatus
+    {
+        auto CreateAllocator = [](VideoCORE& core) -> IAllocation*
+        {
+            return new MfxFrameAllocResponse(core);
+        };
+
+        local.Insert(Tmp::MakeAlloc::Key, new Tmp::MakeAlloc::TRef(CreateAllocator));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+MfxFrameAllocResponse::MfxFrameAllocResponse(VideoCORE& core)
+    : mfxFrameAllocResponse({})
+    , m_core(core)
+{
+}
+
+MfxFrameAllocResponse::~MfxFrameAllocResponse()
+{
+    Free();
+}
+
+Resource MfxFrameAllocResponse::Acquire()
+{
+    Resource res;
+    res.Idx = mfxU8(std::find(m_locked.begin(), m_locked.end(), 0u) - m_locked.begin());
+
+    if (res.Idx >= NumFrameActual)
+    {
+        res.Idx = IDX_INVALID;
+        return res;
+    }
+
+    Lock(res.Idx);
+    ClearFlag(res.Idx);
+    res.Mid = mids[res.Idx];
+
+    return res;
+}
+
+void MfxFrameAllocResponse::Free()
+{
+
+    if (mids)
+    {
+        NumFrameActual = m_numFrameActualReturnedByAllocFrames;
+        m_core.FreeFrames(this);
+        mids = 0;
+    }
+}
+
+mfxStatus MfxFrameAllocResponse::Alloc(
+    mfxFrameAllocRequest & req,
+    bool                   /*isCopyRequired*/)
+{
+    mfxFrameAllocResponse & response = *this;
+
+    req.NumFrameSuggested = req.NumFrameMin;
+
+    mfxStatus sts = m_core.AllocFrames(&req, &response);
+    MFX_CHECK_STS(sts);
+
+    MFX_CHECK(NumFrameActual >= req.NumFrameMin, MFX_ERR_MEMORY_ALLOC);
+
+    m_locked.resize(req.NumFrameMin, 0);
+    std::fill(m_locked.begin(), m_locked.end(), 0);
+
+    m_flag.resize(req.NumFrameMin, 0);
+    std::fill(m_flag.begin(), m_flag.end(), 0);
+
+    m_numFrameActualReturnedByAllocFrames = NumFrameActual;
+    NumFrameActual = req.NumFrameMin;
+    m_info = req.Info;
+    m_isExternal = false;
+    m_isOpaque = false;
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus MfxFrameAllocResponse::AllocOpaque(
+    const mfxFrameInfo & info
+    , mfxU16 type
+    , mfxFrameSurface1 **surfaces
+    , mfxU16 numSurface)
+{
+    mfxFrameAllocResponse & response = *this;
+    mfxFrameAllocRequest req = {};
+
+    req.Info        = info;
+    req.NumFrameMin = req.NumFrameSuggested = numSurface;
+    req.Type        = type;
+
+    mfxStatus sts = m_core.AllocFrames(&req, &response, surfaces, numSurface);
+    MFX_CHECK_STS(sts);
+    MFX_CHECK(NumFrameActual >= numSurface, MFX_ERR_MEMORY_ALLOC);
+
+    m_info = info;
+    m_numFrameActualReturnedByAllocFrames = NumFrameActual;
+    NumFrameActual = req.NumFrameMin;
+    m_isOpaque = true;
+
+    return sts;
+}
+
+mfxU32 MfxFrameAllocResponse::Lock(mfxU32 idx)
+{
+    if (idx >= m_locked.size())
+        return 0;
+    assert(m_locked[idx] < 0xffffffff);
+    return ++m_locked[idx];
+}
+
+void MfxFrameAllocResponse::ClearFlag(mfxU32 idx)
+{
+   assert (idx < m_flag.size());
+   if (idx < m_flag.size())
+   {
+        m_flag[idx] = 0;
+   }
+}
+void MfxFrameAllocResponse::SetFlag(mfxU32 idx, mfxU32 flag)
+{
+   assert (idx < m_flag.size());
+   if (idx < m_flag.size())
+   {
+        m_flag[idx] |= flag;
+   }
+}
+mfxU32 MfxFrameAllocResponse::GetFlag (mfxU32 idx)
+{
+   assert (idx < m_flag.size());
+   if (idx < m_flag.size())
+   {
+        return m_flag[idx];
+   }
+   return 0;
+}
+
+void MfxFrameAllocResponse::Unlock()
+{
+    std::fill(m_locked.begin(), m_locked.end(), 0);
+    std::fill(m_flag.begin(), m_flag.end(), 0);
+}
+
+mfxU32 MfxFrameAllocResponse::Unlock(mfxU32 idx)
+{
+    if (idx >= m_locked.size())
+        return mfxU32(-1);
+    assert(m_locked[idx] > 0);
+    return --m_locked[idx];
+}
+
+mfxU32 MfxFrameAllocResponse::Locked(mfxU32 idx) const
+{
+    return (idx < m_locked.size()) ? m_locked[idx] : 1;
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_alloc.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_alloc.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+#include "mfxstructures.h"
+#include <vector>
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+class MfxFrameAllocResponse
+    : public mfxFrameAllocResponse
+    , public IAllocation
+{
+public:
+    MfxFrameAllocResponse(VideoCORE& core);
+
+    ~MfxFrameAllocResponse();
+
+    virtual
+    mfxStatus Alloc(
+         mfxFrameAllocRequest & req
+        , bool isCopyRequired) override;
+
+    virtual
+    mfxStatus AllocOpaque(
+        const mfxFrameInfo & info
+        , mfxU16 type
+        , mfxFrameSurface1 **surfaces
+        , mfxU16 numSurface) override;
+
+    virtual
+    const mfxFrameAllocResponse& Response() const override
+    {
+        return *this;
+    }
+
+    virtual
+    const mfxFrameInfo& Info() const override
+    {
+        return m_info;
+    }
+
+    virtual
+    Resource Acquire() override;
+
+    virtual
+    void Release(mfxU32 idx) override
+    {
+        Unlock(idx);
+    }
+
+    virtual void   ClearFlag(mfxU32 idx) override;
+    virtual void   SetFlag(mfxU32 idx, mfxU32 flag) override;
+    virtual mfxU32 GetFlag(mfxU32 idx) override;
+    virtual void   Unlock() override;
+
+    mfxU32  Lock(mfxU32 idx);
+    mfxU32  Unlock(mfxU32 idx);
+    mfxU32  Locked(mfxU32 idx) const;
+
+    virtual void Free();
+
+    bool isExternal() { return m_isExternal; };
+
+
+    mfxFrameInfo m_info = {};
+
+protected:
+    MfxFrameAllocResponse(MfxFrameAllocResponse const &) = delete;
+    MfxFrameAllocResponse & operator =(MfxFrameAllocResponse const &) = delete;
+
+    VideoCORE& m_core;
+    mfxU16 m_numFrameActualReturnedByAllocFrames = 0;
+
+    std::vector<mfxFrameAllocResponse> m_responseQueue;
+    std::vector<mfxMemId>              m_mids;
+    std::vector<mfxU32>                m_locked;
+    std::vector<mfxU32>                m_flag;
+    bool m_isExternal = true;
+    bool m_isOpaque   = false;
+};
+
+class Allocator
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Init)
+#define DECL_FEATURE_NAME "G11_Allocator"
+#include "hevcehw_decl_blocks.h"
+
+    Allocator(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+protected:
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_constraints.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_constraints.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_constraints.h"
+#include <algorithm>
+#include <math.h>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+const mfxU32 TableA1[][6] =
+{
+//  Level   |MaxLumaPs |    MaxCPB    | MaxSlice  | MaxTileRows | MaxTileCols
+//                                      Segments  |
+//                                      PerPicture|
+/*  1   */ {   36864,      350,    350,        16,            1,           1},
+/*  2   */ {  122880,     1500,   1500,        16,            1,           1},
+/*  2.1 */ {  245760,     3000,   3000,        20,            1,           1},
+/*  3   */ {  552960,     6000,   6000,        30,            2,           2},
+/*  3.1 */ {  983040,    10000,  10000,        40,            3,           3},
+/*  4   */ { 2228224,    12000,  30000,        75,            5,           5},
+/*  4.1 */ { 2228224,    20000,  50000,        75,            5,           5},
+/*  5   */ { 8912896,    25000, 100000,       200,           11,          10},
+/*  5.1 */ { 8912896,    40000, 160000,       200,           11,          10},
+/*  5.2 */ { 8912896,    60000, 240000,       200,           11,          10},
+/*  6   */ {35651584,    60000, 240000,       600,           22,          20},
+/*  6.1 */ {35651584,   120000, 480000,       600,           22,          20},
+/*  6.2 */ {35651584,   240000, 800000,       600,           22,          20},
+};
+
+const mfxU32 TableA2[][4] =
+{
+//  Level   | MaxLumaSr |      MaxBR   | MinCr
+/*  1    */ {    552960,    128,    128,    2},
+/*  2    */ {   3686400,   1500,   1500,    2},
+/*  2.1  */ {   7372800,   3000,   3000,    2},
+/*  3    */ {  16588800,   6000,   6000,    2},
+/*  3.1  */ {  33177600,  10000,  10000,    2},
+/*  4    */ {  66846720,  12000,  30000,    4},
+/*  4.1  */ { 133693440,  20000,  50000,    4},
+/*  5    */ { 267386880,  25000, 100000,    6},
+/*  5.1  */ { 534773760,  40000, 160000,    8},
+/*  5.2  */ {1069547520,  60000, 240000,    8},
+/*  6    */ {1069547520,  60000, 240000,    8},
+/*  6.1  */ {2139095040, 120000, 480000,    8},
+/*  6.2  */ {4278190080, 240000, 800000,    6},
+};
+
+const mfxU16 MaxLidx = (sizeof(TableA1) / sizeof(TableA1[0]));
+
+mfxU16 LevelIdx(mfxU16 mfx_level)
+{
+    static const std::map<mfxU16, mfxU16> LevelMFX2STD =
+    {
+          {(mfxU16)MFX_LEVEL_HEVC_1 , (mfxU16) 0}
+        , {(mfxU16)MFX_LEVEL_HEVC_2 , (mfxU16) 1}
+        , {(mfxU16)MFX_LEVEL_HEVC_21, (mfxU16) 2}
+        , {(mfxU16)MFX_LEVEL_HEVC_3 , (mfxU16) 3}
+        , {(mfxU16)MFX_LEVEL_HEVC_31, (mfxU16) 4}
+        , {(mfxU16)MFX_LEVEL_HEVC_4 , (mfxU16) 5}
+        , {(mfxU16)MFX_LEVEL_HEVC_41, (mfxU16) 6}
+        , {(mfxU16)MFX_LEVEL_HEVC_5 , (mfxU16) 7}
+        , {(mfxU16)MFX_LEVEL_HEVC_51, (mfxU16) 8}
+        , {(mfxU16)MFX_LEVEL_HEVC_52, (mfxU16) 9}
+        , {(mfxU16)MFX_LEVEL_HEVC_6 , (mfxU16)10}
+        , {(mfxU16)MFX_LEVEL_HEVC_61, (mfxU16)11}
+        , {(mfxU16)MFX_LEVEL_HEVC_62, (mfxU16)12}
+    };
+    return LevelMFX2STD.at(mfx_level & 0xFF);
+}
+
+mfxU16 TierIdx(mfxU16 mfx_level)
+{
+    return !!(mfx_level & MFX_TIER_HEVC_HIGH);
+}
+
+mfxU16 GetMaxDpbSize(mfxU32 PicSizeInSamplesY, mfxU32 MaxLumaPs, mfxU16 maxDpbPicBuf)
+{
+    if (PicSizeInSamplesY <= (MaxLumaPs >> 2))
+        return std::min<mfxU16>(4 * maxDpbPicBuf, 16);
+    else if (PicSizeInSamplesY <= (MaxLumaPs >> 1))
+        return std::min<mfxU16>(2 * maxDpbPicBuf, 16);
+    else if (PicSizeInSamplesY <= ((3 * MaxLumaPs) >> 2))
+        return std::min<mfxU16>((4 * maxDpbPicBuf) / 3, 16U);
+
+    return maxDpbPicBuf;
+}
+
+mfxU16 HEVCEHW::Gen11::GetMaxDpbSizeByLevel(mfxVideoParam const & par, mfxU32 PicSizeInSamplesY)
+{
+    assert(par.mfx.CodecLevel != 0);
+    return GetMaxDpbSize(PicSizeInSamplesY, TableA1[LevelIdx(par.mfx.CodecLevel)][0], 6);
+}
+
+mfxU32 HEVCEHW::Gen11::GetMaxKbpsByLevel(mfxVideoParam const & par)
+{
+    assert(par.mfx.CodecLevel != 0);
+    return TableA2[LevelIdx(par.mfx.CodecLevel)][1 + TierIdx(par.mfx.CodecLevel)] * 1100 / 1000;
+}
+
+mfxF64 HEVCEHW::Gen11::GetMaxFrByLevel(mfxVideoParam const & par, mfxU32 PicSizeInSamplesY)
+{
+    assert(par.mfx.CodecLevel != 0);
+
+    mfxU32 MaxLumaSr = TableA2[LevelIdx(par.mfx.CodecLevel)][0];
+
+    return (mfxF64)MaxLumaSr / PicSizeInSamplesY;
+}
+
+mfxU32 HEVCEHW::Gen11::GetMaxCpbInKBByLevel(mfxVideoParam const & par)
+{
+    assert(par.mfx.CodecLevel != 0);
+
+    return TableA1[LevelIdx(par.mfx.CodecLevel)][1 + TierIdx(par.mfx.CodecLevel)] * 1100 / 8000;
+}
+
+const mfxU16 LevelIdxToMfx[] =
+{
+    MFX_LEVEL_HEVC_1 ,
+    MFX_LEVEL_HEVC_2 ,
+    MFX_LEVEL_HEVC_21,
+    MFX_LEVEL_HEVC_3 ,
+    MFX_LEVEL_HEVC_31,
+    MFX_LEVEL_HEVC_4 ,
+    MFX_LEVEL_HEVC_41,
+    MFX_LEVEL_HEVC_5 ,
+    MFX_LEVEL_HEVC_51,
+    MFX_LEVEL_HEVC_52,
+    MFX_LEVEL_HEVC_6 ,
+    MFX_LEVEL_HEVC_61,
+    MFX_LEVEL_HEVC_62,
+};
+
+inline mfxU16 MaxTidx(mfxU16 l) { return (LevelIdxToMfx[std::min<mfxU16>(l, MaxLidx)] >= MFX_LEVEL_HEVC_4); }
+
+mfxU16 MfxLevel(mfxU16 l, mfxU16 t) { return LevelIdxToMfx[std::min<mfxU16>(l, MaxLidx)] | (MFX_TIER_HEVC_HIGH * !!t); }
+
+mfxU16 HEVCEHW::Gen11::GetMinLevel(
+      mfxU32 frN
+    , mfxU32 frD
+    , mfxU16 PicWidthInLumaSamples
+    , mfxU16 PicHeightInLumaSamples
+    , mfxU16 MinRef
+    , mfxU16 NumTileColumns
+    , mfxU16 NumTileRows
+    , mfxU32 NumSlice
+    , mfxU32 BufferSizeInKB
+    , mfxU32 MaxKbps
+    , mfxU16 StartLevel)
+{
+    bool bInvalid = frN == 0 || frD == 0;
+    if (bInvalid)
+        return 0;
+
+    mfxU32 CpbBrNalFactor    = 1100;
+    mfxU32 PicSizeInSamplesY = (mfxU32)PicWidthInLumaSamples * PicHeightInLumaSamples;
+    mfxU32 LumaSr            = Ceil(mfxF64(PicSizeInSamplesY) * frN / frD);
+
+    mfxU16 lidx = LevelIdx(StartLevel);
+    mfxU16 tidx = TierIdx(StartLevel);
+    bool bSearch = true;
+
+    while (bSearch)
+    {
+        mfxU32 MaxLumaPs   = TableA1[lidx][0];
+        mfxU32 MaxCPB      = TableA1[lidx][1+tidx];
+        mfxU32 MaxSSPP     = TableA1[lidx][3];
+        mfxU32 MaxTileRows = TableA1[lidx][4];
+        mfxU32 MaxTileCols = TableA1[lidx][5];
+        mfxU32 MaxLumaSr   = TableA2[lidx][0];
+        mfxU32 MaxBR       = TableA2[lidx][1+tidx];
+        //mfxU32 MinCR       = TableA2[lidx][3];
+        mfxU16 MaxDpbSize  = GetMaxDpbSize(PicSizeInSamplesY, MaxLumaPs, 6);
+
+        bool bNextTier =
+            BufferSizeInKB * 8000 > CpbBrNalFactor * MaxCPB
+            || LumaSr > MaxLumaSr
+            || MaxKbps * 1000 > CpbBrNalFactor * MaxBR;
+        bool bMaxTier = bNextTier && tidx >= MaxTidx(lidx);
+
+        bool bNextLevel =
+            PicSizeInSamplesY > MaxLumaPs
+            || PicWidthInLumaSamples > sqrt((mfxF64)MaxLumaPs * 8)
+            || PicHeightInLumaSamples > sqrt((mfxF64)MaxLumaPs * 8)
+            || MinRef + 1 > MaxDpbSize
+            || NumTileColumns > MaxTileCols
+            || NumTileRows > MaxTileRows
+            || NumSlice > MaxSSPP
+            || bMaxTier;
+
+        bNextTier &= !bNextLevel;
+
+        bSearch = (lidx < MaxLidx) && (bNextTier || bNextLevel);
+
+        tidx *= !bMaxTier;
+        tidx += bNextTier;
+        lidx += bNextLevel;
+    }
+
+    return MfxLevel(lidx, tidx);
+}
+
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_constraints.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_constraints.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    mfxU16 GetMaxDpbSizeByLevel(mfxVideoParam const & par, mfxU32 PicSizeInSamplesY);
+    mfxU32 GetMaxKbpsByLevel(mfxVideoParam const & par);
+    mfxF64 GetMaxFrByLevel(mfxVideoParam const & par, mfxU32 PicSizeInSamplesY);
+    mfxU32 GetMaxCpbInKBByLevel(mfxVideoParam const & par);
+
+    mfxU16 GetMinLevel(
+        mfxU32 frN
+        , mfxU32 frD
+        , mfxU16 PicWidthInLumaSamples
+        , mfxU16 PicHeightInLumaSamples
+        , mfxU16 MinRef
+        , mfxU16 NumTileColumns
+        , mfxU16 NumTileRows
+        , mfxU32 NumSlice
+        , mfxU32 BufferSizeInKB
+        , mfxU32 MaxKbps
+        , mfxU16 StartLevel);
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_data.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_data.h
@@ -1,0 +1,1413 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_ddi.h"
+#include <vector>
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    static const GUID DXVA2_Intel_Encode_HEVC_Main =
+    { 0x28566328, 0xf041, 0x4466,{ 0x8b, 0x14, 0x8f, 0x58, 0x31, 0xe7, 0x8f, 0x8b } };
+    static const GUID DXVA2_Intel_Encode_HEVC_Main10 =
+    { 0x6b4a94db, 0x54fe, 0x4ae1,{ 0x9b, 0xe4, 0x7a, 0x7d, 0xad, 0x00, 0x46, 0x00 } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main =
+    { 0xb8b28e0c, 0xecab, 0x4217,{ 0x8c, 0x82, 0xea, 0xaa, 0x97, 0x55, 0xaa, 0xf0 } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main10 =
+    { 0x8732ecfd, 0x9747, 0x4897,{ 0xb4, 0x2a, 0xe5, 0x34, 0xf9, 0xff, 0x2b, 0x7a } };
+    static const GUID DXVA2_Intel_Encode_HEVC_Main422 =
+    { 0x056a6e36, 0xf3a8, 0x4d00,{ 0x96, 0x63, 0x7e, 0x94, 0x30, 0x35, 0x8b, 0xf9 } };
+    static const GUID DXVA2_Intel_Encode_HEVC_Main422_10 =
+    { 0xe139b5ca, 0x47b2, 0x40e1,{ 0xaf, 0x1c, 0xad, 0x71, 0xa6, 0x7a, 0x18, 0x36 } };
+    static const GUID DXVA2_Intel_Encode_HEVC_Main444 =
+    { 0x5415a68c, 0x231e, 0x46f4,{ 0x87, 0x8b, 0x5e, 0x9a, 0x22, 0xe9, 0x67, 0xe9 } };
+    static const GUID DXVA2_Intel_Encode_HEVC_Main444_10 =
+    { 0x161be912, 0x44c2, 0x49c0,{ 0xb6, 0x1e, 0xd9, 0x46, 0x85, 0x2b, 0x32, 0xa1 } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main422 =
+    { 0xcee393ab, 0x1030, 0x4f7b,{ 0x8d, 0xbc, 0x55, 0x62, 0x9c, 0x72, 0xf1, 0x7e } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main422_10 =
+    { 0x580da148, 0xe4bf, 0x49b1,{ 0x94, 0x3b, 0x42, 0x14, 0xab, 0x05, 0xa6, 0xff } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main444 =
+    { 0x87b2ae39, 0xc9a5, 0x4c53,{ 0x86, 0xb8, 0xa5, 0x2d, 0x7e, 0xdb, 0xa4, 0x88 } };
+    static const GUID DXVA2_Intel_LowpowerEncode_HEVC_Main444_10 =
+    { 0x10e19ac8, 0xbf39, 0x4443,{ 0xbe, 0xc3, 0x1b, 0x0c, 0xbf, 0xe4, 0xc7, 0xaa } };
+
+    class EndOfBuffer : public std::exception
+    {
+    public:
+        EndOfBuffer() : std::exception() {}
+    };
+
+    constexpr mfxU8  MAX_DPB_SIZE               = 15;
+    constexpr mfxU8  IDX_INVALID                = 0xff;
+    constexpr mfxU8  HW_SURF_ALIGN_W            = 16;
+    constexpr mfxU8  HW_SURF_ALIGN_H            = 16;
+    constexpr mfxU16 MAX_SLICES                 = 600; // conforms to level 6 limits
+    constexpr mfxU8  DEFAULT_LTR_INTERVAL       = 16;
+    constexpr mfxU8  DEFAULT_PPYR_INTERVAL      = 3;
+    constexpr mfxU16 GOP_INFINITE               = 0xFFFF;
+    constexpr mfxU8  MAX_NUM_TILE_COLUMNS       = 20;
+    constexpr mfxU8  MAX_NUM_TILE_ROWS          = 22;
+    constexpr mfxU8  MAX_NUM_LONG_TERM_PICS     = 8;
+    constexpr mfxU16 MIN_TILE_WIDTH_IN_SAMPLES  = 256;
+    constexpr mfxU16 MIN_TILE_HEIGHT_IN_SAMPLES = 64;
+
+    enum NALU_TYPE
+    {
+        TRAIL_N = 0,
+        TRAIL_R,
+        TSA_N, TSA_R,
+        STSA_N, STSA_R,
+        RADL_N, RADL_R,
+        RASL_N, RASL_R,
+        RSV_VCL_N10, RSV_VCL_R11, RSV_VCL_N12, RSV_VCL_R13, RSV_VCL_N14, RSV_VCL_R15,
+        BLA_W_LP, BLA_W_RADL, BLA_N_LP,
+        IDR_W_RADL, IDR_N_LP,
+        CRA_NUT,
+        RSV_IRAP_VCL22, RSV_IRAP_VCL23,
+        RSV_VCL24, RSV_VCL25, RSV_VCL26, RSV_VCL27, RSV_VCL28, RSV_VCL29, RSV_VCL30, RSV_VCL31,
+        VPS_NUT,
+        SPS_NUT,
+        PPS_NUT,
+        AUD_NUT,
+        EOS_NUT,
+        EOB_NUT,
+        FD_NUT,
+        PREFIX_SEI_NUT,
+        SUFFIX_SEI_NUT,
+        RSV_NVCL41, RSV_NVCL42, RSV_NVCL43, RSV_NVCL44, RSV_NVCL45, RSV_NVCL46, RSV_NVCL47,
+        UNSPEC48, UNSPEC49, UNSPEC50, UNSPEC51, UNSPEC52, UNSPEC53, UNSPEC54, UNSPEC55,
+        UNSPEC56, UNSPEC57, UNSPEC58, UNSPEC59, UNSPEC60, UNSPEC61, UNSPEC62, UNSPEC63,
+        num_NALU_TYPE
+    };
+
+    struct PTL
+    {
+        mfxU8  profile_space : 2;
+        mfxU8  tier_flag     : 1;
+        mfxU8  profile_idc   : 5;
+
+        mfxU8  progressive_source_flag    : 1;
+        mfxU8  interlaced_source_flag     : 1;
+        mfxU8  non_packed_constraint_flag : 1;
+        mfxU8  frame_only_constraint_flag : 1;
+        mfxU8  profile_present_flag       : 1;
+        mfxU8  level_present_flag         : 1;
+        mfxU8                             : 2;
+        mfxU8  level_idc;
+
+        mfxU32 profile_compatibility_flags;
+
+        union
+        {
+            mfxU32 rext_constraint_flags_0_31;
+
+            struct
+            {
+                mfxU32 max_12bit        : 1;
+                mfxU32 max_10bit        : 1;
+                mfxU32 max_8bit         : 1;
+                mfxU32 max_422chroma    : 1;
+                mfxU32 max_420chroma    : 1;
+                mfxU32 max_monochrome   : 1;
+                mfxU32 intra            : 1;
+                mfxU32 one_picture_only : 1;
+                mfxU32 lower_bit_rate   : 1;
+                mfxU32                  : 23;
+            } constraint;
+        };
+        mfxU32 rext_constraint_flags_32_42  : 11;
+        mfxU32 inbld_flag                   :  1;
+        mfxU32                              : 20;
+    };
+
+    struct SubLayerOrdering
+    {
+        mfxU8  max_dec_pic_buffering_minus1 : 4;
+        mfxU8  max_num_reorder_pics         : 4;
+        mfxU32 max_latency_increase_plus1;
+    };
+
+    struct STRPS
+    {
+        mfxU8  inter_ref_pic_set_prediction_flag : 1;
+        mfxU8  delta_idx_minus1                  : 6;
+        mfxU8  delta_rps_sign                    : 1;
+
+        mfxU8  num_negative_pics : 4;
+        mfxU8  num_positive_pics : 4;
+
+        mfxU16 abs_delta_rps_minus1;
+        mfxU16 WeightInGop;
+
+        struct Pic
+        {
+            mfxU8 used_by_curr_pic_flag   : 1;
+            mfxU8 use_delta_flag          : 1;
+            mfxI16 DeltaPocSX;
+
+            union
+            {
+                struct
+                {
+                    mfxU16 delta_poc_s0_minus1      : 15;
+                    mfxU16 used_by_curr_pic_s0_flag : 1;
+                };
+                struct
+                {
+                    mfxU16 delta_poc_s1_minus1      : 15;
+                    mfxU16 used_by_curr_pic_s1_flag : 1;
+                };
+                struct
+                {
+                    mfxU16 delta_poc_sx_minus1      : 15;
+                    mfxU16 used_by_curr_pic_sx_flag : 1;
+                };
+            };
+        }pic[16];
+    };
+
+    using STRPSPic = STRPS::Pic;
+
+    struct LayersInfo
+    {
+        mfxU8 sub_layer_ordering_info_present_flag : 1;
+        PTL general;
+        struct SubLayer : PTL, SubLayerOrdering {} sub_layer[8];
+    };
+
+
+    struct HRDInfo
+    {
+        mfxU16 nal_hrd_parameters_present_flag              : 1;
+        mfxU16 vcl_hrd_parameters_present_flag              : 1;
+        mfxU16 sub_pic_hrd_params_present_flag              : 1;
+        mfxU16 du_cpb_removal_delay_increment_length_minus1 : 5;
+        mfxU16 sub_pic_cpb_params_in_pic_timing_sei_flag    : 1;
+        mfxU16 dpb_output_delay_du_length_minus1            : 5;
+
+        mfxU16 tick_divisor_minus2                          : 8;
+        mfxU16 bit_rate_scale                               : 4;
+        mfxU16 cpb_size_scale                               : 4;
+
+        mfxU8  cpb_size_du_scale                            : 4;
+        mfxU16 initial_cpb_removal_delay_length_minus1      : 5;
+        mfxU16 au_cpb_removal_delay_length_minus1           : 5;
+        mfxU16 dpb_output_delay_length_minus1               : 5;
+
+        struct SubLayer
+        {
+            mfxU8  fixed_pic_rate_general_flag     :  1;
+            mfxU8  fixed_pic_rate_within_cvs_flag  :  1;
+            mfxU8  low_delay_hrd_flag              :  1;
+
+            mfxU16 elemental_duration_in_tc_minus1 : 11;
+            mfxU16 cpb_cnt_minus1                  :  5;
+
+            struct CPB
+            {
+                mfxU32 bit_rate_value_minus1;
+                mfxU32 cpb_size_value_minus1;
+                mfxU32 cpb_size_du_value_minus1;
+                mfxU32 bit_rate_du_value_minus1;
+                mfxU8  cbr_flag;
+            } cpb[32];
+        } sl[8];
+    };
+
+    struct BufferingPeriodSEI
+    {
+        mfxU8  seq_parameter_set_id         : 4;
+        mfxU8  irap_cpb_params_present_flag : 1;
+        mfxU8  concatenation_flag           : 1;
+
+        mfxU32 cpb_delay_offset;
+        mfxU32 dpb_delay_offset;
+        mfxU32 au_cpb_removal_delay_delta_minus1;
+
+        struct CPB{
+            mfxU32 initial_cpb_removal_delay;
+            mfxU32 initial_cpb_removal_offset;
+            mfxU32 initial_alt_cpb_removal_delay;
+            mfxU32 initial_alt_cpb_removal_offset;
+        } nal[32], vcl[32];
+    };
+
+    struct PicTimingSEI
+    {
+        mfxU8  pic_struct                       : 4;
+        mfxU8  source_scan_type                 : 2;
+        mfxU8  duplicate_flag                   : 1;
+        mfxU8  du_common_cpb_removal_delay_flag : 1;
+
+        mfxU32 au_cpb_removal_delay_minus1;
+        mfxU32 pic_dpb_output_delay;
+        mfxU32 pic_dpb_output_du_delay;
+        mfxU32 num_decoding_units_minus1;
+        mfxU32 du_common_cpb_removal_delay_increment_minus1;
+
+        mfxU32* num_nalus_in_du_minus1;
+        mfxU32* du_cpb_removal_delay_increment_minus1;
+    };
+
+    struct VPS : LayersInfo
+    {
+        mfxU16 video_parameter_set_id   : 4;
+        mfxU16 reserved_three_2bits     : 2;
+        mfxU16 max_layers_minus1        : 6;
+        mfxU16 max_sub_layers_minus1    : 3;
+        mfxU16 temporal_id_nesting_flag : 1;
+        mfxU16 reserved_0xffff_16bits;
+
+        mfxU16 max_layer_id          :  6;
+        mfxU16 num_layer_sets_minus1 : 10;
+
+        //mfxU8** layer_id_included_flag; // max [1024][64];
+
+        mfxU32 num_units_in_tick;
+        mfxU32 time_scale;
+        mfxU32 timing_info_present_flag        : 1;
+        mfxU32 poc_proportional_to_timing_flag : 1;
+        mfxU32 num_ticks_poc_diff_one_minus1 : 10;
+        mfxU32 num_hrd_parameters            : 10;
+
+        //VPSHRD* hrd; //max 1024
+    };
+
+
+    struct VUI
+    {
+        mfxU8  aspect_ratio_info_present_flag : 1;
+        mfxU8  aspect_ratio_idc;
+        mfxU16 sar_width;
+        mfxU16 sar_height;
+
+        mfxU8  overscan_info_present_flag      : 1;
+        mfxU8  overscan_appropriate_flag       : 1;
+        mfxU8  video_signal_type_present_flag  : 1;
+        mfxU8  video_format                    : 3;
+        mfxU8  video_full_range_flag           : 1;
+        mfxU8  colour_description_present_flag : 1;
+        mfxU8  colour_primaries;
+        mfxU8  transfer_characteristics;
+        mfxU8  matrix_coeffs;
+
+        mfxU8  chroma_loc_info_present_flag        : 1;
+        mfxU8  chroma_sample_loc_type_top_field    : 3;
+        mfxU8  chroma_sample_loc_type_bottom_field : 3;
+    
+        mfxU8  neutral_chroma_indication_flag : 1;
+        mfxU8  field_seq_flag                 : 1;
+        mfxU8  frame_field_info_present_flag  : 1;
+        mfxU8  default_display_window_flag    : 1;
+
+        mfxU32 def_disp_win_left_offset;
+        mfxU32 def_disp_win_right_offset;
+        mfxU32 def_disp_win_top_offset;
+        mfxU32 def_disp_win_bottom_offset;
+
+        mfxU8  timing_info_present_flag        : 1;
+        mfxU8  hrd_parameters_present_flag     : 1;
+        mfxU8  poc_proportional_to_timing_flag : 1;
+
+        mfxU8  bitstream_restriction_flag              : 1;
+        mfxU8  tiles_fixed_structure_flag              : 1;
+        mfxU8  motion_vectors_over_pic_boundaries_flag : 1;
+        mfxU8  restricted_ref_pic_lists_flag           : 1;
+
+        mfxU32 num_units_in_tick;
+        mfxU32 time_scale;
+        mfxU32 num_ticks_poc_diff_one_minus1;
+
+        mfxU32 min_spatial_segmentation_idc : 12;
+        mfxU32 max_bytes_per_pic_denom      :  5;
+        mfxU32 max_bits_per_min_cu_denom    :  5;
+        mfxU16 log2_max_mv_length_horizontal : 5;
+        mfxU16 log2_max_mv_length_vertical   : 4;
+
+        HRDInfo hrd;
+    };
+
+    struct ScalingList
+    {
+        mfxU8 scalingLists0[6][16];
+        mfxU8 scalingLists1[6][64];
+        mfxU8 scalingLists2[6][64];
+        mfxU8 scalingLists3[2][64];
+        mfxU8 scalingListDCCoefSizeID2[6];
+        mfxU8 scalingListDCCoefSizeID3[2];
+    };
+
+    struct SPS : LayersInfo
+    {
+        mfxU8  video_parameter_set_id   : 4;
+        mfxU8  max_sub_layers_minus1    : 3;
+        mfxU8  temporal_id_nesting_flag : 1;
+
+        mfxU8  seq_parameter_set_id       : 4;
+        mfxU8  chroma_format_idc          : 2;
+        mfxU8  separate_colour_plane_flag : 1;
+        mfxU8  conformance_window_flag    : 1;
+
+        mfxU32 pic_width_in_luma_samples;
+        mfxU32 pic_height_in_luma_samples;
+
+        mfxU32 conf_win_left_offset;
+        mfxU32 conf_win_right_offset;
+        mfxU32 conf_win_top_offset;
+        mfxU32 conf_win_bottom_offset;
+
+        mfxU8  bit_depth_luma_minus8                : 3;
+        mfxU8  bit_depth_chroma_minus8              : 3;
+        mfxU8  log2_max_pic_order_cnt_lsb_minus4    : 4;
+        //mfxU8  sub_layer_ordering_info_present_flag : 1;
+
+        mfxU32 log2_min_luma_coding_block_size_minus3;
+        mfxU32 log2_diff_max_min_luma_coding_block_size;
+        mfxU32 log2_min_transform_block_size_minus2;
+        mfxU32 log2_diff_max_min_transform_block_size;
+        mfxU32 max_transform_hierarchy_depth_inter;
+        mfxU32 max_transform_hierarchy_depth_intra;
+
+        mfxU8  scaling_list_enabled_flag      : 1;
+        mfxU8  scaling_list_data_present_flag : 1;
+    
+        mfxU8  amp_enabled_flag                    : 1;
+        mfxU8  sample_adaptive_offset_enabled_flag : 1;
+
+        mfxU8  pcm_enabled_flag                    : 1;
+        mfxU8  pcm_loop_filter_disabled_flag       : 1;
+        mfxU8  pcm_sample_bit_depth_luma_minus1    : 4;
+        mfxU8  pcm_sample_bit_depth_chroma_minus1  : 4;
+        mfxU32 log2_min_pcm_luma_coding_block_size_minus3;
+        mfxU32 log2_diff_max_min_pcm_luma_coding_block_size;
+
+        mfxU8  long_term_ref_pics_present_flag : 1;
+        mfxU8  num_long_term_ref_pics_sps      : 6;
+
+        mfxU16 lt_ref_pic_poc_lsb_sps[32];
+        mfxU8  used_by_curr_pic_lt_sps_flag[32];
+
+        mfxU8  temporal_mvp_enabled_flag           : 1;
+        mfxU8  strong_intra_smoothing_enabled_flag : 1;
+        mfxU8  vui_parameters_present_flag         : 1;
+        mfxU8  extension_flag                      : 1;
+        mfxU8  extension_data_flag                 : 1;
+
+        mfxU8 range_extension_flag                    : 1;
+        mfxU8 transform_skip_rotation_enabled_flag    : 1;
+        mfxU8 transform_skip_context_enabled_flag     : 1;
+        mfxU8 implicit_rdpcm_enabled_flag             : 1;
+        mfxU8 explicit_rdpcm_enabled_flag             : 1;
+        mfxU8 extended_precision_processing_flag      : 1;
+        mfxU8 intra_smoothing_disabled_flag           : 1;
+        mfxU8 high_precision_offsets_enabled_flag     : 1;
+        mfxU8 persistent_rice_adaptation_enabled_flag : 1;
+        mfxU8 cabac_bypass_alignment_enabled_flag     : 1;
+
+        mfxU8 ExtensionFlags;
+        mfxU8 num_short_term_ref_pic_sets;
+        STRPS strps[65];
+
+        ScalingList scl;
+        VUI vui;
+    };
+
+    struct PPS
+    {
+        mfxU16 pic_parameter_set_id : 6;
+        mfxU16 seq_parameter_set_id : 4;
+        mfxU16 dependent_slice_segments_enabled_flag : 1;
+        mfxU16 output_flag_present_flag              : 1;
+        mfxU16 num_extra_slice_header_bits           : 3;
+        mfxU16 sign_data_hiding_enabled_flag         : 1;
+        mfxU16 cabac_init_present_flag               : 1;
+        mfxU16 num_ref_idx_l0_default_active_minus1  : 4;
+        mfxU16 num_ref_idx_l1_default_active_minus1  : 4;
+        mfxU16 constrained_intra_pred_flag           : 1;
+        mfxU16 transform_skip_enabled_flag           : 1;
+        mfxU16 cu_qp_delta_enabled_flag              : 1;
+        mfxU16 slice_segment_header_extension_present_flag : 1;
+
+        mfxU32 diff_cu_qp_delta_depth;
+        mfxI32 init_qp_minus26;
+        mfxI16 cb_qp_offset : 6;
+        mfxI16 cr_qp_offset : 6;
+
+        mfxU8  slice_chroma_qp_offsets_present_flag  : 1;
+        mfxU8  weighted_pred_flag                    : 1;
+        mfxU8  weighted_bipred_flag                  : 1;
+        mfxU8  transquant_bypass_enabled_flag        : 1;
+        mfxU8  tiles_enabled_flag                    : 1;
+        mfxU8  entropy_coding_sync_enabled_flag      : 1;
+        mfxU8  uniform_spacing_flag                  : 1;
+        mfxU8  loop_filter_across_tiles_enabled_flag : 1;
+
+        mfxU16 num_tile_columns_minus1;
+        mfxU16 num_tile_rows_minus1;
+
+        mfxU16 column_width[MAX_NUM_TILE_COLUMNS - 1];
+        mfxU16 row_height[MAX_NUM_TILE_ROWS - 1];
+
+        mfxU8  loop_filter_across_slices_enabled_flag  : 1;
+        mfxU8  deblocking_filter_control_present_flag  : 1;
+        mfxU8  deblocking_filter_override_enabled_flag : 1;
+        mfxU8  deblocking_filter_disabled_flag         : 1;
+        mfxU8  scaling_list_data_present_flag          : 1;
+        mfxU8  lists_modification_present_flag         : 1;
+        mfxU8  extension_flag                          : 1;
+        mfxU8  extension_data_flag                     : 1;
+
+        mfxI8  beta_offset_div2 : 4;
+        mfxI8  tc_offset_div2   : 4;
+
+        //ScalingListData* sld;
+
+        mfxU16 log2_parallel_merge_level_minus2;
+
+        mfxU32 range_extension_flag                      : 1;
+        mfxU32 cross_component_prediction_enabled_flag   : 1;
+        mfxU32 chroma_qp_offset_list_enabled_flag        : 1;
+        mfxU32 log2_sao_offset_scale_luma                : 3;
+        mfxU32 log2_sao_offset_scale_chroma              : 3;
+        mfxU32 chroma_qp_offset_list_len_minus1          : 3;
+        mfxU32 diff_cu_chroma_qp_offset_depth            : 5;
+        mfxU32 log2_max_transform_skip_block_size_minus2 : 5;
+        mfxU32                                           : 10;
+        mfxI8  cb_qp_offset_list[6];
+        mfxI8  cr_qp_offset_list[6];
+
+        mfxU8 ExtensionFlags;
+    };
+
+    struct Slice
+    {
+        mfxU8  no_output_of_prior_pics_flag    : 1;
+        mfxU8  pic_parameter_set_id            : 6;
+        mfxU8  dependent_slice_segment_flag    : 1;
+
+        mfxU32 segment_address;
+
+        mfxU8  reserved_flags;
+        mfxU8  type                       : 2;
+        mfxU8  colour_plane_id            : 2;
+        mfxU8  short_term_ref_pic_set_idx;
+
+        mfxU8  pic_output_flag                 : 1;
+        mfxU8  short_term_ref_pic_set_sps_flag : 1;
+        mfxU8  num_long_term_sps               : 6;
+
+        mfxU8  first_slice_segment_in_pic_flag  : 1;
+        mfxU8  temporal_mvp_enabled_flag        : 1;
+        mfxU8  sao_luma_flag                    : 1;
+        mfxU8  sao_chroma_flag                  : 1;
+        mfxU8  num_ref_idx_active_override_flag : 1;
+        mfxU8  mvd_l1_zero_flag                 : 1;
+        mfxU8  cabac_init_flag                  : 1;
+        mfxU8  collocated_from_l0_flag          : 1;
+
+        mfxU8  collocated_ref_idx            : 4;
+        mfxU8  five_minus_max_num_merge_cand : 3;
+
+        mfxU8  num_ref_idx_l0_active_minus1 : 4;
+        mfxU8  num_ref_idx_l1_active_minus1 : 4;
+
+        mfxU32 pic_order_cnt_lsb;
+        mfxU16 num_long_term_pics;
+
+        mfxI8  slice_qp_delta;
+        mfxI16 slice_cb_qp_offset : 6;
+        mfxI16 slice_cr_qp_offset : 6;
+
+        mfxU8  deblocking_filter_override_flag        : 1;
+        mfxU8  deblocking_filter_disabled_flag        : 1;
+        mfxU8  loop_filter_across_slices_enabled_flag : 1;
+        mfxU8  offset_len_minus1                      : 5;
+
+        mfxI8  beta_offset_div2 : 4;
+        mfxI8  tc_offset_div2   : 4;
+
+        mfxU32 num_entry_point_offsets;
+
+        STRPS strps;
+
+        struct LongTerm
+        {
+            mfxU8  lt_idx_sps                 :  5;
+            mfxU8  used_by_curr_pic_lt_flag   :  1;
+            mfxU8  delta_poc_msb_present_flag :  1;
+            mfxU32 poc_lsb_lt;
+            mfxU32 delta_poc_msb_cycle_lt;
+        } lt[MAX_NUM_LONG_TERM_PICS];
+
+        mfxU8  ref_pic_list_modification_flag_lx[2];
+        mfxU8  list_entry_lx[2][16];
+
+        mfxU16 luma_log2_weight_denom   : 3;
+        mfxU16 chroma_log2_weight_denom : 3;
+        mfxI16 pwt[2][16][3][2]; //[list][list entry][Y, Cb, Cr][weight, offset]
+    };
+
+    struct NALU
+    {
+        mfxU16 long_start_code       : 1;
+        mfxU16 nal_unit_type         : 6;
+        mfxU16 nuh_layer_id          : 6;
+        mfxU16 nuh_temporal_id_plus1 : 3;
+    };
+
+    struct Resource
+    {
+        mfxU8    Idx = IDX_INVALID;
+        mfxMemId Mid = nullptr;
+    };
+
+    class IAllocation
+        : public Storable
+    {
+    public:
+        virtual ~IAllocation() {}
+
+        virtual
+        mfxStatus Alloc(
+             mfxFrameAllocRequest & req
+            , bool isCopyRequired) = 0;
+
+        virtual
+        mfxStatus AllocOpaque(
+            const mfxFrameInfo & info
+            , mfxU16 type
+            , mfxFrameSurface1 **surfaces
+            , mfxU16 numSurface) = 0;
+
+        virtual
+        const mfxFrameAllocResponse& Response() const = 0;
+
+        virtual
+        const mfxFrameInfo& Info() const = 0;
+
+        virtual
+        Resource Acquire() = 0;
+
+        virtual
+        void Release(mfxU32 idx) = 0;
+
+        virtual void   ClearFlag(mfxU32 idx) = 0;
+        virtual void   SetFlag(mfxU32 idx, mfxU32 flag) = 0;
+        virtual mfxU32 GetFlag(mfxU32 idx) = 0;
+        virtual void Unlock() = 0;
+    };
+
+    class IBsReader
+    {
+    public:
+        virtual ~IBsReader() {}
+        virtual mfxU32 GetBit() = 0;
+        virtual mfxU32 GetBits(mfxU32 n) = 0;
+        virtual mfxU32 GetUE() = 0;
+        virtual mfxI32 GetSE() = 0;
+
+        //conditional read
+        template<class TDefault>
+        mfxU32 CondBits(bool bRead, mfxU32 nBits, TDefault defaultVal)
+        {
+            return bRead ? GetBits(nBits) : mfxU32(defaultVal);
+        }
+        template<class TDefault>
+        mfxU32 CondBit(bool bRead, TDefault defaultVal)
+        {
+            return bRead ? GetBit() : mfxU32(defaultVal);
+        }
+        template<class TDefault>
+        mfxU32 CondUE(bool bRead, TDefault defaultVal)
+        {
+            return bRead ? GetUE() : mfxU32(defaultVal);
+        }
+        template<class TDefault>
+        mfxI32 CondSE(bool bRead, TDefault defaultVal)
+        {
+            return bRead ? GetSE() : mfxI32(defaultVal);
+        }
+
+    };
+
+    class IBsWriter
+    {
+    public:
+        virtual ~IBsWriter() {}
+        virtual void PutBits(mfxU32 n, mfxU32 b) = 0;
+        virtual void PutBit(mfxU32 b) = 0;
+        virtual void PutUE(mfxU32 b) = 0;
+        virtual void PutSE(mfxI32 b) = 0;
+    };
+
+    struct SliceInfo
+    {
+        mfxU32 SegmentAddress;
+        mfxU32 NumLCU;
+    };
+
+    constexpr mfxU8 CODING_TYPE_I  = 1;
+    constexpr mfxU8 CODING_TYPE_P  = 2;
+    constexpr mfxU8 CODING_TYPE_B  = 3; //regular B, or no reference to other B frames
+    constexpr mfxU8 CODING_TYPE_B1 = 4; //B1, reference to only I, P or regular B frames
+    constexpr mfxU8 CODING_TYPE_B2 = 5; //B2, references include B1
+
+    // Min frame params required for Reorder, RPL/DPB management
+    struct FrameBaseInfo 
+        : Storable
+    {
+        mfxI32   POC            = -1;
+        mfxU16   FrameType      = 0;
+        bool     isLDB          = false; // is "low-delay B"
+        mfxU8    TemporalID     = 0;
+        mfxU32   BPyramidOrder  = mfxU32(MFX_FRAMEORDER_UNKNOWN);
+        mfxU32   PyramidLevel   = 0;
+        bool     bBottomField   = false;
+        bool     b2ndField      = false;
+    };
+
+    typedef struct _DpbFrame
+        : FrameBaseInfo
+    {
+        mfxU32   DisplayOrder   = mfxU32(-1);
+        mfxU32   EncodedOrder   = mfxU32(-1);
+        bool     isLTR          = false; // is "long-term"
+        mfxU8    CodingType     = 0;
+        Resource Raw;
+        Resource Rec;
+        mfxFrameSurface1* pSurfIn = nullptr; //input surface, may be opaque
+    } DpbFrame, DpbArray[MAX_DPB_SIZE];
+
+    enum eSkipMode
+    {
+        SKIPFRAME_NO = 0
+        , SKIPFRAME_INSERT_DUMMY
+        , SKIPFRAME_INSERT_DUMMY_PROTECTED
+        , SKIPFRAME_INSERT_NOTHING
+        , SKIPFRAME_BRC_ONLY
+        , SKIPFRAME_EXT_PSEUDO
+    };
+
+    enum eSkipCmd
+    {
+        SKIPCMD_NeedInputReplacement        = (1 << 0)
+        , SKIPCMD_NeedDriverCall            = (1 << 1)
+        , SKIPCMD_NeedSkipSliceGen          = (1 << 2)
+        , SKIPCMD_NeedCurrentFrameSkipping  = (1 << 3)
+        , SKIPCMD_NeedNumSkipAdding         = (1 << 4)
+    };
+
+    struct IntraRefreshState
+    {
+        mfxU16  refrType;
+        mfxU16  IntraLocation;
+        mfxU16  IntraSize;
+        mfxI16  IntRefQPDelta;
+        bool    firstFrameInCycle;
+    };
+
+    enum eInsertHeader
+    {
+        INSERT_AUD      = 0x01,
+        INSERT_VPS      = 0x02,
+        INSERT_SPS      = 0x04,
+        INSERT_PPS      = 0x08,
+        INSERT_BPSEI    = 0x10,
+        INSERT_PTSEI    = 0x20,
+        INSERT_DCVSEI   = 0x40,
+        INSERT_LLISEI   = 0x80,
+        INSERT_SEI      = (INSERT_BPSEI | INSERT_PTSEI | INSERT_DCVSEI | INSERT_LLISEI)
+    };
+
+    enum eRecFlag
+    {
+        REC_SKIPPED = 1
+        , REC_READY = 2
+    };
+
+    struct TaskCommonPar
+        : DpbFrame
+    {
+        mfxU32              stage               = 0;
+        mfxU32              MinFrameSize        = 0;
+        mfxU32              BsDataLength        = 0;
+        mfxU32              BsBytesAvailable    = 0;
+        mfxU8*              pBsData             = nullptr;
+        mfxU32*             pBsDataLength       = nullptr;
+        mfxBitstream*       pBsOut              = nullptr;
+        mfxFrameSurface1*   pSurfReal           = nullptr;
+        mfxEncodeCtrl       ctrl                = {};
+        mfxU32              SkipCMD             = 0;
+        Resource            BS;
+        Resource            CUQP;
+        mfxHDLPair          HDLRaw              = {};
+        bool                bCUQPMap            = false;
+        bool                bForceSync          = false;
+        bool                bSkip               = false;
+        bool                bResetBRC           = false;
+        bool                bDontPatchBS        = false;
+        bool                bRecode             = false;
+        bool                bForceLongStartCode = false;
+        IntraRefreshState   IRState             = {};
+        mfxI32              PrevIPoc            = -1;
+        mfxI32              PrevRAP             = -1;
+        mfxU16              NumRecode           = 0;
+        mfxI8               QpY                 = 0;
+        mfxU8               SliceNUT            = 0;
+        mfxU32              InsertHeaders       = 0;
+        mfxU32              RepackHeaders       = 0;
+        mfxU32              StatusReportId      = mfxU32(-1);
+
+        mfxU32              initial_cpb_removal_delay   = 0;
+        mfxU32              initial_cpb_removal_offset  = 0;
+        mfxU32              cpb_removal_delay           = 0;
+        //dpb_output_delay = (DisplayOrder + sps.sub_layer[0].max_num_reorder_pics - EncodedOrder);
+
+        mfxU8 RefPicList[2][MAX_DPB_SIZE] =
+        {
+            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+        };
+        mfxU8 NumRefActive[2] = {};
+
+        struct DPBs
+        {
+            DpbArray 
+                Active   // available during task execution (modified dpb[BEFORE] )
+                , After  // after task execution (ACTIVE + curTask if ref)
+                , Before // after previous task execution (prevTask dpb[AFTER])
+                ;
+        } DPB;
+        std::list<mfxPayload> PLInternal = {};
+    };
+
+    inline void Invalidate(TaskCommonPar& par)
+    {
+        par = TaskCommonPar();
+    }
+    inline bool isValid(DpbFrame const & frame) { return IDX_INVALID != frame.Rec.Idx; }
+    inline bool isDpbEnd(DpbArray const & dpb, mfxU32 idx) { return idx >= MAX_DPB_SIZE || !isValid(dpb[idx]); }
+
+    class FrameLocker
+        : public mfxFrameData
+    {
+    public:
+        mfxU32 Pitch;
+
+        FrameLocker(VideoCORE& core, mfxMemId memId, bool external = false)
+            : m_data(*this)
+            , m_core(core)
+            , m_memId(memId)
+        {
+            m_data   = {};
+            m_status = Lock(external);
+            Pitch    = (mfxFrameData::PitchHigh << 16) + mfxFrameData::PitchLow;
+        }
+        FrameLocker(VideoCORE& core, mfxFrameData& data, bool external = false)
+            : m_data(data)
+            , m_core(core)
+            , m_memId(data.MemId)
+            , m_status(Lock(external))
+        {
+            Pitch = (mfxFrameData::PitchHigh << 16) + mfxFrameData::PitchLow;
+        }
+
+        ~FrameLocker()
+        {
+            Unlock();
+        }
+
+        enum { LOCK_NO, LOCK_INT, LOCK_EXT };
+
+        mfxStatus Unlock()
+        {
+            mfxStatus mfxSts = MFX_ERR_NONE;
+            if (m_status == LOCK_INT)
+                mfxSts = m_core.UnlockFrame(m_memId, &m_data);
+            else if (m_status == LOCK_EXT)
+                mfxSts = m_core.UnlockExternalFrame(m_memId, &m_data);
+            m_status = LOCK_NO;
+            return mfxSts;
+        }
+
+
+        mfxU32 Lock(bool external)
+        {
+            mfxU32 status = LOCK_NO;
+            if (!m_data.Y && !m_data.Y410)
+            {
+                status = external
+                    ? (m_core.LockExternalFrame(m_memId, &m_data) == MFX_ERR_NONE ? LOCK_EXT : LOCK_NO)
+                    : (m_core.LockFrame(m_memId, &m_data) == MFX_ERR_NONE ? LOCK_INT : LOCK_NO);
+            }
+            return status;
+        }
+
+    private:
+        FrameLocker(FrameLocker const &) = delete;
+        FrameLocker & operator =(FrameLocker const &) = delete;
+
+        mfxFrameData& m_data;
+        VideoCORE&    m_core;
+        mfxMemId      m_memId;
+        mfxU32        m_status;
+    };
+
+    enum ePackInfo
+    {
+        PACK_QPDOffset = 0
+        , PACK_SAOOffset
+        , PACK_VUIOffset
+        , PACK_PWTOffset
+        , PACK_PWTLength
+        , NUM_PACK_INFO
+    };
+
+    struct PackedData
+    {
+        mfxU8* pData;
+        mfxU32 BitLen;
+        bool   bHasEP;
+        bool   bLongSC;
+        std::map<mfxU32, mfxU32> PackInfo;
+    };
+
+    struct PackedHeaders
+    {
+        PackedData VPS;
+        PackedData SPS;
+        PackedData PPS;
+        PackedData AUD[3];
+        PackedData PrefixSEI;
+        PackedData SuffixSEI;
+        std::vector<PackedData> SSH;
+    };
+
+    struct DDIExecParam
+    {
+        mfxU32 Function = 0;
+        struct Param
+        {
+            void*  pData = nullptr;
+            mfxU32 Size = 0;
+            mfxU32 Num  = 0;
+        } In, Out, Resource;
+    };
+
+    template<class T>
+    inline T& Deref(const DDIExecParam::Param& par, mfxU32 idx = 0)
+    {
+        ThrowAssert(
+            !par.pData
+            || (par.Size * std::max<mfxU32>(par.Num, 1)) < (sizeof(T) * (idx + 1))
+            , "Invalid DDIExecParam::Param data");
+        return *((T*)par.pData);
+    }
+
+    struct DDIFeedbackParam
+        : DDIExecParam
+    {
+        bool bNotReady;
+        std::function<const void*(mfxU32)> Get;
+        std::function<mfxStatus(mfxU32)> Update;
+    };
+
+    struct BsDataInfo
+    {
+        mfxU8  *Data;
+        mfxU32 DataOffset;
+        mfxU32 DataLength;
+        mfxU32 MaxLength;
+    };
+
+    enum eResetFlags
+    {
+        RF_SPS_CHANGED      = (1 << 0)
+        , RF_PPS_CHANGED    = (1 << 1)
+        , RF_IDR_REQUIRED   = (1 << 2)
+        , RF_BRC_RESET      = (1 << 3)
+        , RF_CANCEL_TASKS   = (1 << 4)
+    };
+
+    struct ResetHint
+    {
+        mfxU32 Flags;
+    };
+
+    struct VAGUID
+    {
+        mfxU32 Profile;
+        mfxU32 Entrypoint;
+    };
+
+    struct LessGUID
+    {
+        bool operator()(const GUID& l, const GUID& r) const
+        {
+            if (l == r)
+                return false;
+            bool bLess = l.Data1 < r.Data1;
+            bool bEQ   = l.Data1 == r.Data1;
+            bLess |= bEQ && l.Data2 < r.Data2;
+            bEQ   |= l.Data2 == r.Data2;
+            bLess |= bEQ && l.Data3 < r.Data3;
+            bEQ   |= l.Data3 == r.Data3;
+            bLess |= bEQ && (memcmp(l.Data4, r.Data4, sizeof(l.Data4)) < 0);
+            return bLess;
+        }
+    };
+
+    typedef std::list<StorageRW>::iterator TTaskIt;
+
+    template<class T, mfxU32 K>
+    struct TaskItWrap
+    {
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = T;
+        using pointer = value_type*;
+        using reference = value_type&;
+        using difference_type = ptrdiff_t;
+        using iterator_type = TaskItWrap;
+
+        TaskItWrap(TTaskIt _it) : it(_it) {}
+
+        bool operator==(const TTaskIt& other) const
+        {
+            return it == other;
+        }
+        bool operator!=(const TTaskIt& other) const
+        {
+            return it != other;
+        }
+        bool operator==(const iterator_type& other) const
+        {
+            return it == other.it;
+        }
+        bool operator!=(const iterator_type& other) const
+        {
+            return it != other.it;
+        }
+        pointer operator->()
+        {
+            return &it->Write<value_type>(K);
+        }
+        reference operator*() const
+        {
+            return it->Write<value_type>(K);
+        }
+        iterator_type& operator++()
+        {
+            ++it; return *this;
+        }
+        iterator_type operator++(int)
+        {
+            iterator_type tmp(it); ++it; return tmp;
+        }
+        iterator_type& operator--()
+        {
+            --it; return *this;
+        }
+        iterator_type operator--(int)
+        {
+            iterator_type tmp(it); --it; return tmp;
+        }
+
+        TTaskIt it;
+    };
+
+    struct Reorderer
+        : CallChain<TTaskIt, const DpbArray&, TTaskIt, TTaskIt, bool>
+    {
+        mfxU16 BufferSize = 0;
+        NotNull<DpbArray*> DPB;
+
+        using TBaseCC = CallChain<TTaskIt, const DpbArray&, TTaskIt, TTaskIt, bool>;
+
+        TTaskIt operator()(TTaskIt itBegin, TTaskIt itEnd, bool bFlush)
+        {
+            return TBaseCC::operator()((const DpbArray&)*DPB, itBegin, itEnd, bFlush);
+        }
+    };
+
+    class EncodeCapsHevc
+        : public ENCODE_CAPS_HEVC
+        , public Storable
+    {
+    public:
+        EncodeCapsHevc()
+            : ENCODE_CAPS_HEVC({})
+        {}
+
+        struct MsdkExt
+        {
+            bool bSingleSliceMultiTile = false;
+            bool CQPSupport            = false;
+            bool CBRSupport            = false;
+            bool VBRSupport            = false;
+            bool ICQSupport            = false;
+            bool PSliceSupport         = false;
+        } msdk;
+    };
+
+    struct Defaults
+    {
+        struct Param
+        {
+            Param(
+                const mfxVideoParam& _par
+                , const EncodeCapsHevc& _caps
+                , eMFXHWType _hw
+                , const Defaults& _d)
+                : mvp(_par)
+                , caps(_caps)
+                , hw(_hw)
+                , base(_d)
+            {}
+            const mfxVideoParam&    mvp;
+            const EncodeCapsHevc&   caps;
+            eMFXHWType              hw;
+            const Defaults&         base;
+        };
+
+        template<class TRV>
+        using TChain = CallChain<TRV, const Param&>;
+        std::map<mfxU32, bool> SetForFeature;
+
+        TChain<mfxU16> GetCodedPicWidth;
+        TChain<mfxU16> GetCodedPicHeight;
+        TChain<mfxU16> GetCodedPicAlignment;
+        TChain<mfxU16> GetMaxDPB;
+        TChain<mfxU16> GetNumTemporalLayers;
+        TChain<mfxU16> GetGopPicSize;
+        TChain<mfxU16> GetGopRefDist;
+        TChain<mfxU16> GetNumBPyramidLayers;
+        TChain<mfxU16> GetNumRefFrames;
+        TChain<mfxU16> GetNumRefBPyramid;
+        TChain<mfxU16> GetNumRefPPyramid;
+        TChain<mfxU16> GetNumRefNoPyramid;
+        TChain<mfxU16> GetMinRefForBPyramid;
+        TChain<mfxU16> GetMinRefForBNoPyramid;
+        TChain<mfxU16> GetBRefType;
+        TChain<mfxU16> GetPRefType;
+        TChain<mfxU16> GetTargetBitDepthLuma;
+        TChain<mfxU16> GetTargetChromaFormat;
+        TChain<mfxU16> GetMaxBitDepth;
+        TChain<mfxU16> GetMaxBitDepthByFourCC;
+        TChain<mfxU16> GetMaxChroma;
+        TChain<mfxU16> GetMaxChromaByFourCC;
+        TChain<mfxU16> GetRateControlMethod;
+        TChain<mfxU16> GetProfile;
+        TChain<mfxU16> GetMBBRC;
+        TChain<mfxU16> GetAsyncDepth;
+        TChain<mfxU16> GetNumSlices;
+        TChain<mfxU16> GetLCUSize;
+        TChain<bool>   GetHRDConformanceON;
+        TChain<mfxU16> GetPicTimingSEI;
+        TChain<mfxU16> GetPPyrInterval;
+        TChain<mfxU32> GetTargetKbps;
+        TChain<mfxU32> GetMaxKbps;
+        TChain<mfxU32> GetBufferSizeInKB;
+        TChain<std::tuple<mfxU16, mfxU16>> GetNumTiles; // (NumTileColumns, NumTileRows)
+        TChain<std::tuple<mfxU16, mfxU16>> GetMaxNumRef;
+        TChain<std::tuple<mfxU32, mfxU32>> GetFrameRate;
+        TChain<std::tuple<mfxU16, mfxU16, mfxU16>> GetQPMFX; //I,P,B
+        TChain<mfxU8> GetMinQPMFX;
+        TChain<mfxU8> GetMaxQPMFX;
+        TChain<mfxU8> GetHighestTId;
+        TChain<mfxU8> GetNumReorderFrames;
+        TChain<bool>  GetNonStdReordering;
+
+        using TGetNumRefActive = CallChain<
+            bool //bExternal
+            , const Defaults::Param&
+            , mfxU16(*)[8] //P
+            , mfxU16(*)[8] //BL0
+            , mfxU16(*)[8]>; //BL1 
+        TGetNumRefActive GetNumRefActive;
+
+        using TGetQPOffset = CallChain<
+            mfxU16 //EnableQPOffset
+            , const Defaults::Param&
+            , mfxI16(*)[8]>;//QPOffset
+        TGetQPOffset GetQPOffset;
+
+        using TGetGUID = CallChain<
+            bool //bSupported
+            , const Defaults::Param&
+            , GUID&>;
+        TGetGUID GetGUID;
+
+        using TGetFrameType = CallChain<
+            mfxU16 // FrameType
+            , const Defaults::Param&
+            , mfxU32//DisplayOrder
+            , mfxU32>; //LastIDR
+        TGetFrameType GetFrameType;
+
+        using TGetPLayer = CallChain<
+            mfxU8 //layer
+            , const Defaults::Param&
+            , mfxU32>; //order
+        TGetPLayer GetPLayer;
+        using TGetTId = TGetPLayer;
+        TGetTId GetTId;
+
+        using TGetRPLFromExt = CallChain<
+            std::tuple<mfxU8, mfxU8> //nL0, nL1
+            , const Defaults::Param&
+            , const DpbArray &
+            , mfxU16, mfxU16 //maxL0, maxL1
+            , const mfxExtAVCRefLists&
+            , mfxU8(&)[2][MAX_DPB_SIZE]>; //out RPL
+        TGetRPLFromExt GetRPLFromExt;
+
+        using TGetRPL = CallChain<
+            std::tuple<mfxU8, mfxU8> //nL0, nL1
+            , const Defaults::Param&
+            , const DpbArray &
+            , mfxU16, mfxU16 //maxL0, maxL1
+            , const FrameBaseInfo&
+            , mfxU8(&)[2][MAX_DPB_SIZE]>; //out RPL
+        TGetRPL GetRPL;
+        TGetRPL GetRPLMod; // apply hw/other specific modifications to RPL (final)
+
+        using TGetRPLFromCtrl = CallChain<
+            std::tuple<mfxU8, mfxU8> //nL0, nL1
+            , const Defaults::Param&
+            , const DpbArray &
+            , mfxU16, mfxU16 //maxL0, maxL1
+            , const FrameBaseInfo&
+            , const mfxExtAVCRefListCtrl&
+            , mfxU8(&)[2][MAX_DPB_SIZE]>; //out RPL
+        TGetRPLFromCtrl GetRPLFromCtrl;
+
+        using TCmpRef = CallChain<
+            bool                      // refA > refB
+            , const Defaults::Param&
+            , const FrameBaseInfo&    // curFrame
+            , const FrameBaseInfo&    // refA
+            , const FrameBaseInfo&>;  // refB
+        TCmpRef CmpRefLX[2];
+        using TGetWeakRef = CallChain<
+            const DpbFrame*
+            , const Defaults::Param&
+            , const FrameBaseInfo&    // curFrame
+            , const DpbFrame*         // begin
+            , const DpbFrame*>;       // end
+        TGetWeakRef GetWeakRef;
+
+        using TGetPreReorderInfo = CallChain<
+            mfxStatus
+            , const Defaults::Param&
+            , FrameBaseInfo&
+            , const mfxFrameSurface1*   //pSurfIn
+            , const mfxEncodeCtrl*      //pCtrl
+            , mfxU32                    //prevIDROrder
+            , mfxI32                    //prevIPOC
+            , mfxU32>;                  //frameOrder
+        TGetPreReorderInfo GetPreReorderInfo; // fill all info available at pre-reorder
+
+        using TGetFrameNumRefActive = CallChain<
+            std::tuple<mfxU8,mfxU8>
+            , const Defaults::Param&
+            , const FrameBaseInfo&>;
+        TGetFrameNumRefActive GetFrameNumRefActive;
+
+        using TGetTileSlices = CallChain<
+            mfxU16
+            , const Defaults::Param&
+            , std::vector<SliceInfo>&
+            , mfxU32   //SliceStructure
+            , mfxU32   //nCol
+            , mfxU32   //nRow
+            , mfxU32>; //nSlice
+        TGetTileSlices GetTileSlices;
+
+        using TGetSlices = CallChain <
+            mfxU16
+            , const Defaults::Param&
+            , std::vector<SliceInfo>&>;
+        TGetSlices GetSlices;
+
+        using TGetSPS = CallChain<mfxStatus, const Defaults::Param&, const VPS&, SPS&>;
+        TGetSPS GetSPS;
+        using TGetPPS = CallChain<mfxStatus, const Defaults::Param&, const SPS&, PPS&>;
+        TGetPPS GetPPS;
+
+        using TGetSHNUT = CallChain<
+            mfxU8                       //NUT
+            , const Defaults::Param&
+            , const TaskCommonPar&      //task
+            , bool>;                    //RAPIntra
+        TGetSHNUT GetSHNUT;
+        using TGetFrameOrder = CallChain<
+            mfxU32                 //FrameOrder
+            , const Defaults::Param&
+            , const StorageR&      //task
+            , mfxU32>;             //prevFrameOrder
+        TGetFrameOrder GetFrameOrder;
+
+        //for Query w/o caps:
+        using TPreCheck = CallChain<mfxStatus, const mfxVideoParam&>;
+        TPreCheck PreCheckCodecId;
+        TPreCheck PreCheckChromaFormat;
+
+        template<class TRV>
+        using TGetHWDefault = CallChain <TRV, const mfxVideoParam&, eMFXHWType>;
+        TGetHWDefault<mfxU16> GetLowPower;
+
+        //for Query w/caps (check + fix)
+        using TCheckAndFix = CallChain<mfxStatus, const Defaults::Param&, mfxVideoParam&>;
+        TCheckAndFix CheckLCUSize;
+        TCheckAndFix CheckLowDelayBRC;
+        TCheckAndFix CheckLevel;
+        TCheckAndFix CheckSurfSize;
+        TCheckAndFix CheckProfile;
+        TCheckAndFix CheckFourCC;
+        TCheckAndFix CheckInputFormatByFourCC;
+        TCheckAndFix CheckTargetChromaFormat;
+        TCheckAndFix CheckTargetBitDepth;
+        TCheckAndFix CheckFourCCByTargetFormat;
+        TCheckAndFix CheckWinBRC;
+        TCheckAndFix CheckSAO;
+        TCheckAndFix CheckNumRefActive;
+    };
+
+    enum eFeatureId
+    {
+          FEATURE_LEGACY = 0
+        , FEATURE_DDI
+        , FEATURE_DDI_PACKER
+        , FEATURE_PARSER
+        , FEATURE_HRD
+        , FEATURE_ALLOCATOR
+        , FEATURE_TASK_MANAGER
+        , FEATURE_PACKER
+        , FEATURE_BLOCKING_SYNC
+        , FEATURE_EXT_BRC
+        , FEATURE_DIRTY_RECT
+        , FEATURE_DPB_REPORT
+        , FEATURE_DUMP_FILES
+        , FEATURE_EXTDDI
+        , FEATURE_HDR_SEI
+        , FEATURE_MAX_FRAME_SIZE
+        , FEATURE_PROTECTED
+        , FEATURE_GPU_HANG
+        , FEATURE_ROI
+        , FEATURE_INTERLACE
+        , FEATURE_BRC_SLIDING_WINDOW
+        , FEATURE_MB_PER_SEC
+        , FEATURE_ENCODED_FRAME_INFO
+        , FEATURE_WEIGHTPRED
+        , FEATURE_QMATRIX
+        , FEATURE_UNITS_INFO
+        , NUM_FEATURES
+    };
+
+    enum eStages
+    {
+        S_NEW = 0
+        , S_PREPARE
+        , S_REORDER
+        , S_SUBMIT
+        , S_QUERY
+        , NUM_STAGES
+    };
+
+    struct Glob
+    {
+        static const StorageR::TKey _KD = __LINE__ + 1;
+        using VideoCore           = StorageVar<__LINE__ - _KD, VideoCORE>;
+        using RTErr               = StorageVar<__LINE__ - _KD, mfxStatus>;
+        using GUID                = StorageVar<__LINE__ - _KD, ::GUID>;
+        using EncodeCaps          = StorageVar<__LINE__ - _KD, EncodeCapsHevc>;
+        using VideoParam          = StorageVar<__LINE__ - _KD, ExtBuffer::Param<mfxVideoParam>>;
+        using VPS                 = StorageVar<__LINE__ - _KD, Gen11::VPS>;
+        using SPS                 = StorageVar<__LINE__ - _KD, Gen11::SPS>;
+        using PPS                 = StorageVar<__LINE__ - _KD, Gen11::PPS>;
+        using SliceInfo           = StorageVar<__LINE__ - _KD, std::vector<Gen11::SliceInfo>>;
+        using AllocRaw            = StorageVar<__LINE__ - _KD, IAllocation>;
+        using AllocOpq            = StorageVar<__LINE__ - _KD, IAllocation>;
+        using AllocRec            = StorageVar<__LINE__ - _KD, IAllocation>;
+        using AllocBS             = StorageVar<__LINE__ - _KD, IAllocation>;
+        using AllocMBQP           = StorageVar<__LINE__ - _KD, IAllocation>;
+        using PackedHeaders       = StorageVar<__LINE__ - _KD, Gen11::PackedHeaders>;
+        using DDI_Resources       = StorageVar<__LINE__ - _KD, std::list<DDIExecParam>>;
+        using DDI_SubmitParam     = StorageVar<__LINE__ - _KD, std::list<DDIExecParam>>;
+        using DDI_Feedback        = StorageVar<__LINE__ - _KD, DDIFeedbackParam>;
+        using DDI_Execute         = StorageVar<__LINE__ - _KD, CallChain<mfxStatus, const DDIExecParam&>>;
+        using RealState           = StorageVar<__LINE__ - _KD, StorageW>;//available during Reset
+        using ResetHint           = StorageVar<__LINE__ - _KD, Gen11::ResetHint>; //available during Reset
+        using Reorder             = StorageVar<__LINE__ - _KD, Reorderer>;
+        using NeedRextConstraints = StorageVar<__LINE__ - _KD, std::function<bool(const Gen11::PTL&)>>;
+        using ReadSpsExt          = StorageVar<__LINE__ - _KD, std::function<bool(const Gen11::SPS&, mfxU8, IBsReader&)>>;
+        using ReadPpsExt          = StorageVar<__LINE__ - _KD, std::function<bool(const Gen11::PPS&, mfxU8, IBsReader&)>>;
+        using PackSpsExt          = StorageVar<__LINE__ - _KD, std::function<bool(const Gen11::SPS&, mfxU8, IBsWriter&)>>;
+        using PackPpsExt          = StorageVar<__LINE__ - _KD, std::function<bool(const Gen11::PPS&, mfxU8, IBsWriter&)>>;
+        using GuidToVa            = StorageVar<__LINE__ - _KD, std::map<::GUID, VAGUID, LessGUID>>;
+        using Defaults            = StorageVar<__LINE__ - _KD, Gen11::Defaults>;
+        static const StorageR::TKey ReservedKey0 = __LINE__ - _KD;
+        static const StorageR::TKey NUM_KEYS = __LINE__ - _KD;
+    };
+
+    struct Tmp
+    {
+        static const StorageR::TKey _KD = __LINE__ + 1;
+        using MakeAlloc     = StorageVar<__LINE__ - _KD, std::function<IAllocation*(VideoCORE&)>>;
+        using BSAllocInfo   = StorageVar<__LINE__ - _KD, mfxFrameAllocRequest>;
+        using MBQPAllocInfo = StorageVar<__LINE__ - _KD, mfxFrameAllocRequest>;
+        using RecInfo       = StorageVar<__LINE__ - _KD, mfxFrameAllocRequest>;
+        using RawInfo       = StorageVar<__LINE__ - _KD, mfxFrameAllocRequest>;
+        using CurrTask      = StorageVar<__LINE__ - _KD, StorageW>;
+        using BsDataInfo    = StorageVar<__LINE__ - _KD, Gen11::BsDataInfo>;
+        using DDI_InitParam = StorageVar<__LINE__ - _KD, std::list<DDIExecParam>>;
+        static const StorageR::TKey NUM_KEYS = __LINE__ - _KD;
+    };
+
+    struct Task
+    {
+        static const StorageR::TKey _KD = __LINE__ + 1;
+        using Common = StorageVar<__LINE__ - _KD, TaskCommonPar>;
+        using SSH    = StorageVar<__LINE__ - _KD, Gen11::Slice>;
+        static const StorageR::TKey ReservedKey0 = __LINE__ - _KD;
+        static const StorageR::TKey NUM_KEYS = __LINE__ - _KD;
+    };
+
+    template<class TEB>
+    inline const TEB& GetRTExtBuffer(const StorageR& glob, const StorageR& task)
+    {
+        const TEB* pEB = ExtBuffer::Get(Task::Common::Get(task).ctrl);
+        if (pEB)
+            return *pEB;
+        return ExtBuffer::Get(Glob::VideoParam::Get(glob));
+    }
+
+} //namespace Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dirty_rect.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dirty_rect.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_dirty_rect.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+mfxStatus CheckAndFixRect(
+    DirtyRect::RectData& rect
+    , mfxVideoParam const & par
+    , ENCODE_CAPS_HEVC const & caps)
+{
+    mfxU32 changed = 0;
+
+    changed += CheckMaxOrClip(rect.Left, par.mfx.FrameInfo.Width);
+    changed += CheckMaxOrClip(rect.Right, par.mfx.FrameInfo.Width);
+    changed += CheckMaxOrClip(rect.Top, par.mfx.FrameInfo.Height);
+    changed += CheckMaxOrClip(rect.Bottom, par.mfx.FrameInfo.Height);
+
+    mfxU32 blockSize = 1 << (caps.BlockSize + 3);
+    changed += AlignDown(rect.Left, blockSize);
+    changed += AlignDown(rect.Top, blockSize);
+    changed += AlignUp(rect.Right, blockSize);
+    changed += AlignUp(rect.Bottom, blockSize);
+
+    return
+        changed
+        ? MFX_WRN_INCOMPATIBLE_VIDEO_PARAM
+        : MFX_ERR_NONE;
+}
+
+mfxStatus CheckAndFixDirtyRect(
+    ENCODE_CAPS_HEVC const & caps
+    , mfxVideoParam const & par
+    , mfxExtDirtyRect& dr)
+{
+    mfxStatus sts = MFX_ERR_NONE, rsts = MFX_ERR_NONE;
+    mfxU32 changed = 0, invalid = 0;
+
+    if (caps.DirtyRectSupport == 0)
+    {
+        invalid++;
+        dr.NumRect = 0;
+    }
+
+    changed += CheckMaxOrClip(dr.NumRect, DirtyRect::MAX_NUM_DIRTY_RECT);
+
+    for (mfxU16 i = 0; i < dr.NumRect; i++)
+    {
+        // check that rectangle dimensions don't conflict with each other and don't exceed frame size
+        rsts = CheckAndFixRect(dr.Rect[i], par, caps);
+    }
+
+    auto IsInvalidRect = [](const DirtyRect::RectData& rect)
+    {
+        return ((rect.Left >= rect.Right) || (rect.Top >= rect.Bottom));
+    };
+    mfxU16 numValidRect = mfxU16(std::remove_if(dr.Rect, dr.Rect + dr.NumRect, IsInvalidRect) - dr.Rect);
+    changed += CheckMinOrClip(dr.NumRect, numValidRect);
+
+    if (changed)
+        sts = MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+    if (invalid)
+        sts = MFX_ERR_UNSUPPORTED;
+
+    return GetWorstSts(sts, rsts);
+}
+
+void DirtyRect::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_DIRTY_RECTANGLES].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtDirtyRect*)pSrc;
+        auto& dst = *(mfxExtDirtyRect*)pDst;
+
+        dst.NumRect = src.NumRect;
+
+        for (mfxU32 i = 0; i < Size(src.Rect); ++i)
+        {
+            dst.Rect[i].Left = src.Rect[i].Left;
+            dst.Rect[i].Top = src.Rect[i].Top;
+            dst.Rect[i].Right = src.Rect[i].Right;
+            dst.Rect[i].Bottom = src.Rect[i].Bottom;
+        }
+    });
+}
+
+void DirtyRect::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFix
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& global) -> mfxStatus
+    {
+        mfxExtDirtyRect* pDR = ExtBuffer::Get(par);
+
+        if (pDR && pDR->NumRect)
+            return CheckAndFixDirtyRect(Glob::EncodeCaps::Get(global), par, *pDR);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DirtyRect::AllocTask(const FeatureBlocks& /*blocks*/, TPushAT Push)
+{
+    Push(BLK_AllocTask
+        , [this](
+            StorageR& /*global*/
+            , StorageW& task) -> mfxStatus
+    {
+        m_taskToRects.emplace(&task, std::vector<RectData>(MAX_NUM_DIRTY_RECT));
+        return MFX_ERR_NONE;
+    });
+}
+
+void DirtyRect::PostReorderTask(const FeatureBlocks& /*blocks*/, TPushPostRT Push)
+{
+    Push(BLK_ConfigureTask
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        mfxExtDirtyRect tmp;
+        mfxExtDirtyRect* pDR = ExtBuffer::Get(Task::Common::Get(s_task).ctrl);
+
+        if (pDR)
+        {
+            tmp = *pDR;
+
+            if (CheckAndFixDirtyRect(Glob::EncodeCaps::Get(global), par, tmp) < MFX_ERR_NONE)
+                pDR = nullptr;
+            else
+                pDR = &tmp;
+        }
+
+        if (!pDR)
+            pDR = ExtBuffer::Get(par);
+
+        auto& rects = m_taskToRects[&s_task];
+
+        if (pDR)
+            rects.assign(pDR->Rect, pDR->Rect + pDR->NumRect);
+        else
+            rects.clear();
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dirty_rect.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dirty_rect.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class DirtyRect
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+        DECL_BLOCK(AllocTask)\
+        DECL_BLOCK(CheckAndFix)\
+        DECL_BLOCK(ConfigureTask)\
+        DECL_BLOCK(PatchDDITask)
+#define DECL_FEATURE_NAME "G11_DirtyRect"
+#include "hevcehw_decl_blocks.h"
+
+        DirtyRect(mfxU32 FeatureId)
+            : FeatureBase(FeatureId)
+        {}
+
+        typedef std::remove_reference<decltype (mfxExtDirtyRect::Rect[0])>::type RectData;
+        static constexpr mfxU8 MAX_NUM_DIRTY_RECT = 64;
+
+    protected:
+        virtual void SetSupported(ParamSupport& par) override;
+        virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+        virtual void AllocTask(const FeatureBlocks& /*blocks*/, TPushAT Push) override;
+        virtual void PostReorderTask(const FeatureBlocks& /*blocks*/, TPushPostRT Push) override;
+        virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override {};
+
+        bool SkipRectangle(const RectData& rect)
+        {
+            if (rect.Left >= rect.Right || rect.Top >= rect.Bottom)
+                return true;
+            return false;
+        }
+
+        std::map<StorageW*, std::vector<RectData>> m_taskToRects;
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dpb_report.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dpb_report.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && (MFX_VERSION >= MFX_VERSION_NEXT)
+
+#include "hevcehw_g11_dpb_report.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void DPBReport::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_DPB].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtDPB*)pSrc;
+        auto& dst = *(mfxExtDPB*)pDst;
+
+        dst.DPBSize = src.DPBSize;
+
+        for (mfxU32 i = 0; i < Size(src.DPB); ++i)
+        {
+            dst.DPB[i].FrameOrder = src.DPB[i].FrameOrder;
+            dst.DPB[i].LongTermIdx = src.DPB[i].LongTermIdx;
+            dst.DPB[i].PicType = src.DPB[i].PicType;
+        }
+    });
+}
+
+void DPBReport::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_Report
+        , [](StorageW& /*global*/, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+        MFX_CHECK(task.pBsOut, MFX_ERR_NONE);
+
+        mfxExtDPB* pDPBReport = ExtBuffer::Get(*task.pBsOut);
+        MFX_CHECK(pDPBReport, MFX_ERR_NONE);
+
+        auto& report = *pDPBReport;
+        const auto& DPB = task.DPB.After;
+        auto& i = report.DPBSize;
+
+        for (i = 0; !isDpbEnd(DPB, i); ++i)
+        {
+            report.DPB[i].FrameOrder = DPB[i].DisplayOrder;
+            report.DPB[i].LongTermIdx = DPB[i].isLTR ? 0 : MFX_LONGTERM_IDX_NO_IDX;
+            report.DPB[i].PicType = MFX_PICTYPE_FRAME;
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dpb_report.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_dpb_report.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && (MFX_VERSION >= MFX_VERSION_NEXT)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+    namespace Gen11
+    {
+        class DPBReport
+            : public FeatureBase
+        {
+        public:
+#define DECL_BLOCK_LIST\
+        DECL_BLOCK(Report)
+#define DECL_FEATURE_NAME "G11_DPBReport"
+#include "hevcehw_decl_blocks.h"
+
+            DPBReport(mfxU32 FeatureId)
+                : FeatureBase(FeatureId)
+            {}
+
+        protected:
+            virtual void SetSupported(ParamSupport& par) override;
+            virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+        };
+
+    } //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_encoded_frame_info.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_encoded_frame_info.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_encoded_frame_info.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void EncodedFrameInfo::SetSupported(ParamSupport& blocks)
+{
+
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtCodingOption2*)pSrc;
+        auto& dst = *(mfxExtCodingOption2*)pDst;
+        dst.EnableMAD = src.EnableMAD;
+    });
+}
+
+void EncodedFrameInfo::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckMAD
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& /*global*/) -> mfxStatus
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        MFX_CHECK(pCO2, MFX_ERR_NONE);
+
+        //not supported in driver
+        bool bChanged = CheckOrZero(
+            pCO2->EnableMAD
+            , (mfxU16)MFX_CODINGOPTION_UNKNOWN
+            , (mfxU16)MFX_CODINGOPTION_OFF);
+
+        MFX_CHECK(!bChanged, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void EncodedFrameInfo::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_QueryTask
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+        MFX_CHECK(task.pBsOut, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        mfxExtAVCEncodedFrameInfo* pInfo = ExtBuffer::Get(*task.pBsOut);
+        MFX_CHECK(pInfo, MFX_ERR_NONE);
+
+        using TUsedRef = std::remove_reference<decltype(pInfo->UsedRefListL0[0])>::type;
+
+        TUsedRef unused = {};
+        unused.FrameOrder  = mfxU32(MFX_FRAMEORDER_UNKNOWN);
+        unused.LongTermIdx = mfxU16(MFX_LONGTERM_IDX_NO_IDX);
+        unused.PicStruct   = mfxU16(MFX_PICSTRUCT_UNKNOWN);
+
+        std::fill(std::begin(pInfo->UsedRefListL0), std::end(pInfo->UsedRefListL0), unused);
+        std::fill(std::begin(pInfo->UsedRefListL1), std::end(pInfo->UsedRefListL1), unused);
+
+        auto picStruct = Glob::VideoParam::Get(global).mfx.FrameInfo.PicStruct;
+        bool bFields = !!(picStruct & (MFX_PICSTRUCT_FIELD_TOP | MFX_PICSTRUCT_FIELD_BOTTOM));
+        const mfxU16 PicStructTable[2][2] =
+        {
+            {mfxU16(MFX_PICSTRUCT_PROGRESSIVE), mfxU16(MFX_PICSTRUCT_PROGRESSIVE)},
+            {mfxU16(MFX_PICSTRUCT_FIELD_TOP),   mfxU16(MFX_PICSTRUCT_FIELD_BOTTOM)}
+        };
+
+        auto GetUsedRef = [&](mfxU8 idx)
+        {
+            TUsedRef dst = {};
+            auto& src = task.DPB.Active[idx % 16];
+
+            dst.FrameOrder  = src.DisplayOrder;
+            dst.LongTermIdx = mfxU16(MFX_LONGTERM_IDX_NO_IDX * !src.isLTR);
+            dst.PicStruct   = PicStructTable[bFields][src.bBottomField];
+
+            return dst;
+        };
+
+        std::transform(task.RefPicList[0], task.RefPicList[0] + task.NumRefActive[0], pInfo->UsedRefListL0, GetUsedRef);
+        std::transform(task.RefPicList[1], task.RefPicList[1] + task.NumRefActive[1], pInfo->UsedRefListL1, GetUsedRef);
+
+        pInfo->FrameOrder   = task.DisplayOrder;
+        pInfo->LongTermIdx  = mfxU16(MFX_LONGTERM_IDX_NO_IDX * !task.isLTR);
+        pInfo->PicStruct    = PicStructTable[bFields][task.bBottomField];
+        pInfo->QP           = 0;
+        pInfo->BRCPanicMode = 0;
+        pInfo->MAD          = 0;
+
+        return GetDdiInfo(Glob::DDI_Feedback::Get(global).Get(task.StatusReportId), *pInfo);
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_encoded_frame_info.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_encoded_frame_info.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+    namespace Gen11
+    {
+        class EncodedFrameInfo
+            : public FeatureBase
+        {
+        public:
+#define DECL_BLOCK_LIST\
+        DECL_BLOCK(CheckMAD)\
+        DECL_BLOCK(QueryTask)
+#define DECL_FEATURE_NAME "G11_EncodedFrameInfo"
+#include "hevcehw_decl_blocks.h"
+
+            EncodedFrameInfo(mfxU32 FeatureId)
+                : FeatureBase(FeatureId)
+            {}
+
+        protected:
+            virtual void SetSupported(ParamSupport& par) override;
+            virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+            virtual void QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push) override;
+
+            virtual mfxStatus GetDdiInfo(const void* pDdiFeedback, mfxExtAVCEncodedFrameInfo& info) = 0;
+        };
+
+    } //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_ext_brc.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_ext_brc.cpp
@@ -1,0 +1,521 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_ext_brc.h"
+#include "mfx_brc_common.h"
+#include "mfx_h265_encode_hw_brc.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+namespace VmeBrcWrapper
+{
+    //TODO: re-implement VMEBrc w/ proper interfaces (remove MfxVideoParam/Task dependencies)
+    using TBRC = MfxHwH265Encode::VMEBrc;
+
+    static mfxStatus Init(mfxHDL pthis, mfxVideoParam* par)
+    {
+        MFX_CHECK_NULL_PTR2(pthis, par);
+        MfxHwH265Encode::MfxVideoParam tmpPar(*par, MFX_HW_UNKNOWN);
+        return ((TBRC*)pthis)->Init(tmpPar);
+    }
+    static mfxStatus Close(mfxHDL pthis)
+    {
+        MFX_CHECK_NULL_PTR1(pthis);
+        return ((TBRC*)pthis)->Close();
+    }
+    static mfxStatus Reset(mfxHDL pthis, mfxVideoParam* par)
+    {
+        Close(pthis);
+        return Init(pthis, par);
+    }
+    static mfxStatus GetFrameCtrl(mfxHDL pthis, mfxBRCFrameParam* par, mfxBRCFrameCtrl* ctrl)
+    {
+        MFX_CHECK_NULL_PTR3(pthis, par, ctrl);
+
+        //only EncodedOrder is really used by VMEBrc::GetQP
+        MfxHwH265Encode::MfxVideoParam fakePar;
+        MfxHwH265Encode::Task task;
+        task.m_eo = par->EncodedOrder;
+
+        ctrl->QpY = ((TBRC*)pthis)->GetQP(fakePar, task);
+
+        return MFX_ERR_NONE;
+    }
+    static mfxStatus Update(mfxHDL pthis, mfxBRCFrameParam* par, mfxBRCFrameCtrl*, mfxBRCFrameStatus* status)
+    {
+        MFX_CHECK_NULL_PTR3(pthis, par, status);
+        ((TBRC*)pthis)->Report(par->FrameType, par->CodedFrameSize, 0, 0, par->EncodedOrder, 0, 0);
+
+        status->BRCStatus = MFX_BRC_OK;
+
+        return MFX_ERR_NONE;
+    }
+    static mfxStatus Create(mfxExtBRC & m_BRC)
+    {
+        MFX_CHECK(!m_BRC.pthis, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        m_BRC.pthis = new TBRC;
+
+        MFX_CHECK(m_BRC.pthis, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        m_BRC.Init          = Init;
+        m_BRC.Reset         = Reset;
+        m_BRC.Close         = Close;
+        m_BRC.GetFrameCtrl  = GetFrameCtrl;
+        m_BRC.Update        = Update;
+
+
+        return MFX_ERR_NONE;
+    }
+    static mfxStatus Destroy(mfxExtBRC & m_BRC)
+    {
+        delete (TBRC*)m_BRC.pthis;
+
+        m_BRC.pthis         = nullptr;
+        m_BRC.Init          = nullptr;
+        m_BRC.Reset         = nullptr;
+        m_BRC.Close         = nullptr;
+        m_BRC.GetFrameCtrl  = nullptr;
+        m_BRC.Update        = nullptr;
+
+        return MFX_ERR_NONE;
+    }
+}
+
+void ExtBRC::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_BRC].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtBRC*)pSrc;
+        auto& dst = *(mfxExtBRC*)pDst;
+
+        dst.pthis           = src.pthis;
+        dst.Init            = src.Init;
+        dst.Reset           = src.Reset;
+        dst.Close           = src.Close;
+        dst.GetFrameCtrl    = src.GetFrameCtrl;
+        dst.Update          = src.Update;
+    });
+}
+
+void ExtBRC::SetInherited(ParamInheritance& par)
+{
+    par.m_ebInheritDefault[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        auto& src = *(const mfxExtCodingOption2*)pSrc;
+        auto& dst = *(mfxExtCodingOption2*)pDst;
+
+        InheritOption(src.ExtBRC, dst.ExtBRC);
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_BRC].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        auto& src = *(const mfxExtBRC*)pSrc;
+        auto& dst = *(mfxExtBRC*)pDst;
+
+        if (   !dst.pthis
+            && !dst.Init
+            && !dst.Reset
+            && !dst.Close
+            && !dst.GetFrameCtrl
+            && !dst.Update)
+        {
+            dst.pthis           = src.pthis;
+            dst.Init            = src.Init;
+            dst.Reset           = src.Reset;
+            dst.Close           = src.Close;
+            dst.GetFrameCtrl    = src.GetFrameCtrl;
+            dst.Update          = src.Update;
+        }
+    });
+}
+
+
+void ExtBRC::Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push)
+{
+    Push(BLK_Check,
+        [&blocks](const mfxVideoParam&, mfxVideoParam& par, StorageW&) -> mfxStatus
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        mfxExtBRC* pBRC = ExtBuffer::Get(par);
+        mfxU32 changed = 0;
+
+        MFX_CHECK(pCO2, MFX_ERR_NONE);
+        
+        bool bAllowed = 
+            par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+            || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR;
+
+        bool bInvalid =
+            IsOn(pCO2->ExtBRC)
+            && pBRC
+            && (   pBRC->pthis
+                || pBRC->Init
+                || pBRC->Close
+                || pBRC->GetFrameCtrl
+                || pBRC->Update
+                || pBRC->Reset)
+            && (   !pBRC->pthis
+                || !pBRC->Init
+                || !pBRC->Close
+                || !pBRC->GetFrameCtrl
+                || !pBRC->Update
+                || !pBRC->Reset);
+
+        changed += CheckOrZero<mfxU16>(pCO2->ExtBRC
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * (bAllowed && !bInvalid)));
+
+        bool bZeroPtrs =
+            !IsOn(pCO2->ExtBRC)
+            && pBRC
+            && (   pBRC->pthis
+                || pBRC->Init
+                || pBRC->Close
+                || pBRC->GetFrameCtrl
+                || pBRC->Update
+                || pBRC->Reset);
+
+        if (bZeroPtrs)
+        {
+            pBRC->pthis         = nullptr;
+            pBRC->Init          = nullptr;
+            pBRC->Close         = nullptr;
+            pBRC->GetFrameCtrl  = nullptr;
+            pBRC->Update        = nullptr;
+            pBRC->Reset         = nullptr;
+            ++changed;
+        }
+
+        bool bInitMode = !FeatureBlocks::BQ<FeatureBlocks::BQ_InitAlloc>::Get(blocks).empty();
+
+        MFX_CHECK(!(bInvalid && bInitMode), MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ExtBRC::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaults
+        , [](mfxVideoParam& par, StorageW&, StorageRW&)
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+
+        if (pCO2 && pCO2->ExtBRC == MFX_CODINGOPTION_UNKNOWN)
+            pCO2->ExtBRC = MFX_CODINGOPTION_OFF;
+    });
+}
+
+void ExtBRC::Reset(const FeatureBlocks& /*blocks*/, TPushR Push)
+{
+    Push(BLK_ResetCheck
+        , [](
+            const mfxVideoParam& /*par*/
+            , StorageRW& global
+            , StorageRW&) -> mfxStatus
+    {
+        auto& init = Glob::RealState::Get(global);
+        auto& parOld = Glob::VideoParam::Get(init);
+        auto& parNew = Glob::VideoParam::Get(global);
+
+        const mfxExtCodingOption2(&CO2)[2] = { ExtBuffer::Get(parOld), ExtBuffer::Get(parNew) };
+
+        MFX_CHECK(CO2[0].ExtBRC == CO2[1].ExtBRC, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
+        if (IsOn(CO2[0].ExtBRC))
+        {
+            const mfxExtBRC(&BRC)[2] = { ExtBuffer::Get(parOld), ExtBuffer::Get(parNew) };
+
+            MFX_CHECK(
+                   BRC[0].pthis         == BRC[1].pthis
+                && BRC[0].Init          == BRC[1].Init
+                && BRC[0].Reset         == BRC[1].Reset
+                && BRC[0].Close         == BRC[1].Close
+                && BRC[0].GetFrameCtrl  == BRC[1].GetFrameCtrl
+                && BRC[0].Update        == BRC[1].Update
+                , MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ExtBRC::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this](
+            StorageRW& global
+            , StorageRW&) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+
+        if (m_brc.Reset)
+        {
+            if (Glob::ResetHint::Get(global).Flags & RF_IDR_REQUIRED)
+            {
+                mfxExtEncoderResetOption& rOpt = ExtBuffer::Get(par);
+                rOpt.StartNewSequence = MFX_CODINGOPTION_ON;
+            }
+
+            mfxStatus sts = m_brc.Reset(m_brc.pthis, &par);
+            MFX_CHECK_STS(sts);
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ExtBRC::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_Init
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto&                      par          = Glob::VideoParam::Get(strg);
+        const mfxExtCodingOption2& CO2          = ExtBuffer::Get(par);
+        const mfxExtCodingOption3& CO3          = ExtBuffer::Get(par);
+        mfxExtBRC&                 brc          = ExtBuffer::Get(par);
+        bool                       bInternalBRC = IsOn(CO2.ExtBRC) && !brc.pthis && !m_brc.pthis;
+        bool                       bExternalBRC = IsOn(CO2.ExtBRC) && brc.pthis && !m_brc.pthis;
+
+        if (par.mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT)
+        {
+            auto sts = VmeBrcWrapper::Create(m_brc);
+            MFX_CHECK_STS(sts);
+
+            m_destroy = [this]()
+            {
+                VmeBrcWrapper::Destroy(m_brc);
+            };
+
+            if (par.mfx.EncodedOrder)
+            {
+                auto& cc = Glob::Defaults::Get(strg);
+
+                cc.GetFrameOrder.Push([this](
+                    Defaults::TGetFrameOrder::TExt
+                    , const Defaults::Param& par
+                    , const StorageR& s_task
+                    , mfxU32 /*prevFrameOrder*/)
+                {
+                    auto& ctrl = Task::Common::Get(s_task).ctrl;
+                    mfxExtLAFrameStatistics* pLAStat = ExtBuffer::CastExtractor(ctrl.ExtParam, ctrl.NumExtParam);
+
+                    ThrowIf(!pLAStat, MFX_ERR_NULL_PTR);
+
+                    auto sts = ((VmeBrcWrapper::TBRC*)m_brc.pthis)->SetFrameVMEData(
+                        pLAStat
+                        , par.mvp.mfx.FrameInfo.Width
+                        , par.mvp.mfx.FrameInfo.Height);
+
+                    ThrowIf(!!sts, sts);
+
+                    m_pLAStat = pLAStat;
+
+                    return pLAStat->FrameStat[0].FrameDisplayOrder;
+                });
+
+                cc.GetPreReorderInfo.Push([this](
+                    Defaults::TGetPreReorderInfo::TExt prev
+                    , const Defaults::Param& par
+                    , FrameBaseInfo& fi
+                    , const mfxFrameSurface1* pSurfIn
+                    , const mfxEncodeCtrl*    pCtrl
+                    , mfxU32 prevIDROrder
+                    , mfxI32 prevIPOC
+                    , mfxU32 frameOrder)
+                {
+                    if (pCtrl)
+                    {
+                        auto&         stat = m_pLAStat->FrameStat[0];
+                        mfxEncodeCtrl ctrl = *pCtrl;
+
+                        ctrl.FrameType = mfxU16(stat.FrameType);
+
+                        auto sts = prev(par, fi, pSurfIn, &ctrl, prevIDROrder, prevIPOC, frameOrder);
+
+                        fi.PyramidLevel = stat.Layer;
+
+                        return sts;
+                    }
+
+                    return prev(par, fi, pSurfIn, pCtrl, prevIDROrder, prevIPOC, frameOrder);
+                });
+            }
+        }
+
+        if (bInternalBRC)
+        {
+            auto sts = HEVCExtBRC::Create(m_brc);
+            MFX_CHECK_STS(sts);
+
+            m_destroy = [this]()
+            {
+                HEVCExtBRC::Destroy(m_brc);
+            };
+        }
+
+        SetIf(m_brc, bExternalBRC, brc);
+
+        if (m_brc.Init)
+        {
+            mfxStatus sts = m_brc.Init(m_brc.pthis, &par);
+            MFX_CHECK_STS(sts);
+        }
+
+        m_bUseLevel = !(IGNORE_P_PYRAMID_LEVEL && CO3.PRefType == MFX_P_REF_PYRAMID);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+mfxBRCFrameParam ExtBRC::MakeFrameParam(const TaskCommonPar& task)
+{
+    mfxBRCFrameParam    fp = {};
+
+    fp.DisplayOrder   = task.DisplayOrder;
+    fp.EncodedOrder   = task.EncodedOrder;
+    fp.FrameType      = task.FrameType;
+    fp.PyramidLayer   = mfxU16(task.PyramidLevel * m_bUseLevel + task.b2ndField);
+    fp.NumRecode      = task.NumRecode;
+    fp.CodedFrameSize = task.BsDataLength;
+
+    return fp;
+}
+
+void ExtBRC::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_GetFrameCtrl
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        MFX_CHECK(m_brc.GetFrameCtrl, MFX_ERR_NONE);
+
+        auto&      par  = Glob::VideoParam::Get(global);
+        auto&      task = Task::Common::Get(s_task);
+        auto&      sh   = Task::SSH::Get(s_task);
+        auto&      sps  = Glob::SPS::Get(global);
+        auto&      pps  = Glob::PPS::Get(global);
+        eMFXHWType hw   = Glob::VideoCore::Get(global).GetHWType();
+
+        bool bNegativeQpAllowed = !(IsOn(par.mfx.LowPower) || (hw >= MFX_HW_KBL && hw < MFX_HW_CNL));
+
+        mfxI32 minQP = (-6 * sps.bit_depth_luma_minus8) * bNegativeQpAllowed;
+        mfxI32 maxQP = 51;
+
+        mfxBRCFrameParam fp = MakeFrameParam(task);
+        mfxBRCFrameCtrl  fc = {};
+
+        mfxStatus sts = m_brc.GetFrameCtrl(m_brc.pthis, &fp, &fc);
+        MFX_CHECK_STS(sts);
+
+        SetDefault(fc.InitialCpbRemovalDelay, task.initial_cpb_removal_delay);
+        SetDefault(fc.InitialCpbRemovalOffset, task.initial_cpb_removal_offset);
+
+        task.initial_cpb_removal_delay  = fc.InitialCpbRemovalDelay;
+        task.initial_cpb_removal_offset = fc.InitialCpbRemovalOffset;
+
+        task.QpY = mfxI8(mfx::clamp(fc.QpY, minQP, maxQP));
+        sh.slice_qp_delta = mfxI8(task.QpY - (pps.init_qp_minus26 + 26));
+
+        sh.temporal_mvp_enabled_flag &= !(par.AsyncDepth > 1 && task.NumRecode); // WA
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ExtBRC::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_Update
+        , [this](
+            StorageW& /*global*/
+            , StorageW& s_task) -> mfxStatus
+    {
+
+        MFX_CHECK(m_brc.Update, MFX_ERR_NONE);
+
+        auto& task = Task::Common::Get(s_task);
+            
+        mfxBRCFrameParam    fp = MakeFrameParam(task);
+        mfxBRCFrameCtrl     fc = {};
+        mfxBRCFrameStatus   fs = {};
+
+        fc.QpY = task.QpY;
+
+        mfxStatus sts = m_brc.Update(m_brc.pthis, &fp, &fc, &fs);
+        MFX_CHECK_STS(sts);
+
+        switch (fs.BRCStatus)
+        {
+        case MFX_BRC_OK:
+            break;
+        case MFX_BRC_PANIC_SMALL_FRAME:
+            task.MinFrameSize = fs.MinFrameSize;
+            fp.NumRecode++;
+            fp.CodedFrameSize = fs.MinFrameSize;
+
+            sts = m_brc.Update(m_brc.pthis, &fp, &fc, &fs);
+            MFX_CHECK_STS(sts);
+            MFX_CHECK(fs.BRCStatus == MFX_BRC_OK, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+            break;
+        case MFX_BRC_PANIC_BIG_FRAME:
+            task.bSkip = true;
+        case MFX_BRC_BIG_FRAME:
+        case MFX_BRC_SMALL_FRAME:
+            task.bRecode = true;
+            break;
+        default:
+            return MFX_ERR_UNDEFINED_BEHAVIOR;
+        }
+
+        task.bForceSync |= task.bSkip;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ExtBRC::Close(const FeatureBlocks& /*blocks*/, TPushCLS Push)
+{
+    Push(BLK_Close
+        , [this](StorageW& /*global*/)
+    {
+        if (m_brc.Close)
+            m_brc.Close(m_brc.pthis);
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_ext_brc.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_ext_brc.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+class ExtBRC
+    : public FeatureBase
+{
+public:
+    //TODO: to align with legacy code behavior, disable after investigation effect on SWBRC
+    static const bool IGNORE_P_PYRAMID_LEVEL = true; 
+
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Check)\
+    DECL_BLOCK(Init)\
+    DECL_BLOCK(ResetCheck)\
+    DECL_BLOCK(Reset)\
+    DECL_BLOCK(GetFrameCtrl)\
+    DECL_BLOCK(Update)\
+    DECL_BLOCK(Close)\
+    DECL_BLOCK(SetDefaults)
+#define DECL_FEATURE_NAME "G11_ExtBRC"
+#include "hevcehw_decl_blocks.h"
+
+    ExtBRC(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+protected:
+    virtual void SetSupported(ParamSupport& par) override;
+    virtual void SetInherited(ParamInheritance& par) override;
+    virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void SetDefaults(const FeatureBlocks& blocks, TPushSD Push) override;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+    virtual void Reset(const FeatureBlocks& blocks, TPushR Push) override;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+    virtual void Close(const FeatureBlocks& blocks, TPushCLS Push) override;
+
+    mfxBRCFrameParam MakeFrameParam(const TaskCommonPar& task);
+
+    mfxExtBRC m_brc = {};
+    OnExit    m_destroy;
+    bool      m_bUseLevel = true;
+    NotNull<mfxExtLAFrameStatistics*> m_pLAStat;
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hdr_sei.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hdr_sei.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_hdr_sei.h"
+#include "hevcehw_g11_packer.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void HdrSei::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtContentLightLevelInfo*)pSrc;
+        auto& dst = *(mfxExtContentLightLevelInfo*)pDst;
+
+        dst.InsertPayloadToggle     = src.InsertPayloadToggle;
+        dst.MaxContentLightLevel    = src.MaxContentLightLevel;
+        dst.MaxPicAverageLightLevel = src.MaxPicAverageLightLevel;
+    });
+
+    blocks.m_ebCopySupported[MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtMasteringDisplayColourVolume*)pSrc;
+        auto& dst = *(mfxExtMasteringDisplayColourVolume*)pDst;
+
+        dst.InsertPayloadToggle = src.InsertPayloadToggle;
+        std::copy_n(src.DisplayPrimariesX, Size(src.DisplayPrimariesX), dst.DisplayPrimariesX);
+        std::copy_n(src.DisplayPrimariesY, Size(src.DisplayPrimariesY), dst.DisplayPrimariesY);
+        dst.WhitePointX = src.WhitePointX;
+        dst.WhitePointY = src.WhitePointY;
+        dst.MaxDisplayMasteringLuminance = src.MaxDisplayMasteringLuminance;
+        dst.MinDisplayMasteringLuminance = src.MinDisplayMasteringLuminance;
+    });
+}
+
+void PackSEIPayload(
+    BitstreamWriter& bs
+    , const mfxExtMasteringDisplayColourVolume & DisplayColour)
+{
+    mfxU32 size = CeilDiv(bs.GetOffset(), 8u);
+    mfxU8* pl = bs.GetStart() + size; // payload start
+
+    bs.PutBits(8, 137);  //payload type
+    bs.PutBits(8, 0xff); //place for payload  size
+    size += 2;
+
+    for (int i = 0; i < 3; i++)
+    {
+        bs.PutBits(16, DisplayColour.DisplayPrimariesX[i]);
+        bs.PutBits(16, DisplayColour.DisplayPrimariesY[i]);
+    }
+    bs.PutBits(16, DisplayColour.WhitePointX);
+    bs.PutBits(16, DisplayColour.WhitePointY);
+    bs.PutBits(32, DisplayColour.MaxDisplayMasteringLuminance);
+    bs.PutBits(32, DisplayColour.MinDisplayMasteringLuminance);
+
+    size = CeilDiv(bs.GetOffset(), 8u) - size;
+
+    assert(size < 256);
+    pl[1] = (mfxU8)size; //payload size
+}
+
+void PackSEIPayload(
+    BitstreamWriter& bs
+    , const mfxExtContentLightLevelInfo & LightLevel)
+{
+    mfxU32 size = CeilDiv(bs.GetOffset(), 8u);
+    mfxU8* pl = bs.GetStart() + size; // payload start
+
+    bs.PutBits(8, 144);  //payload type
+    bs.PutBits(8, 0xff); //place for payload  size
+    size += 2;
+
+    bs.PutBits(16, LightLevel.MaxContentLightLevel);
+    bs.PutBits(16, LightLevel.MaxPicAverageLightLevel);
+
+    size = CeilDiv(bs.GetOffset(), 8u) - size;
+
+    assert(size < 256);
+    pl[1] = (mfxU8)size; //payload size
+}
+
+void HdrSei::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFixMDCV
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& /*global*/) -> mfxStatus
+    {
+        mfxExtMasteringDisplayColourVolume* pMDCV = ExtBuffer::Get(par);
+        MFX_CHECK(pMDCV, MFX_ERR_NONE);
+        mfxU32 changed = 0;
+
+        changed += CheckOrZero<mfxU16, MFX_PAYLOAD_OFF, MFX_PAYLOAD_IDR>(pMDCV->InsertPayloadToggle);
+        changed += CheckMaxOrClip(pMDCV->WhitePointX, 50000u);
+        changed += CheckMaxOrClip(pMDCV->WhitePointY, 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesX[0], 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesX[1], 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesX[2], 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesY[0], 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesY[1], 50000u);
+        changed += CheckMaxOrClip(pMDCV->DisplayPrimariesY[2], 50000u);
+
+        return changed ? MFX_WRN_INCOMPATIBLE_VIDEO_PARAM : MFX_ERR_NONE;
+    });
+    Push(BLK_CheckAndFixCLLI
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& /*global*/) -> mfxStatus
+    {
+        mfxExtContentLightLevelInfo* pCLLI = ExtBuffer::Get(par);
+        MFX_CHECK(pCLLI, MFX_ERR_NONE);
+        mfxU32 changed = 0;
+
+        changed += CheckOrZero<mfxU16, MFX_PAYLOAD_OFF, MFX_PAYLOAD_IDR>(pCLLI->InsertPayloadToggle);
+
+        return changed ? MFX_WRN_INCOMPATIBLE_VIDEO_PARAM : MFX_ERR_NONE;
+    });
+}
+
+void HdrSei::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaultsMDCV
+        , [](mfxVideoParam& par, StorageW& /*strg*/, StorageRW&)
+    {
+        mfxExtMasteringDisplayColourVolume* pMDCV = ExtBuffer::Get(par);
+        MFX_CHECK(pMDCV, MFX_ERR_NONE);
+
+        SetDefault<mfxU16>(pMDCV->InsertPayloadToggle, MFX_PAYLOAD_OFF);
+
+        return MFX_ERR_NONE;
+    });
+    Push(BLK_SetDefaultsCLLI
+        , [](mfxVideoParam& par, StorageW& /*strg*/, StorageRW&)
+    {
+        mfxExtContentLightLevelInfo* pCLLI = ExtBuffer::Get(par);
+        MFX_CHECK(pCLLI, MFX_ERR_NONE);
+
+        SetDefault<mfxU16>(pCLLI->InsertPayloadToggle, MFX_PAYLOAD_OFF);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void HdrSei::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_InsertPayloads
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        auto& task = Task::Common::Get(s_task);
+
+        const mfxExtMasteringDisplayColourVolume* pMDCV = ExtBuffer::Get(task.ctrl);
+        const mfxExtContentLightLevelInfo* pCLLI = ExtBuffer::Get(task.ctrl);
+
+        bool bInsertMDCV = !!pMDCV;
+        bool bInsertCLLI = !!pCLLI;
+
+        SetDefault(pMDCV, (const mfxExtMasteringDisplayColourVolume*)ExtBuffer::Get(par));
+        SetDefault(pCLLI, (const mfxExtContentLightLevelInfo*)ExtBuffer::Get(par));
+
+        bInsertMDCV |= (pMDCV->InsertPayloadToggle == MFX_PAYLOAD_IDR) && (task.FrameType & MFX_FRAMETYPE_IDR);
+        bInsertCLLI |= (pCLLI->InsertPayloadToggle == MFX_PAYLOAD_IDR) && (task.FrameType & MFX_FRAMETYPE_IDR);
+
+        MFX_CHECK(bInsertMDCV || bInsertCLLI, MFX_ERR_NONE);
+
+        BitstreamWriter bs(m_buf.data(), (mfxU32)m_buf.size(), 0);
+
+        if (bInsertMDCV)
+        {
+            mfxPayload pl = {};
+
+            pl.Type     = 137;
+            pl.NumBit   = bs.GetOffset();
+            pl.BufSize  = (mfxU16)CeilDiv(pl.NumBit, 8u);
+            pl.Data     = bs.GetStart() + pl.BufSize;
+
+            PackSEIPayload(bs, *pMDCV);
+
+            pl.NumBit   = bs.GetOffset() - pl.NumBit;
+            pl.BufSize  = (mfxU16)CeilDiv(pl.NumBit, 8u);
+
+            task.PLInternal.push_back(pl);
+
+            task.InsertHeaders |= INSERT_DCVSEI;
+        }
+
+        if (bInsertCLLI)
+        {
+            mfxPayload pl = {};
+
+            pl.Type     = 144;
+            pl.NumBit   = bs.GetOffset();
+            pl.BufSize  = (mfxU16)CeilDiv(pl.NumBit, 8u);
+            pl.Data     = bs.GetStart() + pl.BufSize;
+
+            PackSEIPayload(bs, *pCLLI);
+
+            pl.NumBit   = bs.GetOffset() - pl.NumBit;
+            pl.BufSize  = (mfxU16)CeilDiv(pl.NumBit, 8u);
+
+            task.PLInternal.push_back(pl);
+
+            task.InsertHeaders |= INSERT_LLISEI;
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hdr_sei.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hdr_sei.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+    namespace Gen11
+    {
+        class HdrSei
+            : public FeatureBase
+        {
+        public:
+#define DECL_BLOCK_LIST\
+        DECL_BLOCK(CheckAndFixMDCV)\
+        DECL_BLOCK(CheckAndFixCLLI)\
+        DECL_BLOCK(SetDefaultsMDCV)\
+        DECL_BLOCK(SetDefaultsCLLI)\
+        DECL_BLOCK(InsertPayloads)
+#define DECL_FEATURE_NAME "G11_HdrSei"
+#include "hevcehw_decl_blocks.h"
+
+            HdrSei(mfxU32 FeatureId)
+                : FeatureBase(FeatureId)
+            {}
+
+        protected:
+            virtual void SetSupported(ParamSupport& par) override;
+            virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+            virtual void SetDefaults(const FeatureBlocks& blocks, TPushSD Push) override;
+            virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
+
+            std::array<mfxU8, 32> m_buf;
+        };
+
+    } //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hrd.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hrd.cpp
@@ -1,0 +1,228 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_hrd.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void HRD::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_Init
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        Init(
+            Glob::SPS::Get(strg)
+            , InitialDelayInKB(Glob::VideoParam::Get(strg).mfx)
+        );
+        m_prevBpEncOrderAsync = 0;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void HRD::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        Reset(Glob::SPS::Get(strg));
+        return MFX_ERR_NONE;
+    });
+
+}
+
+void HRD::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SubmitTask
+        , [this](StorageW&, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        if (task.NumRecode == 0)
+            task.cpb_removal_delay = !!task.EncodedOrder * (task.EncodedOrder - m_prevBpEncOrderAsync);
+
+        bool bBPSEI    = (task.InsertHeaders & INSERT_BPSEI);
+        bool bSetBPPar =
+            bBPSEI
+            && !task.initial_cpb_removal_delay
+            && !task.initial_cpb_removal_offset;
+
+        if (bSetBPPar)
+        {
+            task.initial_cpb_removal_delay = GetInitCpbRemovalDelay(task.EncodedOrder);
+            task.initial_cpb_removal_offset = GetInitCpbRemovalDelayOffset();
+        }
+
+        SetIf(m_prevBpEncOrderAsync, bBPSEI, task.EncodedOrder);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void HRD::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_QueryTask
+        , [this](StorageW&, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        Update(task.BsDataLength * 8, task.EncodedOrder, !!(task.InsertHeaders & INSERT_BPSEI));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void HRD::Init(const SPS &sps, mfxU32 InitialDelayInKB)
+{
+    VUI const & vui = sps.vui;
+    HRDInfo const & hrd = sps.vui.hrd;
+    HRDInfo::SubLayer::CPB const & cpb0 = hrd.sl[0].cpb[0];
+
+    m_bIsHrdRequired =
+        !(     !sps.vui_parameters_present_flag
+            || !sps.vui.hrd_parameters_present_flag
+            || !(hrd.nal_hrd_parameters_present_flag || hrd.vcl_hrd_parameters_present_flag));
+
+    if (!m_bIsHrdRequired)
+        return;
+
+    mfxU32 cpbSize = (cpb0.cpb_size_value_minus1 + 1) << (4 + hrd.cpb_size_scale);
+    m_cbrFlag = !!cpb0.cbr_flag;
+    m_bitrate = (cpb0.bit_rate_value_minus1 + 1) << (6 + hrd.bit_rate_scale);
+    m_maxCpbRemovalDelay = 1 << (hrd.au_cpb_removal_delay_length_minus1 + 1);
+
+    m_cpbSize90k = mfxU32(90000. * cpbSize / m_bitrate);
+    m_initCpbRemovalDelay = mfxU32(90000. * 8000. * InitialDelayInKB / m_bitrate);
+    m_clockTick = (mfxF64)vui.num_units_in_tick * 90000 / vui.time_scale;
+
+    m_prevAuCpbRemovalDelayMinus1 = -1;
+    m_prevAuCpbRemovalDelayMsb = 0;
+    m_prevAuFinalArrivalTime = 0;
+    m_prevBpAuNominalRemovalTime = m_initCpbRemovalDelay;
+    m_prevBpEncOrder = 0;
+}
+
+void HRD::Reset(SPS const & sps)
+{
+    HRDInfo const & hrd = sps.vui.hrd;
+    HRDInfo::SubLayer::CPB const & cpb0 = hrd.sl[0].cpb[0];
+
+    if (m_bIsHrdRequired == false)
+        return;
+
+    mfxU32 cpbSize = (cpb0.cpb_size_value_minus1 + 1) << (4 + hrd.cpb_size_scale);
+    m_bitrate = (cpb0.bit_rate_value_minus1 + 1) << (6 + hrd.bit_rate_scale);
+    m_cpbSize90k = mfxU32(90000. * cpbSize / m_bitrate);
+}
+
+void HRD::Update(mfxU32 sizeInbits, mfxU32 encOrder, bool bufferingPeriodPic)
+{
+    mfxF64 auNominalRemovalTime;
+
+    if (m_bIsHrdRequired == false)
+        return;
+
+    // (C-9)
+    auNominalRemovalTime = m_initCpbRemovalDelay;
+
+    if (encOrder > 0)
+    {
+        mfxU32  auCpbRemovalDelayMinus1 = (encOrder - m_prevBpEncOrder) - 1;
+        bool    bSetDelayMsb            = !bufferingPeriodPic && auCpbRemovalDelayMinus1;
+        // (D-1)
+        mfxU32 auCpbRemovalDelayMsb =
+            bSetDelayMsb
+            * (m_prevAuCpbRemovalDelayMsb
+                + m_maxCpbRemovalDelay * (mfxI32(auCpbRemovalDelayMinus1) <= m_prevAuCpbRemovalDelayMinus1));
+
+        m_prevAuCpbRemovalDelayMsb      = auCpbRemovalDelayMsb;
+        m_prevAuCpbRemovalDelayMinus1   = auCpbRemovalDelayMinus1;
+
+        // (D-2)
+        mfxU32 auCpbRemovalDelayValMinus1 = auCpbRemovalDelayMsb + auCpbRemovalDelayMinus1;
+        // (C-10, C-11)
+        auNominalRemovalTime = m_prevBpAuNominalRemovalTime + m_clockTick * (auCpbRemovalDelayValMinus1 + 1);
+    }
+
+    // (C-3)
+    mfxF64 initArrivalTime = m_prevAuFinalArrivalTime;
+
+    if (!m_cbrFlag)
+    {
+        mfxF64 initArrivalEarliestTime = auNominalRemovalTime;
+        // (C-7)
+        initArrivalEarliestTime -= !!bufferingPeriodPic * m_initCpbRemovalDelay;
+        // (C-6)
+        initArrivalEarliestTime -= !bufferingPeriodPic * m_cpbSize90k;
+        // (C-4)
+        initArrivalTime = std::max<mfxF64>(m_prevAuFinalArrivalTime, initArrivalEarliestTime * m_bitrate);
+    }
+    // (C-8)
+    mfxF64 auFinalArrivalTime = initArrivalTime + (mfxF64)sizeInbits * 90000;
+
+    m_prevAuFinalArrivalTime = auFinalArrivalTime;
+
+    if (bufferingPeriodPic)
+    {
+        m_prevBpAuNominalRemovalTime = auNominalRemovalTime;
+        m_prevBpEncOrder            = encOrder;
+    }
+
+    /*fprintf (stderr, "FO: %d\ninitArrivalTime = %f\nauFinalArrivalTime = %f\nauNominalRemovalTime = %f\n",
+        encOrder, initArrivalTime / 90000 / m_bitrate, auFinalArrivalTime / 90000 / m_bitrate, auNominalRemovalTime / 90000);
+    fflush(stderr);*/
+}
+
+mfxU32 HRD::GetInitCpbRemovalDelay(mfxU32 encOrder)
+{
+    mfxF64 auNominalRemovalTime;
+
+    if (m_bIsHrdRequired == false)
+        return 0;
+
+    if (encOrder > 0)
+    {
+        // (D-1)
+        mfxU32 auCpbRemovalDelayMsb = 0;
+        mfxU32 auCpbRemovalDelayMinus1 = encOrder - m_prevBpEncOrder - 1;
+
+        // (D-2)
+        mfxU32 auCpbRemovalDelayValMinus1 = auCpbRemovalDelayMsb + auCpbRemovalDelayMinus1;
+        // (C-10, C-11)
+        auNominalRemovalTime = m_prevBpAuNominalRemovalTime + m_clockTick * (auCpbRemovalDelayValMinus1 + 1);
+
+        // (C-17)
+        mfxF64 deltaTime90k = auNominalRemovalTime - m_prevAuFinalArrivalTime / m_bitrate;
+
+        m_initCpbRemovalDelay = m_cbrFlag
+            // (C-19)
+            ? (mfxU32)(deltaTime90k)
+            // (C-18)
+            : (mfxU32)std::min<mfxF64>(deltaTime90k, m_cpbSize90k);
+    }
+
+    return (mfxU32)m_initCpbRemovalDelay;
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hrd.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_hrd.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+class HRD
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Init) \
+    DECL_BLOCK(Reset) \
+    DECL_BLOCK(SubmitTask) \
+    DECL_BLOCK(QueryTask)
+#define DECL_FEATURE_NAME "G11_HRD"
+#include "hevcehw_decl_blocks.h"
+
+    HRD(mfxU32 id)
+        : FeatureBase(id)
+        , m_bIsHrdRequired(false)
+        , m_cbrFlag(false)
+        , m_bitrate(0)
+        , m_maxCpbRemovalDelay(0)
+        , m_clockTick(0)
+        , m_cpbSize90k(0)
+        , m_initCpbRemovalDelay(0)
+        , m_prevAuCpbRemovalDelayMinus1(0)
+        , m_prevAuCpbRemovalDelayMsb(0)
+        , m_prevAuFinalArrivalTime(0)
+        , m_prevBpAuNominalRemovalTime(0)
+        , m_prevBpEncOrder(0)
+        , m_prevBpEncOrderAsync(0)
+    {}
+
+protected:
+    bool   m_bIsHrdRequired;
+    bool   m_cbrFlag;
+    mfxU32 m_bitrate;
+    mfxU32 m_maxCpbRemovalDelay;
+    mfxF64 m_clockTick;
+    mfxF64 m_cpbSize90k;
+    mfxF64 m_initCpbRemovalDelay;
+
+    mfxI32 m_prevAuCpbRemovalDelayMinus1;
+    mfxU32 m_prevAuCpbRemovalDelayMsb;
+    mfxF64 m_prevAuFinalArrivalTime;
+    mfxF64 m_prevBpAuNominalRemovalTime;
+    mfxU32 m_prevBpEncOrder;
+    mfxU32 m_prevBpEncOrderAsync;
+
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+
+    using FeatureBase::Init;
+    void Init(const SPS &sps, mfxU32 InitialDelayInKB);
+    using FeatureBase::Reset;
+    void Reset(SPS const & sps);
+    void Update(mfxU32 sizeInbits, mfxU32 encOrder, bool bufferingPeriodPic);
+    mfxU32 GetInitCpbRemovalDelay(mfxU32 encOrder);
+
+    mfxU32 GetInitCpbRemovalDelayOffset() const
+    {
+        return mfxU32(m_cpbSize90k - m_initCpbRemovalDelay);
+    }
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_iddi.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_iddi.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+class IDDI
+    : public virtual FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(SetCallChains) \
+    DECL_BLOCK(QueryCaps)     \
+    DECL_BLOCK(CreateDevice)  \
+    DECL_BLOCK(CreateService) \
+    DECL_BLOCK(Register)      \
+    DECL_BLOCK(Reset)      \
+    DECL_BLOCK(SubmitTask)    \
+    DECL_BLOCK(QueryTask)
+#define DECL_FEATURE_NAME "G11_IDDI"
+#include "hevcehw_decl_blocks.h"
+
+    IDDI(mfxU32 /*FeatureId*/) {}
+
+protected:
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override = 0;
+    virtual void InitExternal(const FeatureBlocks& blocks, TPushIE Push) override = 0;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override = 0;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override = 0;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override = 0;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override = 0;
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_iddi_packer.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_iddi_packer.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+class IDDIPacker
+    : public virtual FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Init) \
+    DECL_BLOCK(Reset) \
+    DECL_BLOCK(SubmitTask) \
+    DECL_BLOCK(QueryTask) \
+    DECL_BLOCK(SetCallChains) \
+    DECL_BLOCK(HardcodeCaps)
+#define DECL_FEATURE_NAME "G11_IDDIPacker"
+#include "hevcehw_decl_blocks.h"
+
+    IDDIPacker(mfxU32 /*FeatureId*/) {}
+
+protected:
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override = 0;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override = 0;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override = 0;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override = 0;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override = 0;
+
+    void HardcodeCapsCommon(EncodeCapsHevc& caps, eMFXHWType hw, const mfxVideoParam& par)
+    {
+        if (hw < MFX_HW_CNL)
+        {   // not set until CNL now
+            caps.LCUSizeSupported = 0b10; // 32x32 lcu is only supported
+            caps.BlockSize        = 0b10; // 32x32
+        }
+
+        caps.SliceIPOnly        = IsOn(par.mfx.LowPower);
+        caps.msdk.PSliceSupport = !(IsOn(par.mfx.LowPower) || hw > MFX_HW_ICL);
+    }
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_interlace.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_interlace.cpp
@@ -1,0 +1,539 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_interlace.h"
+#include "hevcehw_g11_packer.h"
+#include "hevcehw_g11_legacy.h"
+#include <numeric>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Interlace::Query1NoCaps(const FeatureBlocks& , TPushQ1 Push)
+{
+    Push(BLK_SetDefaultsCallChain,
+        [this](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+    {
+        auto& defaults = Glob::Defaults::GetOrConstruct(strg);
+        auto& bSet = defaults.SetForFeature[GetID()];
+        MFX_CHECK(!bSet, MFX_ERR_NONE);
+
+        defaults.GetMinRefForBPyramid.Push(
+            [](Defaults::TChain<mfxU16>::TExt prev
+                , const Defaults::Param& par)
+        {
+            bool bField = IsField(par.mvp.mfx.FrameInfo.PicStruct);
+            return mfxU16(prev(par) * (1 + bField) + bField);
+        });
+
+        defaults.GetMinRefForBNoPyramid.Push(
+            [](Defaults::TChain<mfxU16>::TExt prev
+                , const Defaults::Param& par)
+        {
+            bool bField = IsField(par.mvp.mfx.FrameInfo.PicStruct);
+            return mfxU16(prev(par) * (1 + bField));
+        });
+
+        defaults.GetNumReorderFrames.Push(
+            [](Defaults::TChain<mfxU8>::TExt prev
+                , const Defaults::Param& par)
+        {
+            bool bField = IsField(par.mvp.mfx.FrameInfo.PicStruct);
+            return mfxU8(prev(par) * (1 + bField));
+        });
+
+        defaults.GetNonStdReordering.Push(
+            [](Defaults::TChain<bool>::TExt prev
+                , const Defaults::Param& par)
+        {
+            return
+                (IsField(par.mvp.mfx.FrameInfo.PicStruct)
+                    && par.mvp.mfx.EncodedOrder
+                    && par.mvp.mfx.NumRefFrame
+                    && par.mvp.mfx.GopRefDist > 1
+                    && par.base.GetMinRefForBNoPyramid(par) > par.mvp.mfx.NumRefFrame)
+                || prev(par);
+        });
+
+        defaults.GetNumRefPPyramid.Push(
+            [](Defaults::TChain<mfxU16>::TExt prev
+                , const Defaults::Param& par)
+        {
+            mfxU16 k = 1 + IsField(par.mvp.mfx.FrameInfo.PicStruct);
+            return std::max<mfxU16>(DEFAULT_PPYR_INTERVAL * k, prev(par));
+        });
+
+        defaults.GetNumRefNoPyramid.Push(
+            [](Defaults::TChain<mfxU16>::TExt prev
+                , const Defaults::Param& par)
+        {
+            return mfxU16(prev(par) * (1 + IsField(par.mvp.mfx.FrameInfo.PicStruct)));
+        });
+
+        defaults.GetFrameType.Push(
+            [](Defaults::TGetFrameType::TExt prev
+                , const Defaults::Param& par
+                , mfxU32 fo
+                , mfxU32 lastIDR)
+        {
+            bool   bField       = IsField(par.mvp.mfx.FrameInfo.PicStruct);
+            mfxU32 dFO          = bField * (lastIDR % 2);
+            mfxU32 nPicInFrame  = bField + 1;
+
+            auto   ft = prev(par, (fo + dFO - lastIDR) / nPicInFrame,  0);
+
+            bool   b2ndField    = bField && ((fo + dFO - lastIDR) % 2);
+            bool   bForceP      = b2ndField && IsI(ft);
+
+            ft &= ~((MFX_FRAMETYPE_I | MFX_FRAMETYPE_IDR) * bForceP);
+            ft |= MFX_FRAMETYPE_P * bForceP;
+
+            bool bForceRef = bField && !b2ndField && !IsB(ft);
+            ft |= MFX_FRAMETYPE_REF * bForceRef;
+            return ft;
+        });
+
+        defaults.GetPicTimingSEI.Push(
+            [](Defaults::TChain<mfxU16>::TExt prev
+            , const Defaults::Param& par)
+        {
+            return Bool2CO(IsField(par.mvp.mfx.FrameInfo.PicStruct) || IsOn(prev(par)));
+        });
+
+        defaults.GetPLayer.Push(
+            [](Defaults::TGetPLayer::TExt prev
+                , const Defaults::Param& par
+                , mfxU32 fo)
+        {
+            return prev(par, fo / (1 + IsField(par.mvp.mfx.FrameInfo.PicStruct)));
+        });
+
+        defaults.GetTId.Push(
+            [](Defaults::TGetTId::TExt prev
+                , const Defaults::Param& par
+                , mfxU32 fo)
+        {
+            return prev(par, fo / (1 + IsField(par.mvp.mfx.FrameInfo.PicStruct)));
+        });
+
+        defaults.GetRPL.Push( [](
+            Defaults::TGetRPL::TExt prev
+            , const Defaults::Param& par
+            , const DpbArray &DPB
+            , mfxU16 maxL0
+            , mfxU16 maxL1
+            , const FrameBaseInfo& cur
+            , mfxU8(&RPL)[2][MAX_DPB_SIZE]) -> std::tuple<mfxU8, mfxU8>
+        {
+            if (!IsField(par.mvp.mfx.FrameInfo.PicStruct))
+                return prev(par, DPB, maxL0, maxL1, cur, RPL);
+
+            auto nRefLX = prev(par, DPB, MAX_DPB_SIZE, MAX_DPB_SIZE, cur, RPL);
+            auto& l0    = std::get<0>(nRefLX);
+            auto& l1    = std::get<1>(nRefLX);
+
+            bool bValid = l0 <= maxL0 && l1 <= maxL1;
+            if (!bValid)
+            {
+                std::list<mfxU8> L0(RPL[0], RPL[0] + l0);
+                std::list<mfxU8> L1(RPL[1], RPL[1] + l1);
+                auto CmpRef = [&](mfxU8 a, mfxU8 b)
+                {
+                    auto FN = [](const FrameBaseInfo& x) { return (x.POC + !x.b2ndField) / 2; };
+                    auto aDist = abs(FN(DPB[a]) - FN(cur)) * 2 + (DPB[a].bBottomField != cur.bBottomField);
+                    auto bDist = abs(FN(DPB[b]) - FN(cur)) * 2 + (DPB[b].bBottomField != cur.bBottomField);
+                    return aDist <= bDist;
+                };
+                auto IsNotInL0 = [&](mfxU8 x) { return std::find(L0.begin(), L0.end(), x) == L0.end(); };
+                auto IsNotInL1 = [&](mfxU8 x) { return std::find(L1.begin(), L1.end(), x) == L1.end(); };
+
+                L0.sort(CmpRef);
+                L1.sort(CmpRef);
+
+                L0.resize(std::min<mfxU16>(maxL0, l0));
+                L1.resize(std::min<mfxU16>(maxL1, l1));
+
+                std::remove_if(RPL[0], RPL[0] + l0, IsNotInL0);
+                std::remove_if(RPL[1], RPL[1] + l1, IsNotInL1);
+
+                l0 = mfxU8(L0.size());
+                l1 = mfxU8(L1.size());
+
+                std::fill(std::next(RPL[0], l0), std::end(RPL[0]), IDX_INVALID);
+                std::fill(std::next(RPL[1], l1), std::end(RPL[1]), IDX_INVALID);
+            }
+
+            return nRefLX;
+        });
+
+        defaults.GetPreReorderInfo.Push([](
+            Defaults::TGetPreReorderInfo::TExt  prev
+            , const Defaults::Param&            par
+            , FrameBaseInfo&                    fi
+            , const mfxFrameSurface1*           pSurfIn
+            , const mfxEncodeCtrl*              pCtrl
+            , mfxU32                            prevIDROrder
+            , mfxI32                            prevIPOC
+            , mfxU32                            frameOrder)
+        {
+            auto sts = prev(par, fi, pSurfIn, pCtrl, prevIDROrder, prevIPOC, frameOrder);
+            MFX_CHECK_STS(sts);
+
+            MFX_CHECK(IsField(par.mvp.mfx.FrameInfo.PicStruct), MFX_ERR_NONE);
+
+            bool bInfoValid = pSurfIn && !!(pSurfIn->Info.PicStruct & (MFX_PICSTRUCT_FIELD_TFF | MFX_PICSTRUCT_FIELD_BFF));
+            fi.b2ndField = !!(frameOrder & 1);
+            fi.bBottomField =
+                (bInfoValid && IsBFF(pSurfIn->Info.PicStruct))
+                || (!bInfoValid && (IsBFF(par.mvp.mfx.FrameInfo.PicStruct) != fi.b2ndField));
+
+            return MFX_ERR_NONE;
+        });
+
+        // min 2 active L0 refs for 2nd field
+        defaults.GetFrameNumRefActive.Push([](
+            Defaults::TGetFrameNumRefActive::TExt prev
+            , const Defaults::Param& par
+            , const FrameBaseInfo& fi)
+        {
+            auto  nRef      = prev(par, fi);
+            auto& nL0       = std::get<0>(nRef);
+            bool  bSetMinL0 = nL0 && fi.b2ndField && nL0 < 2;
+
+            SetIf(nL0, bSetMinL0, mfxU8(2));
+
+            return nRef;
+        });
+
+        defaults.GetSHNUT.Push([](
+            Defaults::TGetSHNUT::TExt prev
+            , const Defaults::Param& par
+            , const TaskCommonPar& task
+            , bool bRAPIntra)
+        {
+            return prev(par, task, bRAPIntra && !IsField(par.mvp.mfx.FrameInfo.PicStruct));
+        });
+
+        defaults.GetSPS.Push([](
+            Defaults::TGetSPS::TExt prev
+            , const Defaults::Param& par
+            , const VPS& vps
+            , SPS& sps)
+        {
+            auto  sts = prev(par, vps, sps);
+            auto& mfx = par.mvp.mfx;
+
+            MFX_CHECK(IsField(mfx.FrameInfo.PicStruct) && sts >= MFX_ERR_NONE, sts);
+
+            sps.log2_max_pic_order_cnt_lsb_minus4 =
+                mfx::clamp<mfxU32>(
+                    CeilLog2(mfx.GopRefDist * 2 + sps.sub_layer[sps.max_sub_layers_minus1].max_dec_pic_buffering_minus1) - 1
+                    , sps.log2_max_pic_order_cnt_lsb_minus4
+                    , 12u);
+            sps.vui.frame_field_info_present_flag = 1;
+            sps.vui.field_seq_flag                = 1;
+
+            return sts;
+        });
+        defaults.GetWeakRef.Push([](
+            Defaults::TGetWeakRef::TExt prev
+            , const Defaults::Param& par
+            , const FrameBaseInfo  &cur
+            , const DpbFrame       *begin
+            , const DpbFrame       *end)
+        {
+            if (!IsField(par.mvp.mfx.FrameInfo.PicStruct))
+            {
+                return prev(par, cur, begin, end);
+            }
+
+            const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+            auto POCLess = [](const DpbFrame& l, const DpbFrame& r) { return l.POC < r.POC; };
+
+            if (CO3.PRefType == MFX_P_REF_PYRAMID)
+            {
+                auto PyrInt = par.base.GetPPyrInterval(par);
+                auto FN     = [](const FrameBaseInfo& x) { return (x.POC + !x.b2ndField) / 2; };
+                auto IsWeak = [&](const FrameBaseInfo& x) { return (FN(x) - FN(*begin)) % PyrInt != 0; };
+
+                if (FN(begin[1]) == FN(begin[0]))
+                {
+                    return std::find_if(begin, end, IsWeak);
+                }
+
+                return begin;
+            }
+
+            return std::min_element(begin, end, POCLess);
+        });
+
+        bSet = true;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Interlace::Query1WithCaps(const FeatureBlocks&, TPushQ1 Push)
+{
+    Push(BLK_CheckPicStruct,
+        [](const mfxVideoParam&, mfxVideoParam& par, StorageRW&) -> mfxStatus
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        bool bInterlaceAllowed =
+            par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+            || (   pCO2
+                && IsOn(pCO2->ExtBRC)
+                && (   par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+                    || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR));
+
+        bool bChanged = CheckOrZero<mfxU16>(
+            par.mfx.FrameInfo.PicStruct
+            , mfxU16(MFX_PICSTRUCT_UNKNOWN)
+            , mfxU16(MFX_PICSTRUCT_PROGRESSIVE)
+            , mfxU16(bInterlaceAllowed * MFX_PICSTRUCT_FIELD_TOP)
+            , mfxU16(bInterlaceAllowed * MFX_PICSTRUCT_FIELD_BOTTOM)
+            , mfxU16(bInterlaceAllowed * MFX_PICSTRUCT_FIELD_SINGLE)
+            , mfxU16(bInterlaceAllowed * MFX_PICSTRUCT_FIELD_TFF)
+            , mfxU16(bInterlaceAllowed * MFX_PICSTRUCT_FIELD_BFF));
+
+        MFX_CHECK(!bChanged, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    });
+}
+
+void Interlace::QueryIOSurf(const FeatureBlocks&, TPushQIS Push)
+{
+    Push(BLK_QueryIOSurf
+        , [](const mfxVideoParam&, mfxFrameAllocRequest& req, StorageRW& strg) -> mfxStatus
+    {
+        auto& par  = Glob::VideoParam::Get(strg);
+        mfxU16 nExtraRaw = IsField(par.mfx.FrameInfo.PicStruct) * (par.mfx.GopRefDist - 1);
+
+        req.NumFrameMin += nExtraRaw;
+        req.NumFrameSuggested += nExtraRaw;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+using TTaskItWrap = TaskItWrap<FrameBaseInfo, Task::Common::Key>;
+
+static bool IsL1Ready(
+    DpbArray const & dpb,
+    mfxI32 poc,
+    TTaskItWrap begin,
+    TTaskItWrap end,
+    bool flush)
+{
+    std::list<const DpbFrame*> bwd(Size(dpb), nullptr);
+    std::iota(bwd.begin(), bwd.end(), std::begin(dpb));
+
+    bwd.remove_if([&](const DpbFrame* p) { return !isValid(*p) || p->POC < poc; });
+
+    if (bwd.size() != 1)
+        return !bwd.empty();
+
+    auto top = std::find_if_not(begin, end
+        , [&](const FrameBaseInfo& f) { return f.POC <= bwd.back()->POC; });
+
+    bool bRes = (top != end && IsB(top->FrameType))
+        || (top == end && flush);
+
+    return bRes;
+}
+
+template <class T>
+static T IntBPyrReorder(T begin, T end)
+{
+    typedef typename std::iterator_traits<T>::reference TRef;
+
+    mfxU32 num = mfxU32(std::distance(begin, end));
+    bool bSetOrder = num && (*begin)->BPyramidOrder == mfxU32(MFX_FRAMEORDER_UNKNOWN);
+
+    if (bSetOrder)
+    {
+        mfxU32 i = 0;
+        std::for_each(begin, end, [&](TRef bref)
+        {
+            bool bRef = false;
+            bref->BPyramidOrder = Legacy::GetBiFrameLocation(i++ / 2, num / 2, bRef, bref->PyramidLevel);
+            bref->PyramidLevel *= 2;
+            bref->FrameType |= mfxU16(MFX_FRAMETYPE_REF * (bRef || !bref->b2ndField));
+        });
+    }
+
+    return std::min_element(begin, end
+        , [](TRef a, TRef b) { return a->BPyramidOrder < b->BPyramidOrder; });
+}
+
+static TTaskItWrap IntReorder(
+    mfxVideoParam const & par,
+    DpbArray const & dpb,
+    TTaskItWrap begin,
+    TTaskItWrap end,
+    bool flush)
+{
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+    bool bBPyramid = (CO2.BRefType == MFX_B_REF_PYRAMID);
+    auto top = begin;
+    std::list<TTaskItWrap> brefs;
+
+    auto IsB      = [] (FrameBaseInfo& f){ return !!(f.FrameType & MFX_FRAMETYPE_B); };
+    auto NoL1     = [&](TTaskItWrap f)   { return !IsL1Ready(dpb, f->POC, begin, end, flush); };
+    auto NextBRef = [&]()                { return *IntBPyrReorder(brefs.begin(), brefs.end()); };
+
+    std::generate_n(
+        std::back_inserter(brefs)
+        , std::distance(begin, std::find_if_not(begin, end, IsB))
+        , [&]() { return top++; });
+
+    brefs.remove_if(NoL1);
+
+    bool bNoPyramidB = !bBPyramid && !brefs.empty();
+
+    if (bNoPyramidB)
+    {
+        auto            topB        = brefs.begin();
+        FrameBaseInfo*  pPrevB      = nullptr;
+        auto            IsNextBRef  = [&](TTaskItWrap& f)
+        {
+            bool bRes = IsRef(f->FrameType) && (!pPrevB || ((f->POC - pPrevB->POC) < 3));
+            pPrevB = &*f;
+            return bRes;
+        };
+        auto ref = std::find_if(brefs.begin(), brefs.end(), IsNextBRef);
+
+        SetIf(topB, ref != brefs.end(), ref);
+
+        return *topB;
+    }
+
+    SetIf(top, !brefs.empty(), NextBRef);
+
+    bool bForcePRef = flush && top == end && begin != end;
+    while (bForcePRef)
+    {
+        --top;
+        top->FrameType = mfxU16(MFX_FRAMETYPE_P | MFX_FRAMETYPE_REF);
+        bForcePRef = top != begin && top->b2ndField;
+    }
+
+    return top;
+}
+
+void Interlace::InitInternal(const FeatureBlocks&, TPushII Push)
+{
+    Push(BLK_SetReorder
+        , [](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+        MFX_CHECK(IsField(par.mfx.FrameInfo.PicStruct), MFX_ERR_NONE);
+
+        auto& rdr = Glob::Reorder::Get(strg);
+        rdr.BufferSize += par.mfx.GopRefDist - 1;
+        rdr.Push([&](Reorderer::TExt, const DpbArray& DPB, TTaskIt begin, TTaskIt end, bool bFlush)
+        {
+            return IntReorder(par, DPB, begin, end, bFlush).it;
+        });
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_PatchRawInfo
+        , [](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+        MFX_CHECK(IsField(par.mfx.FrameInfo.PicStruct), MFX_ERR_NONE);
+
+        Tmp::RawInfo::Get(local).NumFrameMin += par.mfx.GopRefDist - 1;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Interlace::SubmitTask(const FeatureBlocks& , TPushST Push)
+{
+    Push(BLK_InsertPTSEI
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        auto PS = par.mfx.FrameInfo.PicStruct;
+        MFX_CHECK(IsField(PS), MFX_ERR_NONE);
+
+        auto& task = Task::Common::Get(s_task);
+        MFX_CHECK(task.InsertHeaders & INSERT_PTSEI, MFX_ERR_NONE);
+
+        auto usrPlEnd = task.ctrl.Payload + task.ctrl.NumPayload;
+        bool bUserPTSEI = usrPlEnd != std::find_if(task.ctrl.Payload, usrPlEnd
+            , [](const mfxPayload* pPl) { return pPl && pPl->Type == 1; });
+        MFX_CHECK(!bUserPTSEI, MFX_ERR_NONE);
+
+        auto& sps = Glob::SPS::Get(global);
+        static const std::map<mfxU16, mfxU8> PicStructMFX2STD =
+        {
+              {mfxU16(MFX_PICSTRUCT_FIELD_TOP), mfxU8(1)}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_BOTTOM), mfxU8(2)}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_TOP | MFX_PICSTRUCT_FIELD_PAIRED_PREV), mfxU8(9)}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_TOP | MFX_PICSTRUCT_FIELD_PAIRED_NEXT), mfxU8(11)}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_BOTTOM | MFX_PICSTRUCT_FIELD_PAIRED_PREV), mfxU8(10)}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_BOTTOM | MFX_PICSTRUCT_FIELD_PAIRED_NEXT), mfxU8(12)}
+        };
+        PicTimingSEI pt = {};
+        pt.pic_struct = 1 + task.bBottomField;
+
+        if (PicStructMFX2STD.count(task.pSurfIn->Info.PicStruct))
+            pt.pic_struct = PicStructMFX2STD.at(task.pSurfIn->Info.PicStruct);
+
+        pt.source_scan_type = 0;
+        pt.duplicate_flag = 0;
+
+        pt.au_cpb_removal_delay_minus1 = std::max<mfxU32>(task.cpb_removal_delay, 1) - 1;
+        pt.pic_dpb_output_delay =
+            task.DisplayOrder
+            + sps.sub_layer[sps.max_sub_layers_minus1].max_num_reorder_pics
+            - task.EncodedOrder;
+
+        BitstreamWriter bs(m_buf.data(), (mfxU32)m_buf.size(), 0);
+        mfxPayload pl = {};
+        pl.Type = 1;
+        pl.Data = bs.GetStart();
+
+        bs.PutBits(8, 1);    //payload type
+        bs.PutBits(8, 0xff); //place for payload size
+
+        Packer::PackSEIPayload(bs, sps.vui, pt);
+
+        pl.NumBit  = bs.GetOffset();
+        pl.BufSize = mfxU16(CeilDiv(pl.NumBit, 8u));
+
+        assert(pl.BufSize < 256);
+        pl.Data[1] = (mfxU8)pl.BufSize - 2; //payload size
+
+        task.PLInternal.push_back(pl);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_interlace.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_interlace.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class Interlace
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(CheckPicStruct)\
+    DECL_BLOCK(SetDefaultsCallChain)\
+    DECL_BLOCK(SetReorder)\
+    DECL_BLOCK(PatchRawInfo)\
+    DECL_BLOCK(PrepareTask)\
+    DECL_BLOCK(InsertPTSEI)\
+    DECL_BLOCK(PatchDDITask)\
+    DECL_BLOCK(QueryIOSurf)
+#define DECL_FEATURE_NAME "G11_Interlace"
+#include "hevcehw_decl_blocks.h"
+
+        Interlace(mfxU32 FeatureId)
+            : FeatureBase(FeatureId)
+        {}
+
+    protected:
+        virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+        virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+        virtual void QueryIOSurf(const FeatureBlocks& blocks, TPushQIS Push) override;
+        virtual void InitInternal(const FeatureBlocks& blocks, TPushII Push) override;
+        virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
+
+        static bool IsField(mfxU16 PicStruct) { return  !!(PicStruct & MFX_PICSTRUCT_FIELD_SINGLE); }
+        static bool IsBFF(mfxU16 PicStruct) { return !!(PicStruct & MFX_PICSTRUCT_FIELD_BFF); }
+
+        std::array<mfxU8, 32> m_buf;
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy.cpp
@@ -1,0 +1,4863 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_legacy.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_constraints.h"
+#include "hevcehw_g11_parser.h"
+#include "fast_copy.h"
+#include <algorithm>
+#include <exception>
+#include <numeric>
+#include <set>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Legacy::SetSupported(ParamSupport& blocks)
+{
+    auto CopyRawBuffer = [](mfxU8* pSrcBuf, mfxU16 szSrcBuf, mfxU8* pDstBuf, mfxU16& szDstBuf)
+    {
+        bool bCopy = pSrcBuf && pDstBuf;
+        ThrowIf(bCopy && szSrcBuf > szDstBuf, MFX_ERR_NOT_ENOUGH_BUFFER);
+
+        if (bCopy)
+        {
+            std::copy_n(pSrcBuf, szSrcBuf, pDstBuf);
+            szDstBuf = szSrcBuf;
+        }
+    };
+
+    blocks.m_mvpCopySupported.emplace_back(
+        [](const mfxVideoParam* pSrc, mfxVideoParam* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxVideoParam*)pSrc;
+        auto& buf_dst = *(mfxVideoParam*)pDst;
+        MFX_COPY_FIELD(IOPattern);
+        MFX_COPY_FIELD(Protected);
+        MFX_COPY_FIELD(AsyncDepth);
+        MFX_COPY_FIELD(mfx.CodecId);
+        MFX_COPY_FIELD(mfx.LowPower);
+        MFX_COPY_FIELD(mfx.CodecLevel);
+        MFX_COPY_FIELD(mfx.CodecProfile);
+        MFX_COPY_FIELD(mfx.TargetUsage);
+        MFX_COPY_FIELD(mfx.GopPicSize);
+        MFX_COPY_FIELD(mfx.GopRefDist);
+        MFX_COPY_FIELD(mfx.GopOptFlag);
+        MFX_COPY_FIELD(mfx.IdrInterval);
+        MFX_COPY_FIELD(mfx.BRCParamMultiplier);
+        MFX_COPY_FIELD(mfx.RateControlMethod);
+        MFX_COPY_FIELD(mfx.InitialDelayInKB);
+        MFX_COPY_FIELD(mfx.BufferSizeInKB);
+        MFX_COPY_FIELD(mfx.TargetKbps);
+        MFX_COPY_FIELD(mfx.MaxKbps);
+        MFX_COPY_FIELD(mfx.NumSlice);
+        MFX_COPY_FIELD(mfx.NumRefFrame);
+        MFX_COPY_FIELD(mfx.EncodedOrder);
+        MFX_COPY_FIELD(mfx.FrameInfo.Shift);
+        MFX_COPY_FIELD(mfx.FrameInfo.BitDepthLuma);
+        MFX_COPY_FIELD(mfx.FrameInfo.BitDepthChroma);
+        MFX_COPY_FIELD(mfx.FrameInfo.FourCC);
+        MFX_COPY_FIELD(mfx.FrameInfo.Width);
+        MFX_COPY_FIELD(mfx.FrameInfo.Height);
+        MFX_COPY_FIELD(mfx.FrameInfo.CropX);
+        MFX_COPY_FIELD(mfx.FrameInfo.CropY);
+        MFX_COPY_FIELD(mfx.FrameInfo.CropW);
+        MFX_COPY_FIELD(mfx.FrameInfo.CropH);
+        MFX_COPY_FIELD(mfx.FrameInfo.FrameRateExtN);
+        MFX_COPY_FIELD(mfx.FrameInfo.FrameRateExtD);
+        MFX_COPY_FIELD(mfx.FrameInfo.AspectRatioW);
+        MFX_COPY_FIELD(mfx.FrameInfo.AspectRatioH);
+        MFX_COPY_FIELD(mfx.FrameInfo.ChromaFormat);
+        MFX_COPY_FIELD(mfx.FrameInfo.PicStruct);
+    });
+
+    blocks.m_ebCopySupported[MFX_EXTBUFF_HEVC_PARAM].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtHEVCParam*)pSrc;
+        auto& buf_dst = *(mfxExtHEVCParam*)pDst;
+        MFX_COPY_FIELD(PicWidthInLumaSamples);
+        MFX_COPY_FIELD(PicHeightInLumaSamples);
+        MFX_COPY_FIELD(GeneralConstraintFlags);
+        MFX_COPY_FIELD(SampleAdaptiveOffset);
+        MFX_COPY_FIELD(LCUSize);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_HEVC_TILES].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtHEVCTiles*)pSrc;
+        auto& buf_dst = *(mfxExtHEVCTiles*)pDst;
+        MFX_COPY_FIELD(NumTileRows);
+        MFX_COPY_FIELD(NumTileColumns);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtOpaqueSurfaceAlloc*)pSrc;
+        auto& buf_dst = *(mfxExtOpaqueSurfaceAlloc*)pDst;
+        MFX_COPY_FIELD(In.Surfaces);
+        MFX_COPY_FIELD(In.Type);
+        MFX_COPY_FIELD(In.NumSurface);
+        MFX_COPY_FIELD(Out.Surfaces);
+        MFX_COPY_FIELD(Out.Type);
+        MFX_COPY_FIELD(Out.NumSurface);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_AVC_REFLISTS].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtAVCRefLists*)pSrc;
+        auto& buf_dst = *(mfxExtAVCRefLists*)pDst;
+        MFX_COPY_FIELD(NumRefIdxL0Active);
+        MFX_COPY_FIELD(NumRefIdxL1Active);
+        for (mfxU32 i = 0; i < 16; i++)
+        {
+            MFX_COPY_FIELD(RefPicList0[i].FrameOrder);
+            MFX_COPY_FIELD(RefPicList1[i].FrameOrder);
+        }
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOption*)pSrc;
+        auto& buf_dst = *(mfxExtCodingOption*)pDst;
+        MFX_COPY_FIELD(PicTimingSEI);
+        MFX_COPY_FIELD(VuiNalHrdParameters);
+        MFX_COPY_FIELD(NalHrdConformance);
+        MFX_COPY_FIELD(AUDelimiter);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOption2*)pSrc;
+        auto& buf_dst = *(mfxExtCodingOption2*)pDst;
+        MFX_COPY_FIELD(IntRefType);
+        MFX_COPY_FIELD(IntRefCycleSize);
+        MFX_COPY_FIELD(IntRefQPDelta);
+        MFX_COPY_FIELD(MBBRC);
+        MFX_COPY_FIELD(BRefType);
+        MFX_COPY_FIELD(NumMbPerSlice);
+        MFX_COPY_FIELD(DisableDeblockingIdc);
+        MFX_COPY_FIELD(RepeatPPS);
+        MFX_COPY_FIELD(MaxSliceSize);
+        MFX_COPY_FIELD(ExtBRC);
+        MFX_COPY_FIELD(MinQPI);
+        MFX_COPY_FIELD(MaxQPI);
+        MFX_COPY_FIELD(MinQPP);
+        MFX_COPY_FIELD(MaxQPP);
+        MFX_COPY_FIELD(MinQPB);
+        MFX_COPY_FIELD(MaxQPB);
+        MFX_COPY_FIELD(SkipFrame);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION3].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOption3*)pSrc;
+        auto& buf_dst = *(mfxExtCodingOption3*)pDst;
+        MFX_COPY_FIELD(PRefType);
+        MFX_COPY_FIELD(IntRefCycleDist);
+        MFX_COPY_FIELD(EnableQPOffset);
+        MFX_COPY_FIELD(GPB);
+        MFX_COPY_ARRAY_FIELD(QPOffset);
+        MFX_COPY_ARRAY_FIELD(NumRefActiveP);
+        MFX_COPY_ARRAY_FIELD(NumRefActiveBL0);
+        MFX_COPY_ARRAY_FIELD(NumRefActiveBL1);
+        MFX_COPY_FIELD(QVBRQuality);
+        MFX_COPY_FIELD(EnableMBQP);
+        MFX_COPY_FIELD(TransformSkip);
+        MFX_COPY_FIELD(TargetChromaFormatPlus1);
+        MFX_COPY_FIELD(TargetBitDepthLuma);
+        MFX_COPY_FIELD(TargetBitDepthChroma);
+        MFX_COPY_FIELD(WinBRCMaxAvgKbps);
+        MFX_COPY_FIELD(WinBRCSize);
+        MFX_COPY_FIELD(EnableNalUnitType);
+        MFX_COPY_FIELD(LowDelayBRC);
+#if MFX_VERSION >= MFX_VERSION_NEXT
+        MFX_COPY_FIELD(DeblockingAlphaTcOffset);
+        MFX_COPY_FIELD(DeblockingBetaOffset);
+#endif
+        MFX_COPY_FIELD(BRCPanicMode);
+        MFX_COPY_FIELD(ScenarioInfo);
+    });
+    blocks.m_ebCopyPtrs[MFX_EXTBUFF_CODING_OPTION_SPSPPS].emplace_back(
+        [&](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOptionSPSPPS*)pSrc;
+        auto&       buf_dst = *(mfxExtCodingOptionSPSPPS*)pDst;
+
+        MFX_COPY_FIELD(SPSBuffer);
+        MFX_COPY_FIELD(SPSBufSize);
+        MFX_COPY_FIELD(PPSBuffer);
+        MFX_COPY_FIELD(PPSBufSize);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION_SPSPPS].emplace_back(
+        [&](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOptionSPSPPS*)pSrc;
+        auto&       buf_dst = *(mfxExtCodingOptionSPSPPS*)pDst;
+
+        CopyRawBuffer(buf_src.SPSBuffer, buf_src.SPSBufSize, buf_dst.SPSBuffer, buf_dst.SPSBufSize);
+        CopyRawBuffer(buf_src.PPSBuffer, buf_src.PPSBufSize, buf_dst.PPSBuffer, buf_dst.PPSBufSize);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_AVC_REFLIST_CTRL].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtAVCRefListCtrl*)pSrc;
+        auto& buf_dst = *(mfxExtAVCRefListCtrl*)pDst;
+        MFX_COPY_FIELD(NumRefIdxL0Active);
+        MFX_COPY_FIELD(NumRefIdxL1Active);
+        for (mfxU32 i = 0; i < 16; i++)
+        {
+            MFX_COPY_FIELD(PreferredRefList[i].FrameOrder);
+            MFX_COPY_FIELD(RejectedRefList[i].FrameOrder);
+            MFX_COPY_FIELD(LongTermRefList[i].FrameOrder);
+        }
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_AVC_TEMPORAL_LAYERS].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtAvcTemporalLayers*)pSrc;
+        auto& buf_dst = *(mfxExtAvcTemporalLayers*)pDst;
+        for (mfxU32 i = 0; i < 7; i++)
+        {
+            MFX_COPY_FIELD(Layer[i].Scale);
+        }
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_ENCODER_RESET_OPTION].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtEncoderResetOption*)pSrc;
+        auto& buf_dst = *(mfxExtEncoderResetOption*)pDst;
+        MFX_COPY_FIELD(StartNewSequence);
+    });
+    blocks.m_ebCopyPtrs[MFX_EXTBUFF_CODING_OPTION_VPS].emplace_back(
+        [&](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOptionVPS*)pSrc;
+        auto&       buf_dst = *(mfxExtCodingOptionVPS*)pDst;
+
+        MFX_COPY_FIELD(VPSBuffer);
+        MFX_COPY_FIELD(VPSBufSize);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION_VPS].emplace_back(
+        [&](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtCodingOptionVPS*)pSrc;
+        auto& buf_dst = *(mfxExtCodingOptionVPS*)pDst;
+
+        CopyRawBuffer(buf_src.VPSBuffer, buf_src.VPSBufSize, buf_dst.VPSBuffer, buf_dst.VPSBufSize);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_VIDEO_SIGNAL_INFO].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtVideoSignalInfo*)pSrc;
+        auto& buf_dst = *(mfxExtVideoSignalInfo*)pDst;
+        buf_dst = buf_src;
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_LOOKAHEAD_STAT].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtLAFrameStatistics*)pSrc;
+        auto& buf_dst = *(mfxExtLAFrameStatistics*)pDst;
+        MFX_COPY_FIELD(NumAlloc);
+        MFX_COPY_FIELD(NumStream);
+        MFX_COPY_FIELD(NumFrame);
+        MFX_COPY_FIELD(FrameStat);
+        MFX_COPY_FIELD(OutSurface);
+    });
+    blocks.m_ebCopySupported[MFX_EXTBUFF_MBQP].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        const auto& buf_src = *(const mfxExtMBQP*)pSrc;
+        auto& buf_dst = *(mfxExtMBQP*)pDst;
+        MFX_COPY_FIELD(NumQPAlloc);
+        MFX_COPY_FIELD(QP);
+    });
+}
+
+void Legacy::SetInherited(ParamInheritance& par)
+{
+    par.m_mvpInheritDefault.emplace_back(
+        [](const mfxVideoParam* pSrc, mfxVideoParam* pDst)
+    {
+        auto& parInit = *pSrc;
+        auto& parReset = *pDst;
+
+#define INHERIT_OPT(OPT) InheritOption(parInit.OPT, parReset.OPT)
+#define INHERIT_BRC(OPT) { OPT tmp(parReset.mfx); InheritOption(OPT(parInit.mfx), tmp); }
+
+        INHERIT_OPT(AsyncDepth);
+        //INHERIT_OPT(mfx.BRCParamMultiplier);
+        INHERIT_OPT(mfx.CodecId);
+        INHERIT_OPT(mfx.CodecProfile);
+        INHERIT_OPT(mfx.CodecLevel);
+        INHERIT_OPT(mfx.NumThread);
+        INHERIT_OPT(mfx.TargetUsage);
+        INHERIT_OPT(mfx.GopPicSize);
+        INHERIT_OPT(mfx.GopRefDist);
+        INHERIT_OPT(mfx.GopOptFlag);
+        INHERIT_OPT(mfx.IdrInterval);
+        INHERIT_OPT(mfx.RateControlMethod);
+        INHERIT_OPT(mfx.BufferSizeInKB);
+        INHERIT_OPT(mfx.NumSlice);
+        INHERIT_OPT(mfx.NumRefFrame);
+
+        mfxU16 RC = parInit.mfx.RateControlMethod
+            * (parInit.mfx.RateControlMethod == parReset.mfx.RateControlMethod);
+        static const std::map<
+            mfxU16 , std::function<void(const mfxVideoParam&, mfxVideoParam&)>
+        > InheritBrcOpt =
+        {
+            {
+                mfxU16(MFX_RATECONTROL_CBR)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_BRC(InitialDelayInKB);
+                    INHERIT_BRC(TargetKbps);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_VBR)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_BRC(InitialDelayInKB);
+                    INHERIT_BRC(TargetKbps);
+                    INHERIT_BRC(MaxKbps);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_CQP)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_OPT(mfx.QPI);
+                    INHERIT_OPT(mfx.QPP);
+                    INHERIT_OPT(mfx.QPB);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_ICQ)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_OPT(mfx.ICQQuality);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_LA_ICQ)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_OPT(mfx.ICQQuality);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_VCM)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_BRC(InitialDelayInKB);
+                    INHERIT_BRC(TargetKbps);
+                    INHERIT_BRC(MaxKbps);
+                }
+            }
+            , {
+                mfxU16(MFX_RATECONTROL_QVBR)
+                , [](const mfxVideoParam& parInit, mfxVideoParam& parReset)
+                {
+                    INHERIT_BRC(InitialDelayInKB);
+                    INHERIT_BRC(TargetKbps);
+                    INHERIT_BRC(MaxKbps);
+                }
+            }
+        };
+        auto itInheritBrcOpt = InheritBrcOpt.find(RC);
+
+        if (itInheritBrcOpt != InheritBrcOpt.end())
+            itInheritBrcOpt->second(parInit, parReset);
+
+        INHERIT_OPT(mfx.FrameInfo.FourCC);
+        INHERIT_OPT(mfx.FrameInfo.Width);
+        INHERIT_OPT(mfx.FrameInfo.Height);
+        INHERIT_OPT(mfx.FrameInfo.CropX);
+        INHERIT_OPT(mfx.FrameInfo.CropY);
+        INHERIT_OPT(mfx.FrameInfo.CropW);
+        INHERIT_OPT(mfx.FrameInfo.CropH);
+        INHERIT_OPT(mfx.FrameInfo.FrameRateExtN);
+        INHERIT_OPT(mfx.FrameInfo.FrameRateExtD);
+        INHERIT_OPT(mfx.FrameInfo.AspectRatioW);
+        INHERIT_OPT(mfx.FrameInfo.AspectRatioH);
+
+#undef INHERIT_OPT
+#undef INHERIT_BRC
+    });
+
+#define INIT_EB(TYPE)\
+    if (!pSrc || !pDst) return;\
+    auto& ebInit = *(TYPE*)pSrc;\
+    auto& ebReset = *(TYPE*)pDst;
+#define INHERIT_OPT(OPT) InheritOption(ebInit.OPT, ebReset.OPT);
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_HEVC_PARAM].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtHEVCParam);
+        INHERIT_OPT(GeneralConstraintFlags);
+        INHERIT_OPT(SampleAdaptiveOffset);
+        INHERIT_OPT(LCUSize);
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_HEVC_TILES].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtHEVCTiles);
+        INHERIT_OPT(NumTileColumns);
+        INHERIT_OPT(NumTileRows);
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_CODING_OPTION].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtCodingOption);
+        INHERIT_OPT(VuiNalHrdParameters);
+        INHERIT_OPT(NalHrdConformance);
+        INHERIT_OPT(PicTimingSEI);
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtCodingOption2);
+        INHERIT_OPT(IntRefType);
+        INHERIT_OPT(IntRefCycleSize);
+        INHERIT_OPT(IntRefQPDelta);
+        INHERIT_OPT(MBBRC);
+        INHERIT_OPT(BRefType);
+        INHERIT_OPT(NumMbPerSlice);
+        INHERIT_OPT(MinQPI);
+        INHERIT_OPT(MinQPP);
+        INHERIT_OPT(MinQPB);
+        INHERIT_OPT(MaxQPI);
+        INHERIT_OPT(MaxQPP);
+        INHERIT_OPT(MaxQPB);
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_CODING_OPTION3].emplace_back(
+        [this](const mfxVideoParam& parInit
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& parReset
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtCodingOption3);
+        INHERIT_OPT(IntRefCycleDist);
+        INHERIT_OPT(PRefType);
+        INHERIT_OPT(GPB);
+        INHERIT_OPT(TransformSkip);
+        INHERIT_OPT(TargetChromaFormatPlus1);
+        INHERIT_OPT(TargetBitDepthLuma);
+        INHERIT_OPT(TargetBitDepthChroma);
+        INHERIT_OPT(WinBRCMaxAvgKbps);
+        INHERIT_OPT(WinBRCSize);
+        INHERIT_OPT(EnableMBQP);
+
+        mfxU16 RC = parInit.mfx.RateControlMethod
+            * (parInit.mfx.RateControlMethod == parReset.mfx.RateControlMethod);
+
+        if (RC == MFX_RATECONTROL_QVBR)
+            INHERIT_OPT(QVBRQuality);
+
+        if (parInit.mfx.TargetUsage != parReset.mfx.TargetUsage)
+        {
+            auto maxRef = m_GetMaxRef(parReset);
+            auto ClipRef0 = [&](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<0>(maxRef)); };
+            auto ClipRef1 = [&](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<1>(maxRef)); };
+
+            std::transform(ebInit.NumRefActiveP, ebInit.NumRefActiveP + 8, ebReset.NumRefActiveP, ClipRef0);
+            std::transform(ebInit.NumRefActiveBL0, ebInit.NumRefActiveBL0 + 8, ebReset.NumRefActiveBL0, ClipRef0);
+            std::transform(ebInit.NumRefActiveBL1, ebInit.NumRefActiveBL1 + 8, ebReset.NumRefActiveBL1, ClipRef1);
+        }
+        else
+        {
+            InheritOptions(ebInit.NumRefActiveP, ebInit.NumRefActiveP + 8, ebReset.NumRefActiveP);
+            InheritOptions(ebInit.NumRefActiveBL0, ebInit.NumRefActiveBL0 + 8, ebReset.NumRefActiveBL0);
+            InheritOptions(ebInit.NumRefActiveBL1, ebInit.NumRefActiveBL1 + 8, ebReset.NumRefActiveBL1);
+        }
+    });
+
+    par.m_ebInheritDefault[MFX_EXTBUFF_VIDEO_SIGNAL_INFO].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        INIT_EB(mfxExtVideoSignalInfo);
+        INHERIT_OPT(VideoFormat);
+        INHERIT_OPT(ColourPrimaries);
+        INHERIT_OPT(TransferCharacteristics);
+        INHERIT_OPT(MatrixCoefficients);
+        INHERIT_OPT(VideoFullRange);
+        INHERIT_OPT(ColourDescriptionPresent);
+    });
+#undef INIT_EB
+#undef INHERIT_OPT
+}
+
+void Legacy::Query0(const FeatureBlocks& blocks, TPushQ0 Push)
+{
+    using namespace std::placeholders;
+    Push( BLK_Query0, std::bind(&Legacy::CheckQuery0, this, std::cref(blocks), _1));
+}
+
+void Legacy::Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push)
+{
+    Push(BLK_SetDefaultsCallChain,
+        [this](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+    {
+        auto& defaults = Glob::Defaults::GetOrConstruct(strg);
+        auto& bSet = defaults.SetForFeature[GetID()];
+        MFX_CHECK(!bSet, MFX_ERR_NONE);
+
+        PushDefaults(defaults);
+
+        bSet = true;
+
+        m_pQNCDefaults = &defaults;
+        m_hw = Glob::VideoCore::Get(strg).GetHWType();
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_PreCheckCodecId,
+        [this](const mfxVideoParam& in, mfxVideoParam&, StorageRW& /*strg*/) -> mfxStatus
+    {
+        return m_pQNCDefaults->PreCheckCodecId(in);
+    });
+
+    Push(BLK_PreCheckChromaFormat,
+        [this](const mfxVideoParam& in, mfxVideoParam&, StorageW&) -> mfxStatus
+    {
+        return m_pQNCDefaults->PreCheckChromaFormat(in);
+    });
+
+    Push(BLK_PreCheckExtBuffers
+        , [this, &blocks](const mfxVideoParam& in, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckBuffers(blocks, in, &out);
+    });
+
+    Push(BLK_CopyConfigurable
+        , [this, &blocks](const mfxVideoParam& in, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CopyConfigurable(blocks, in, out);
+    });
+
+    Push(BLK_SetLowPowerDefault
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW& /*strg*/) -> mfxStatus
+    {
+        auto lowPower = m_pQNCDefaults->GetLowPower(out, m_hw);
+        bool bChanged = out.mfx.LowPower && out.mfx.LowPower != lowPower;
+
+        out.mfx.LowPower = lowPower;
+
+        MFX_CHECK(!bChanged, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetGUID
+        , [](const mfxVideoParam&, mfxVideoParam& out, StorageRW& strg) -> mfxStatus
+    {
+        MFX_CHECK(!strg.Contains(Glob::GUID::Key), MFX_ERR_NONE);
+
+        if (strg.Contains(Glob::RealState::Key))
+        {
+            //don't change GUID in Reset
+            auto& initPar = Glob::RealState::Get(strg);
+            strg.Insert(Glob::GUID::Key, make_storable<GUID>(Glob::GUID::Get(initPar)));
+            return MFX_ERR_NONE;
+        }
+
+        VideoCORE& core = Glob::VideoCore::Get(strg);
+        auto pGUID = make_storable<GUID>();
+        auto& defaults = Glob::Defaults::Get(strg);
+        EncodeCapsHevc fakeCaps;
+        Defaults::Param defPar(out, fakeCaps, core.GetHWType(), defaults);
+        fakeCaps.MaxEncodedBitDepth = (defPar.hw >= MFX_HW_KBL);
+
+        MFX_CHECK(defaults.GetGUID(defPar, *pGUID), MFX_ERR_NONE);
+        strg.Insert(Glob::GUID::Key, std::move(pGUID));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckHeaders
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW& strg) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        m_pQWCDefaults.reset(
+            new Defaults::Param(
+                out
+                , Glob::EncodeCaps::Get(strg)
+                , Glob::VideoCore::Get(strg).GetHWType()
+                , Glob::Defaults::Get(strg)));
+
+        if (strg.Contains(Glob::SPS::Key))
+            sts = CheckSPS(Glob::SPS::Get(strg), m_pQWCDefaults->caps, m_pQWCDefaults->hw);
+
+        if (!sts && strg.Contains(Glob::PPS::Key))
+            sts = CheckPPS(Glob::PPS::Get(strg), m_pQWCDefaults->caps, m_pQWCDefaults->hw);
+
+        return sts;
+    });
+
+    Push(BLK_CheckLCUSize
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW& ) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckLCUSize(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckFormat
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        auto sts = m_pQWCDefaults->base.CheckFourCC(*m_pQWCDefaults, out);
+        MFX_CHECK_STS(sts);
+        sts = m_pQWCDefaults->base.CheckInputFormatByFourCC(*m_pQWCDefaults, out);
+        MFX_CHECK_STS(sts);
+        sts = m_pQWCDefaults->base.CheckTargetChromaFormat(*m_pQWCDefaults, out);
+        MFX_CHECK_STS(sts);
+        sts = m_pQWCDefaults->base.CheckTargetBitDepth(*m_pQWCDefaults, out);
+        MFX_CHECK_STS(sts);
+        return m_pQWCDefaults->base.CheckFourCCByTargetFormat(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckLowDelayBRC
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckLowDelayBRC(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckLevel
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckLevel(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckSurfSize
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckSurfSize(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckCodedPicSize
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckCodedPicSize(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckTiles
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckTiles(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckTU
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckTU(out, m_pQWCDefaults->caps);
+    });
+
+    Push(BLK_CheckTemporalLayers
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckTemporalLayers(out);
+    });
+
+    Push(BLK_CheckGopRefDist
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckGopRefDist(out, m_pQWCDefaults->caps);
+    });
+
+    Push(BLK_CheckNumRefFrame
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckNumRefFrame(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckIOPattern
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckIOPattern(out);
+    });
+
+    Push(BLK_CheckBRC
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckBRC(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckCrops
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckCrops(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckShift
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckShift(out, ExtBuffer::Get(out));
+    });
+
+    Push(BLK_CheckFrameRate
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckFrameRate(out);
+    });
+
+    Push(BLK_CheckSlices
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckSlices(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckBPyramid
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckBPyramid(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckPPyramid
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckPPyramid(out);
+    });
+
+    Push(BLK_CheckIntraRefresh
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckIntraRefresh(out, *m_pQWCDefaults);
+    });
+
+    Push(BLK_CheckSkipFrame
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckSkipFrame(out);
+    });
+
+    Push(BLK_CheckGPB
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckGPB(out);
+    });
+
+    Push(BLK_CheckESPackParam
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckESPackParam(out, m_pQWCDefaults->hw);
+    });
+
+    Push(BLK_CheckNumRefActive
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckNumRefActive(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckSAO
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckSAO(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckProfile
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return m_pQWCDefaults->base.CheckProfile(*m_pQWCDefaults, out);
+    });
+
+    Push(BLK_CheckLevelConstraints
+        , [this](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        return CheckLevelConstraints(out, *m_pQWCDefaults);
+    });
+}
+
+void Legacy::QueryIOSurf(const FeatureBlocks& blocks, TPushQIS Push)
+{
+    Push(BLK_CheckVideoParam
+        , [&blocks](const mfxVideoParam& par, mfxFrameAllocRequest&, StorageRW& strg) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        auto pTmpPar = make_storable<ExtBuffer::Param<mfxVideoParam>>(par);
+
+        auto& queryNC = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1NoCaps>::Get(blocks);
+        sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, queryNC, par, *pTmpPar, strg);
+        MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        auto& queryWC = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1WithCaps>::Get(blocks);
+        sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, queryWC, par, *pTmpPar, strg);
+        MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        strg.Insert(Glob::VideoParam::Key, std::move(pTmpPar));
+
+        return sts;
+    });
+
+    Push(BLK_SetDefaults
+        , [&blocks](const mfxVideoParam&, mfxFrameAllocRequest&, StorageRW& strg) -> mfxStatus
+    {
+        ExtBuffer::Param<mfxVideoParam>& par = Glob::VideoParam::Get(strg);
+        StorageRW local;
+
+        auto& qSD = FeatureBlocks::BQ<FeatureBlocks::BQ_SetDefaults>::Get(blocks);
+        return RunBlocks(IgnoreSts, qSD, par, strg, local);
+    });
+
+    Push(BLK_SetFrameAllocRequest
+        , [this](const mfxVideoParam&, mfxFrameAllocRequest& req, StorageRW& strg) -> mfxStatus
+    {
+        ExtBuffer::Param<mfxVideoParam>& par = Glob::VideoParam::Get(strg);
+        auto fourCC = par.mfx.FrameInfo.FourCC;
+
+        req.Info = par.mfx.FrameInfo;
+        SetDefault(req.Info.Shift, (fourCC == MFX_FOURCC_P010 || fourCC == MFX_FOURCC_Y210));
+
+        bool bSYS = par.IOPattern == MFX_IOPATTERN_IN_SYSTEM_MEMORY;
+        bool bVID = par.IOPattern == MFX_IOPATTERN_IN_VIDEO_MEMORY;
+        bool bOPQ = par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY;
+
+        req.Type =
+            bSYS * (MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_SYSTEM_MEMORY | MFX_MEMTYPE_EXTERNAL_FRAME)
+            + bVID * (MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_DXVA2_DECODER_TARGET | MFX_MEMTYPE_EXTERNAL_FRAME)
+            + bOPQ * (MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_DXVA2_DECODER_TARGET | MFX_MEMTYPE_OPAQUE_FRAME);
+        MFX_CHECK(req.Type, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        req.NumFrameMin = GetMaxRaw(par);
+        req.NumFrameSuggested = req.NumFrameMin;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaults
+        , [this](mfxVideoParam& par, StorageW& strg, StorageRW&)
+    {
+        auto& core = Glob::VideoCore::Get(strg);
+        auto& caps = Glob::EncodeCaps::Get(strg);
+        auto& defchain = Glob::Defaults::Get(strg);
+        SetDefaults(par, Defaults::Param(par, caps, core.GetHWType(), defchain), core.IsExternalFrameAllocator());
+    });
+}
+
+void Legacy::InitExternal(const FeatureBlocks& blocks, TPushIE Push)
+{
+    Push(BLK_SetGUID
+        , [&blocks](const mfxVideoParam& in, StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        const auto& query = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1NoCaps>::Get(blocks);
+        mfxStatus sts = MFX_ERR_NONE;
+        auto pPar = make_storable<ExtBuffer::Param<mfxVideoParam>>(in);
+        ExtBuffer::Param<mfxVideoParam>& par = *pPar;
+
+        sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, query, in, par, strg);
+        MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        strg.Insert(Glob::VideoParam::Key, std::move(pPar));
+
+        return sts;
+    });
+
+    Push(BLK_CheckVideoParam
+        , [&blocks](const mfxVideoParam& in, StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        const auto& query = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1WithCaps>::Get(blocks);
+        mfxStatus sts = MFX_ERR_NONE;
+        ExtBuffer::Param<mfxVideoParam>& par = Glob::VideoParam::Get(strg);
+
+        sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, query, in, par, strg);
+        MFX_CHECK(sts != MFX_ERR_UNSUPPORTED, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        MFX_CHECK(in.mfx.FrameInfo.Width  == par.mfx.FrameInfo.Width
+               && in.mfx.FrameInfo.Height == par.mfx.FrameInfo.Height, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        return sts;
+    });
+
+    Push(BLK_SetDefaults
+        , [&blocks](const mfxVideoParam&, StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+
+        for (auto& eb : blocks.m_ebCopySupported)
+            par.NewEB(eb.first, false);
+
+        auto& qSD = FeatureBlocks::BQ<FeatureBlocks::BQ_SetDefaults>::Get(blocks);
+        return RunBlocks(IgnoreSts, qSD, par, strg, local);
+    });
+}
+
+void Legacy::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
+{
+    Push(BLK_SetReorder
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        using namespace std::placeholders;
+        auto& par = Glob::VideoParam::Get(strg);
+
+        auto pReorderer = make_storable<Reorderer>();
+
+        pReorderer->BufferSize = par.mfx.GopRefDist - 1;
+        pReorderer->DPB        = &m_prevTask.DPB.After;
+
+        pReorderer->Push(
+            [&](Reorderer::TExt, const DpbArray& DPB, TTaskIt begin, TTaskIt end, bool bFlush)
+        {
+            auto IsIdrFrame = [](TItWrap::reference fi) { return IsIdr(fi.FrameType); };
+            auto newEnd = std::find_if(TItWrap(begin), TItWrap(end), IsIdrFrame);
+
+            bFlush |= (newEnd != begin && newEnd != end);
+
+            return Reorder(par, DPB, TItWrap(begin), newEnd, bFlush).it;
+        });
+
+        strg.Insert(Glob::Reorder::Key, std::move(pReorderer));
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetVPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        MFX_CHECK(!strg.Contains(Glob::VPS::Key), MFX_ERR_NONE);
+        auto dflts = GetRTDefaults(strg);
+        SetVPS(dflts, Glob::VPS::GetOrConstruct(strg));
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetSPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        if (!strg.Contains(Glob::SPS::Key))
+        {
+            auto pSPS = make_storable<SPS>();
+            auto dflts = GetRTDefaults(strg);
+
+            auto sts = dflts.base.GetSPS(dflts, Glob::VPS::Get(strg), *pSPS);
+            MFX_CHECK_STS(sts);
+
+            strg.Insert(Glob::SPS::Key, std::move(pSPS));
+        }
+
+        if (strg.Contains(Glob::RealState::Key))
+        {
+            auto& hint = Glob::ResetHint::Get(strg);
+            const SPS& oldSPS = Glob::SPS::Get(Glob::RealState::Get(strg));
+            SPS& newSPS = Glob::SPS::Get(strg);
+
+            SPS oldSPScopy = oldSPS;
+            std::copy(newSPS.strps, newSPS.strps + Size(newSPS.strps), oldSPScopy.strps);
+            oldSPScopy.num_short_term_ref_pic_sets = newSPS.num_short_term_ref_pic_sets;
+
+            if (!oldSPS.vui_parameters_present_flag)
+                oldSPScopy.vui = newSPS.vui;
+
+            bool bSPSChanged = !!memcmp(&newSPS, &oldSPScopy, sizeof(SPS));
+
+            hint.Flags |= RF_SPS_CHANGED * (bSPSChanged || (hint.Flags & RF_IDR_REQUIRED));
+        }
+
+        return CheckSPS(Glob::SPS::Get(strg)
+            , Glob::EncodeCaps::Get(strg)
+            , Glob::VideoCore::Get(strg).GetHWType());
+    });
+
+    Push(BLK_NestSTRPS
+        , [](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        MFX_CHECK(
+            strg.Contains(Glob::RealState::Key)
+            && !(Glob::ResetHint::Get(strg).Flags & RF_SPS_CHANGED)
+            , MFX_ERR_NONE);
+
+        SPS& newSPS = Glob::SPS::Get(strg);
+        const SPS& oldSPS = Glob::SPS::Get(Glob::RealState::Get(strg));
+
+        //sacrifice STRPS optimization at Reset to avoid IDR insertion
+        newSPS.num_short_term_ref_pic_sets = oldSPS.num_short_term_ref_pic_sets;
+        std::copy(oldSPS.strps, oldSPS.strps + Size(oldSPS.strps), newSPS.strps);
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetSTRPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        SPS& sps = Glob::SPS::Get(strg);
+
+        MFX_CHECK(
+            !sps.num_short_term_ref_pic_sets
+            && !(strg.Contains(Glob::RealState::Key)
+                && !(Glob::ResetHint::Get(strg).Flags & RF_SPS_CHANGED))
+            , MFX_ERR_NONE);
+
+        auto dflts = GetRTDefaults(strg);
+
+        MFX_CHECK(!dflts.base.GetNonStdReordering(dflts), MFX_ERR_NONE);
+
+        SetSTRPS(dflts, sps, Glob::Reorder::Get(strg));
+
+        return MFX_ERR_NONE;
+    });
+
+
+    Push(BLK_SetPPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        if (!strg.Contains(Glob::PPS::Key))
+        {
+            std::unique_ptr<MakeStorable<PPS>> pPPS(new MakeStorable<PPS>);
+            auto dflts = GetRTDefaults(strg);
+
+            auto sts = dflts.base.GetPPS(dflts, Glob::SPS::Get(strg), *pPPS);
+            MFX_CHECK_STS(sts);
+
+            strg.Insert(Glob::PPS::Key, std::move(pPPS));
+        }
+
+        if (strg.Contains(Glob::RealState::Key))
+        {
+            const PPS& oldPPS = Glob::PPS::Get(Glob::RealState::Get(strg));
+            PPS& newPPS = Glob::PPS::Get(strg);
+
+            if (memcmp(&oldPPS, &newPPS, sizeof(PPS)))
+                Glob::ResetHint::Get(strg).Flags |= RF_PPS_CHANGED;
+        }
+
+        return CheckPPS(Glob::PPS::Get(strg)
+            , Glob::EncodeCaps::Get(strg)
+            , Glob::VideoCore::Get(strg).GetHWType());
+    });
+
+    Push(BLK_SetSlices
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto dflts = GetRTDefaults(strg);
+        dflts.base.GetSlices(dflts, Glob::SliceInfo::GetOrConstruct(strg));
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetRecInfo
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+        mfxFrameAllocRequest rec = {}, raw = {};
+
+        if (GetRecInfo(par, ExtBuffer::Get(par), Glob::VideoCore::Get(strg).GetHWType(), rec.Info))
+        {
+            auto& recInfo = Tmp::RecInfo::GetOrConstruct(local, rec);
+            SetDefault(recInfo.NumFrameMin, GetMaxRec(par));
+        }
+
+        raw.Info = par.mfx.FrameInfo;
+        auto& rawInfo = Tmp::RawInfo::GetOrConstruct(local, raw);
+        SetDefault(rawInfo.NumFrameMin, GetMaxRaw(par));
+        SetDefault(rawInfo.Type
+            , mfxU16(MFX_MEMTYPE_FROM_ENCODE
+                | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+                | MFX_MEMTYPE_INTERNAL_FRAME));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_AllocRaw
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        auto& par = Glob::VideoParam::Get(strg);
+        const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+        auto& rawInfo = Tmp::RawInfo::Get(local);
+        auto AllocRaw = [&](mfxU16 NumFrameMin)
+        {
+            std::unique_ptr<IAllocation> pAlloc(Tmp::MakeAlloc::Get(local)(Glob::VideoCore::Get(strg)));
+            mfxFrameAllocRequest req = rawInfo;
+            req.NumFrameMin = NumFrameMin;
+
+            sts = pAlloc->Alloc(req, true);
+            MFX_CHECK_STS(sts);
+
+            strg.Insert(Glob::AllocRaw::Key, std::move(pAlloc));
+
+            return MFX_ERR_NONE;
+        };
+
+        if (par.IOPattern == MFX_IOPATTERN_IN_SYSTEM_MEMORY)
+        {
+            sts = AllocRaw(rawInfo.NumFrameMin);
+            MFX_CHECK_STS(sts);
+        }
+        else if (par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY)
+        {
+            const mfxExtOpaqueSurfaceAlloc& osa = ExtBuffer::Get(par);
+            std::unique_ptr<IAllocation> pAllocOpq(Tmp::MakeAlloc::Get(local)(Glob::VideoCore::Get(strg)));
+
+            sts = pAllocOpq->AllocOpaque(par.mfx.FrameInfo, osa.In.Type, osa.In.Surfaces, osa.In.NumSurface);
+            MFX_CHECK_STS(sts);
+
+            strg.Insert(Glob::AllocOpq::Key, std::move(pAllocOpq));
+
+            if (osa.In.Type & MFX_MEMTYPE_SYSTEM_MEMORY)
+            {
+                sts = AllocRaw(osa.In.NumSurface);
+                MFX_CHECK_STS(sts);
+            }
+        }
+
+        bool bSkipFramesMode = (
+            (IsSWBRC(par, &CO2)
+                && (par.mfx.RateControlMethod == MFX_RATECONTROL_CBR || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR))
+            || (CO2.SkipFrame == MFX_SKIPFRAME_INSERT_DUMMY))
+            && !strg.Contains(Glob::AllocRaw::Key);
+
+        if (bSkipFramesMode)
+        {
+            sts = AllocRaw(GetMaxBS(par));
+            MFX_CHECK_STS(sts);
+        }
+
+        return sts;
+    });
+
+    Push(BLK_AllocRec
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        auto& par = Glob::VideoParam::Get(strg);
+        std::unique_ptr<IAllocation> pAlloc(Tmp::MakeAlloc::Get(local)(Glob::VideoCore::Get(strg)));
+
+        MFX_CHECK(local.Contains(Tmp::RecInfo::Key), MFX_ERR_UNDEFINED_BEHAVIOR);
+        auto& req = Tmp::RecInfo::Get(local);
+
+        SetDefault(req.NumFrameMin, GetMaxRec(par));
+        SetDefault(req.Type
+            , mfxU16(MFX_MEMTYPE_FROM_ENCODE
+            | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+            | MFX_MEMTYPE_INTERNAL_FRAME
+            | MFX_MEMTYPE_VIDEO_MEMORY_ENCODER_TARGET));
+
+        sts = pAlloc->Alloc(req, false);
+        MFX_CHECK_STS(sts);
+
+        strg.Insert(Glob::AllocRec::Key, std::move(pAlloc));
+
+        return sts;
+    });
+
+    Push(BLK_AllocBS
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        auto& par = Glob::VideoParam::Get(strg);
+        std::unique_ptr<IAllocation> pAlloc(Tmp::MakeAlloc::Get(local)(Glob::VideoCore::Get(strg)));
+
+        MFX_CHECK(local.Contains(Tmp::BSAllocInfo::Key), MFX_ERR_UNDEFINED_BEHAVIOR);
+        auto& req = Tmp::BSAllocInfo::Get(local);
+
+        SetDefault(req.NumFrameMin, GetMaxBS(par));
+        SetDefault(req.Type
+            , mfxU16(MFX_MEMTYPE_FROM_ENCODE
+            | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+            | MFX_MEMTYPE_INTERNAL_FRAME));
+
+        mfxU32 minBS = GetMinBsSize(par, ExtBuffer::Get(par), ExtBuffer::Get(par), ExtBuffer::Get(par));
+
+        if (mfxU32(req.Info.Width * req.Info.Height) < minBS)
+        {
+            MFX_CHECK(req.Info.Width != 0, MFX_ERR_UNDEFINED_BEHAVIOR);
+            req.Info.Height = (mfxU16)CeilDiv<mfxU32>(minBS, req.Info.Width);
+        }
+
+        sts = pAlloc->Alloc(req, false);
+        MFX_CHECK_STS(sts);
+
+        strg.Insert(Glob::AllocBS::Key, std::move(pAlloc));
+
+        return sts;
+    });
+
+    Push(BLK_AllocMBQP
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        mfxStatus sts = MFX_ERR_NONE;
+        auto& par = Glob::VideoParam::Get(strg);
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+        auto& core = Glob::VideoCore::Get(strg);
+
+        MFX_CHECK(IsOn(CO3.EnableMBQP) && core.GetVAType() != MFX_HW_VAAPI, MFX_ERR_NONE);
+
+        MFX_CHECK(local.Contains(Tmp::MBQPAllocInfo::Key), MFX_ERR_UNDEFINED_BEHAVIOR);
+        auto& req = Tmp::MBQPAllocInfo::Get(local);
+
+        SetDefault(req.NumFrameMin, GetMaxBS(par));
+        SetDefault(req.Type
+            , mfxU16(MFX_MEMTYPE_FROM_ENCODE
+                | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+                | MFX_MEMTYPE_INTERNAL_FRAME));
+
+        std::tie(sts, m_CUQPBlkW, m_CUQPBlkH) = GetCUQPMapBlockSize(
+            par.mfx.FrameInfo.Width
+            , par.mfx.FrameInfo.Height
+            , req.Info.Width
+            , req.Info.Height);
+        MFX_CHECK_STS(sts);
+
+        std::unique_ptr<IAllocation> pAlloc(Tmp::MakeAlloc::Get(local)(core));
+        sts = pAlloc->Alloc(req, true);
+        MFX_CHECK_STS(sts);
+
+        strg.Insert(Glob::AllocMBQP::Key, std::move(pAlloc));
+
+        return sts;
+    });
+
+    Push(BLK_ResetState
+        , [this](StorageRW& /*strg*/, StorageRW& /*local*/) -> mfxStatus
+    {
+        ResetState();
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::Reset(const FeatureBlocks& blocks, TPushR Push)
+{
+    Push(BLK_ResetInit
+        , [this, &blocks](
+            const mfxVideoParam& par
+            , StorageRW& global
+            , StorageRW& local) -> mfxStatus
+    {
+        mfxStatus wrn = MFX_ERR_NONE;
+        auto& init = Glob::RealState::Get(global);
+        if (par.NumExtParam != 0)
+            MFX_CHECK(std::none_of(par.ExtParam, par.ExtParam + par.NumExtParam, [](mfxExtBuffer* buf) { return buf == nullptr; }), MFX_ERR_NULL_PTR);
+        auto pParNew = make_storable<ExtBuffer::Param<mfxVideoParam>>(par);
+        ExtBuffer::Param<mfxVideoParam>& parNew = *pParNew;
+        auto& parOld = Glob::VideoParam::Get(init);
+        auto& core = Glob::VideoCore::Get(init);
+
+        global.Insert(Glob::ResetHint::Key, make_storable<ResetHint>(ResetHint{}));
+        auto& hint = Glob::ResetHint::Get(global);
+
+        const mfxExtEncoderResetOption* pResetOpt = ExtBuffer::Get(par);
+
+        hint.Flags = RF_IDR_REQUIRED * (pResetOpt && IsOn(pResetOpt->StartNewSequence));
+
+
+        m_GetMaxRef = [&](const mfxVideoParam& par)
+        {
+            auto& def = Glob::Defaults::Get(init);
+            auto hw = core.GetHWType();
+            auto& caps = Glob::EncodeCaps::Get(init);
+            return def.GetMaxNumRef(Defaults::Param(par, caps, hw, def));
+        };
+
+        std::for_each(std::begin(blocks.m_ebCopySupported)
+            , std::end(blocks.m_ebCopySupported)
+            , [&](decltype(*std::begin(blocks.m_ebCopySupported)) eb) { parNew.NewEB(eb.first, false); });
+
+        std::for_each(std::begin(blocks.m_mvpInheritDefault)
+            , std::end(blocks.m_mvpInheritDefault)
+            , [&](decltype(*std::begin(blocks.m_mvpInheritDefault)) inherit) { inherit(&parOld, &parNew); });
+
+
+        std::for_each(std::begin(blocks.m_ebInheritDefault)
+            , std::end(blocks.m_ebInheritDefault)
+            , [&](decltype(*std::begin(blocks.m_ebInheritDefault)) eb)
+        {
+            auto pEbNew = ExtBuffer::Get(parNew, eb.first);
+            auto pEbOld = ExtBuffer::Get(parOld, eb.first);
+
+            MFX_CHECK(pEbNew && pEbOld, MFX_ERR_NONE);
+
+            std::for_each(std::begin(eb.second)
+                , std::end(eb.second)
+                , [&](decltype(*std::begin(eb.second)) inherit) { inherit(parOld, pEbOld, parNew, pEbNew); });
+
+            return MFX_ERR_NONE;
+        });
+
+        auto& qInitExternal = FeatureBlocks::BQ<FeatureBlocks::BQ_InitExternal>::Get(blocks);
+        auto& qInitInternal = FeatureBlocks::BQ<FeatureBlocks::BQ_InitInternal>::Get(blocks);
+
+        auto sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, qInitExternal, parNew, global, local);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+        wrn = sts;
+
+        sts = RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, qInitInternal, global, local);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        return GetWorstSts(sts, wrn);
+    });
+
+    Push(BLK_ResetCheck
+        , [this](
+            const mfxVideoParam& par
+            , StorageRW& global
+            , StorageRW& local) -> mfxStatus
+    {
+        auto& init = Glob::RealState::Get(global);
+        auto& parOld = Glob::VideoParam::Get(init);
+        auto& parNew = Glob::VideoParam::Get(global);
+        auto& hint = Glob::ResetHint::Get(global);
+        auto defOld = GetRTDefaults(init);
+        auto defNew = GetRTDefaults(global);
+
+        const mfxExtEncoderResetOption* pResetOpt = ExtBuffer::Get(par);
+
+        const mfxExtHEVCParam (&hevcPar)[2] = { ExtBuffer::Get(parOld), ExtBuffer::Get(parNew) };
+        MFX_CHECK(hevcPar[0].LCUSize == hevcPar[1].LCUSize, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM); // LCU Size Can't be changed
+
+        MFX_CHECK(parOld.AsyncDepth                 == parNew.AsyncDepth,                   MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(parOld.mfx.GopRefDist             >= parNew.mfx.GopRefDist,               MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(parOld.mfx.NumRefFrame            >= parNew.mfx.NumRefFrame,              MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(parOld.mfx.RateControlMethod      == parNew.mfx.RateControlMethod,        MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(parOld.mfx.FrameInfo.ChromaFormat == parNew.mfx.FrameInfo.ChromaFormat,   MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(parOld.IOPattern                  == parNew.IOPattern,                    MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
+        MFX_CHECK(local.Contains(Tmp::RecInfo::Key), MFX_ERR_UNDEFINED_BEHAVIOR);
+        auto& recOld = Glob::AllocRec::Get(init).Info();
+        auto& recNew = Tmp::RecInfo::Get(local).Info;
+        MFX_CHECK(recOld.Width  >= recNew.Width,  MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(recOld.Height >= recNew.Height, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+        MFX_CHECK(recOld.FourCC == recNew.FourCC, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
+        MFX_CHECK(
+            !(   parOld.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+              || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+              || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VCM)
+            ||(  (mfxU32)InitialDelayInKB(parOld.mfx) == (mfxU32)InitialDelayInKB(parNew.mfx)
+              && (mfxU32)BufferSizeInKB(parOld.mfx) == (mfxU32)BufferSizeInKB(parNew.mfx))
+            , MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
+        mfxU32 tempLayerIdx = 0;
+        bool changeTScalLayers = false;
+        bool isIdrRequired = false;
+
+        // check if change of temporal scalability required by new parameters
+        auto numTlOld = defOld.base.GetNumTemporalLayers(defOld);
+        auto numTlNew = defNew.base.GetNumTemporalLayers(defNew);
+        bool bTlActive = numTlOld > 1 && numTlNew > 1;
+
+        if (bTlActive)
+        {
+            // calculate temporal layer for next frame
+            tempLayerIdx = defOld.base.GetTId(defOld, m_frameOrder + 1);
+            changeTScalLayers = numTlOld != numTlNew;
+        }
+
+        // check if IDR required after change of encoding parameters
+        const mfxExtCodingOption2(&CO2)[2] = { ExtBuffer::Get(parOld), ExtBuffer::Get(parNew) };
+
+        isIdrRequired =
+               (hint.Flags & RF_SPS_CHANGED)
+            || (hint.Flags & RF_IDR_REQUIRED)
+            || (tempLayerIdx != 0 && changeTScalLayers)
+            || parOld.mfx.GopPicSize != parNew.mfx.GopPicSize
+            || CO2[0].IntRefType != CO2[1].IntRefType;
+
+        hint.Flags |= RF_IDR_REQUIRED * isIdrRequired;
+
+        MFX_CHECK(!isIdrRequired || !(pResetOpt && IsOff(pResetOpt->StartNewSequence))
+            , MFX_ERR_INVALID_VIDEO_PARAM); // Reset can't change parameters w/o IDR. Report an error
+
+        bool brcReset =
+            (      parOld.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+                || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+                || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VCM)
+            && (   (mfxU32)TargetKbps(parOld.mfx) != (mfxU32)TargetKbps(parNew.mfx)
+                || (mfxU32)BufferSizeInKB(parOld.mfx) != (mfxU32)BufferSizeInKB(parNew.mfx)
+                || (mfxU32)InitialDelayInKB(parOld.mfx) != (mfxU32)InitialDelayInKB(parNew.mfx)
+                || parOld.mfx.FrameInfo.FrameRateExtN != parNew.mfx.FrameInfo.FrameRateExtN
+                || parOld.mfx.FrameInfo.FrameRateExtD != parNew.mfx.FrameInfo.FrameRateExtD);
+
+        brcReset |=
+            (      parOld.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+                || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VCM)
+            && ((mfxU32)MaxKbps(parOld.mfx) != (mfxU32)MaxKbps(parNew.mfx));
+
+        const mfxExtCodingOption(&CO)[2] = { ExtBuffer::Get(parOld), ExtBuffer::Get(parNew) };
+        bool HRDConformance = !(IsOff(CO[1].NalHrdConformance) || IsOff(CO[1].VuiNalHrdParameters));
+
+        MFX_CHECK(
+           !(   brcReset
+             && parOld.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+             && (HRDConformance || !isIdrRequired))
+            , MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
+        hint.Flags |= RF_BRC_RESET * (brcReset || isIdrRequired);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::ResetState(const FeatureBlocks& blocks, TPushRS Push)
+{
+    Push(BLK_ResetState
+        , [this, &blocks](
+            StorageRW& global
+            , StorageRW&) -> mfxStatus
+    {
+        auto& real = Glob::RealState::Get(global);
+        auto& parInt = Glob::VideoParam::Get(real);
+        auto& parNew = Glob::VideoParam::Get(global);
+        auto& hint = Glob::ResetHint::Get(global);
+
+        CopyConfigurable(blocks, parNew, parInt);
+        Glob::VPS::Get(real) = Glob::VPS::Get(global);
+        Glob::SPS::Get(real) = Glob::SPS::Get(global);
+        Glob::PPS::Get(real) = Glob::PPS::Get(global);
+        Glob::SliceInfo::Get(real) = Glob::SliceInfo::Get(global);
+
+        m_forceHeaders |= !!(hint.Flags & RF_PPS_CHANGED) * INSERT_PPS;
+
+        MFX_CHECK(hint.Flags & RF_IDR_REQUIRED, MFX_ERR_NONE);
+
+        Glob::AllocRec::Get(real).Unlock();
+        Glob::AllocBS::Get(real).Unlock();
+
+        if (real.Contains(Glob::AllocMBQP::Key))
+            Glob::AllocMBQP::Get(real).Unlock();
+
+        if (real.Contains(Glob::AllocRaw::Key))
+            Glob::AllocRaw::Get(real).Unlock();
+
+        ResetState();
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::FrameSubmit(const FeatureBlocks& /*blocks*/, TPushFS Push)
+{
+    Push(BLK_CheckSurf
+        , [](
+            const mfxEncodeCtrl* /*pCtrl*/
+            , const mfxFrameSurface1* pSurf
+            , mfxBitstream& /*bs*/
+            , StorageW& global
+            , StorageRW& /*local*/) -> mfxStatus
+    {
+        MFX_CHECK(pSurf, MFX_ERR_NONE);
+
+        auto& par = Glob::VideoParam::Get(global);
+        MFX_CHECK(LumaIsNull(pSurf) == (pSurf->Data.UV == 0), MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(pSurf->Info.Width >= par.mfx.FrameInfo.Width, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(pSurf->Info.Height >= par.mfx.FrameInfo.Height, MFX_ERR_INVALID_VIDEO_PARAM);
+        
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_CheckBS
+        , [](
+            const mfxEncodeCtrl* /*pCtrl*/
+            , const mfxFrameSurface1* /*pSurf*/
+            , mfxBitstream& bs
+            , StorageW& global
+            , StorageRW& local) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        BsDataInfo bsData = {};
+
+        bsData.Data       = bs.Data;
+        bsData.DataLength = bs.DataLength;
+        bsData.DataOffset = bs.DataOffset;
+        bsData.MaxLength  = bs.MaxLength;
+
+        if (local.Contains(Tmp::BsDataInfo::Key))
+            bsData = Tmp::BsDataInfo::Get(local);
+
+        MFX_CHECK(bsData.DataOffset <= bsData.MaxLength, MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(bsData.DataOffset + bsData.DataLength + BufferSizeInKB(par.mfx) * 1000u <= bsData.MaxLength, MFX_ERR_NOT_ENOUGH_BUFFER);
+        MFX_CHECK_NULL_PTR1(bsData.Data);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::AllocTask(const FeatureBlocks& /*blocks*/, TPushAT Push)
+{
+    Push(BLK_AllocTask
+        , [](
+            StorageR& /*global*/
+            , StorageRW& task) -> mfxStatus
+    {
+        task.Insert(Task::Common::Key, new Task::Common::TRef);
+        task.Insert(Task::SSH::Key, new MakeStorable<Task::SSH::TRef>);
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::InitTask(const FeatureBlocks& /*blocks*/, TPushIT Push)
+{
+    Push(BLK_InitTask
+        , [](
+            mfxEncodeCtrl* pCtrl
+            , mfxFrameSurface1* pSurf
+            , mfxBitstream* pBs
+            , StorageW& global
+            , StorageW& task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        auto& core = Glob::VideoCore::Get(global);
+        auto& tpar = Task::Common::Get(task);
+
+        auto stage = tpar.stage;
+        tpar = TaskCommonPar();
+        tpar.stage = stage;
+        tpar.pBsOut = pBs;
+
+        MFX_CHECK(pSurf, MFX_ERR_NONE);
+
+        tpar.pSurfIn = pSurf;
+
+        if (pCtrl)
+            tpar.ctrl = *pCtrl;
+
+        if (par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY)
+        {
+            tpar.pSurfReal = core.GetNativeSurface(tpar.pSurfIn);
+            MFX_CHECK(tpar.pSurfReal, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+            tpar.pSurfReal->Info             = tpar.pSurfIn->Info;
+            tpar.pSurfReal->Data.TimeStamp   = tpar.pSurfIn->Data.TimeStamp;
+            tpar.pSurfReal->Data.FrameOrder  = tpar.pSurfIn->Data.FrameOrder;
+            tpar.pSurfReal->Data.Corrupted   = tpar.pSurfIn->Data.Corrupted;
+            tpar.pSurfReal->Data.DataFlag    = tpar.pSurfIn->Data.DataFlag;
+        }
+        else
+            tpar.pSurfReal = tpar.pSurfIn;
+
+        core.IncreaseReference(&tpar.pSurfIn->Data);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::PreReorderTask(const FeatureBlocks& /*blocks*/, TPushPreRT Push)
+{
+    Push(BLK_PrepareTask
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        auto& task = Task::Common::Get(s_task);
+        auto  dflts = GetRTDefaults(global);
+
+        m_frameOrder = dflts.base.GetFrameOrder(dflts, s_task, m_frameOrder);
+
+        auto sts = dflts.base.GetPreReorderInfo(
+            dflts, task, task.pSurfIn, &task.ctrl, m_lastIDR, m_prevTask.PrevIPoc, m_frameOrder);
+        MFX_CHECK_STS(sts);
+
+        if (par.mfx.EncodedOrder)
+        {
+            auto MaxReorder     = Glob::Reorder::Get(global).BufferSize;
+            bool bFrameFromPast = m_frameOrder && (m_frameOrder < m_prevTask.DisplayOrder);
+
+            MFX_CHECK(!bFrameFromPast || ((m_prevTask.DisplayOrder - m_frameOrder) <= MaxReorder), MFX_ERR_UNDEFINED_BEHAVIOR);
+            MFX_CHECK(m_frameOrder <= (m_prevTask.EncodedOrder + 1 + MaxReorder), MFX_ERR_UNDEFINED_BEHAVIOR);
+            MFX_CHECK(isValid(m_prevTask.DPB.After[0]) || IsIdr(task.FrameType), MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+        task.DisplayOrder = m_frameOrder;
+        task.PrevIPoc     = m_prevTask.PrevIPoc;
+        
+        SetIf(m_lastIDR, IsIdr(task.FrameType), m_frameOrder);
+        SetIf(task.PrevIPoc, IsI(task.FrameType), task.POC);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::PostReorderTask(const FeatureBlocks& /*blocks*/, TPushPostRT Push)
+{
+    Push(BLK_ConfigureTask
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        if (global.Contains(Glob::AllocRaw::Key))
+        {
+            task.Raw = Glob::AllocRaw::Get(global).Acquire();
+            MFX_CHECK(task.Raw.Mid, MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+        if (global.Contains(Glob::AllocMBQP::Key))
+        {
+            task.CUQP = Glob::AllocMBQP::Get(global).Acquire();
+            MFX_CHECK(task.CUQP.Mid, MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+
+        task.Rec = Glob::AllocRec::Get(global).Acquire();
+        task.BS = Glob::AllocBS::Get(global).Acquire();
+        MFX_CHECK(task.BS.Idx != IDX_INVALID, MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(task.Rec.Idx != IDX_INVALID, MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(task.Rec.Mid && task.BS.Mid, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        auto& par = Glob::VideoParam::Get(global);
+        auto& sps = Glob::SPS::Get(global);
+        auto& pps = Glob::PPS::Get(global);
+        auto  def = GetRTDefaults(global);
+
+        ConfigureTask(task, def, sps);
+
+        auto sts = GetSliceHeader(par, task, sps, pps, Task::SSH::Get(s_task));
+        MFX_CHECK_STS(sts);
+
+        return sts;
+    });
+}
+
+void Legacy::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SkipFrame
+        , [](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        auto& task = Task::Common::Get(s_task);
+
+        bool bCheckSkip =
+            !task.bSkip
+            && IsB(task.FrameType)
+            && !task.isLDB
+            && IsSWBRC(par, ExtBuffer::Get(par));
+
+        auto& allocRec = Glob::AllocRec::Get(global);
+
+        task.bSkip |=
+            bCheckSkip
+            && !!(allocRec.GetFlag(task.DPB.Active[task.RefPicList[1][0]].Rec.Idx) & REC_SKIPPED);
+
+        MFX_CHECK(task.bSkip, MFX_ERR_NONE);
+
+        task.bForceSync = true;
+
+        if (IsI(task.FrameType))
+        {
+            MFX_CHECK(
+                par.mfx.FrameInfo.FourCC == MFX_FOURCC_NV12
+                || par.mfx.FrameInfo.FourCC == MFX_FOURCC_P010
+                , MFX_ERR_UNDEFINED_BEHAVIOR);
+
+            FrameLocker raw(Glob::VideoCore::Get(global), task.Raw.Mid);
+
+            mfxU32 size = raw.Pitch * par.mfx.FrameInfo.Height;
+            int UVFiller = (par.mfx.FrameInfo.FourCC == MFX_FOURCC_NV12) * 126;
+
+            memset(raw.Y, 0, size);
+            memset(raw.UV, UVFiller, size >> 1);
+
+            allocRec.SetFlag(task.Rec.Idx, REC_SKIPPED);
+
+            return MFX_ERR_NONE;
+        }
+
+        auto& core = Glob::VideoCore::Get(global);
+        bool  bL1  = (IsB(task.FrameType) && !task.isLDB && task.NumRefActive[1]);
+        auto  idx  = task.RefPicList[bL1][0];
+
+        mfxFrameSurface1 surfSrc = {};
+        mfxFrameSurface1 surfDst = {};
+
+        surfSrc.Info = par.mfx.FrameInfo;
+        surfDst.Info = allocRec.Info();
+
+        MFX_CHECK(!memcmp(&surfSrc.Info, &surfDst.Info, sizeof(mfxFrameInfo)), MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(idx < MAX_DPB_SIZE, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        auto& ref = task.DPB.Active[idx];
+
+        allocRec.SetFlag(task.Rec.Idx, REC_SKIPPED);
+
+        MFX_CHECK(allocRec.GetFlag(ref.Rec.Idx) & REC_READY, MFX_ERR_NONE);
+
+        surfSrc.Data.MemId = ref.Rec.Mid;
+        surfDst.Data.MemId = task.Raw.Mid;
+
+        FrameLocker lock_dst(core, surfSrc.Data);
+        FrameLocker lock_src(core, surfDst.Data);
+
+        mfxStatus sts = core.CopyFrame(&surfDst, &surfSrc);
+        MFX_CHECK_STS(sts);
+
+        allocRec.SetFlag(ref.Rec.Idx, REC_SKIPPED * !!idx);
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_GetRawHDL
+        , [](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& core = Glob::VideoCore::Get(global);
+        auto& par = Glob::VideoParam::Get(global);
+        const mfxExtOpaqueSurfaceAlloc& opaq = ExtBuffer::Get(par);
+        auto& task = Task::Common::Get(s_task);
+
+        bool bInternalFrame =
+            par.IOPattern == MFX_IOPATTERN_IN_SYSTEM_MEMORY
+            || (par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY
+                && (opaq.In.Type & MFX_MEMTYPE_SYSTEM_MEMORY))
+            || task.bSkip;
+
+        MFX_CHECK(!bInternalFrame, core.GetFrameHDL(task.Raw.Mid, &task.HDLRaw.first));
+
+        MFX_CHECK(par.IOPattern != MFX_IOPATTERN_IN_VIDEO_MEMORY
+            , core.GetExternalFrameHDL(task.pSurfReal->Data.MemId, &task.HDLRaw.first));
+
+        MFX_CHECK(par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY
+            , MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        return core.GetFrameHDL(task.pSurfReal->Data.MemId, &task.HDLRaw.first);
+    });
+
+    Push(BLK_CopySysToRaw
+        , [](
+            StorageW& global
+            , StorageW& s_task)->mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        const mfxExtOpaqueSurfaceAlloc& opaq = ExtBuffer::Get(par);
+        auto& task = Task::Common::Get(s_task);
+
+        MFX_CHECK(
+            !(task.bSkip
+            || par.IOPattern == MFX_IOPATTERN_IN_VIDEO_MEMORY
+            || (    par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY
+                 && !(opaq.In.Type & MFX_MEMTYPE_SYSTEM_MEMORY)))
+            , MFX_ERR_NONE);
+
+        auto& core = Glob::VideoCore::Get(global);
+
+        mfxFrameSurface1 surfSrc = { {}, par.mfx.FrameInfo, task.pSurfReal->Data };
+        mfxFrameSurface1 surfDst = { {}, par.mfx.FrameInfo, {} };
+        surfDst.Data.MemId = task.Raw.Mid;
+
+        surfDst.Info.Shift =
+            surfDst.Info.FourCC == MFX_FOURCC_P010
+            || surfDst.Info.FourCC == MFX_FOURCC_Y210; // convert to native shift in core.CopyFrame() if required
+
+        return core.DoFastCopyWrapper(
+            &surfDst
+            , MFX_MEMTYPE_INTERNAL_FRAME | MFX_MEMTYPE_DXVA2_DECODER_TARGET | MFX_MEMTYPE_FROM_ENCODE
+            , &surfSrc
+            , MFX_MEMTYPE_EXTERNAL_FRAME | MFX_MEMTYPE_SYSTEM_MEMORY);
+    });
+
+    Push(BLK_FillCUQPSurf
+        , [this](
+            StorageW& global
+            , StorageW& s_task)->mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        MFX_CHECK(task.CUQP.Mid && !task.bCUQPMap, MFX_ERR_NONE);
+
+        mfxExtMBQP *mbqp = ExtBuffer::Get(task.ctrl);
+        auto& par = Glob::VideoParam::Get(global);
+        auto& core = Glob::VideoCore::Get(global);
+        auto& CUQPFrameInfo = Glob::AllocMBQP::Get(global).Info();
+
+        MFX_CHECK(CUQPFrameInfo.Width && CUQPFrameInfo.Height, MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(m_CUQPBlkW && m_CUQPBlkH, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        mfxU32 drBlkW = m_CUQPBlkW;  // block size of driver
+        mfxU32 drBlkH = m_CUQPBlkH;  // block size of driver
+        mfxU16 inBlkSize = 16; //mbqp->BlockSize ? mbqp->BlockSize : 16;  //input block size
+
+        mfxU32 pitch_MBQP = (par.mfx.FrameInfo.Width + inBlkSize - 1) / inBlkSize;
+
+        MFX_CHECK(mbqp && mbqp->NumQPAlloc, MFX_ERR_NONE);
+
+        bool bInvalid =
+            (mbqp->NumQPAlloc * inBlkSize * inBlkSize) < (drBlkW * drBlkH * CUQPFrameInfo.Width * CUQPFrameInfo.Height);
+
+        task.bCUQPMap &= !bInvalid;
+        MFX_CHECK(!bInvalid, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        FrameLocker lock(core, task.CUQP.Mid);
+        MFX_CHECK(lock.Y, MFX_ERR_LOCK_MEMORY);
+
+        auto itSrcRow   = MakeStepIter(mbqp->QP, drBlkH / inBlkSize * pitch_MBQP);
+        auto itDstRow   = MakeStepIter(lock.Y, lock.Pitch);
+        auto stepSrcRow = drBlkW / inBlkSize;
+
+        std::for_each(itSrcRow, std::next(itSrcRow, CUQPFrameInfo.Height)
+            , [&](mfxU8& rSrcRowBegin)
+        {
+            std::copy_n(MakeStepIter(&rSrcRowBegin, stepSrcRow), CUQPFrameInfo.Width, &*itDstRow++);
+        });
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_CopyBS
+        , [](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        if (!task.pBsData)
+        {
+            auto& bs              = *task.pBsOut;
+            task.pBsData          = bs.Data + bs.DataOffset + bs.DataLength;
+            task.pBsDataLength    = &bs.DataLength;
+            task.BsBytesAvailable = bs.MaxLength - bs.DataOffset - bs.DataLength;
+        }
+
+        MFX_CHECK(task.BsDataLength, MFX_ERR_NONE);
+
+        mfxStatus sts = MFX_ERR_NONE;
+
+        MFX_CHECK(task.BsBytesAvailable >= task.BsDataLength, MFX_ERR_NOT_ENOUGH_BUFFER);
+
+        FrameLocker codedFrame(Glob::VideoCore::Get(global), task.BS.Mid);
+        MFX_CHECK(codedFrame.Y, MFX_ERR_LOCK_MEMORY);
+
+        sts = FastCopy::Copy(
+            task.pBsData
+            , task.BsDataLength
+            , codedFrame.Y
+            , codedFrame.Pitch
+            , { int(task.BsDataLength), 1 }
+            , COPY_VIDEO_TO_SYS);
+        MFX_CHECK_STS(sts);
+
+        task.BsBytesAvailable -= task.BsDataLength;
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_DoPadding
+        , [](StorageW& /*global*/, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        MFX_CHECK(task.MinFrameSize >= task.BsDataLength, MFX_ERR_NONE);
+        MFX_CHECK(!task.bDontPatchBS, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        mfxU32 padding = task.MinFrameSize - task.BsDataLength;
+
+        MFX_CHECK(task.BsBytesAvailable >= padding, MFX_ERR_NOT_ENOUGH_BUFFER);
+
+        memset(task.pBsData + task.BsDataLength, 0, padding);
+
+        task.BsDataLength += padding;
+        task.BsBytesAvailable -= padding;
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_UpdateBsInfo
+        , [](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        const auto& par = Glob::VideoParam::Get(global);
+        auto& task = Task::Common::Get(s_task);
+        auto& sps = Glob::SPS::Get(global);
+        auto& bs = *task.pBsOut;
+        mfxI32 dpbOutputDelay =
+            task.DisplayOrder
+            + sps.sub_layer[sps.max_sub_layers_minus1].max_num_reorder_pics
+            - task.EncodedOrder;
+
+        bs.TimeStamp = task.pSurfIn->Data.TimeStamp;
+        bs.DecodeTimeStamp = MFX_TIMESTAMP_UNKNOWN;
+
+        if (bs.TimeStamp != mfxU64(MFX_TIMESTAMP_UNKNOWN))
+        {
+            mfxF64 tcDuration90KHz = (mfxF64)par.mfx.FrameInfo.FrameRateExtD / par.mfx.FrameInfo.FrameRateExtN * 90000;
+            bs.DecodeTimeStamp = mfxI64(bs.TimeStamp - tcDuration90KHz * dpbOutputDelay);
+        }
+
+        bs.PicStruct = task.pSurfIn->Info.PicStruct;
+        bs.FrameType = task.FrameType;
+        bs.FrameType &= ~(task.isLDB * MFX_FRAMETYPE_B);
+        bs.FrameType |= task.isLDB * MFX_FRAMETYPE_P;
+
+        *task.pBsDataLength += task.BsDataLength;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+inline bool ReleaseResource(IAllocation& a, Resource& r)
+{
+    if (r.Mid)
+    {
+        a.Release(r.Idx);
+        r = Resource();
+        return true;
+    }
+
+    return r.Idx == IDX_INVALID;
+}
+
+void Legacy::FreeTask(const FeatureBlocks& /*blocks*/, TPushFT Push)
+{
+    Push(BLK_FreeTask
+        , [](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+        auto& core = Glob::VideoCore::Get(global);
+
+        ThrowAssert(
+            !ReleaseResource(Glob::AllocBS::Get(global), task.BS)
+            , "task.BS resource is invalid");
+        ThrowAssert(
+            global.Contains(Glob::AllocMBQP::Key)
+            && !ReleaseResource(Glob::AllocMBQP::Get(global), task.CUQP)
+            , "task.CUQP resource is invalid");
+        ThrowAssert(
+            global.Contains(Glob::AllocRaw::Key)
+            && !ReleaseResource(Glob::AllocRaw::Get(global), task.Raw)
+            , "task.Raw resource is invalid");
+
+        SetIf(task.pSurfIn, task.pSurfIn && !core.DecreaseReference(&task.pSurfIn->Data), nullptr);
+        ThrowAssert(!!task.pSurfIn, "failed in core.DecreaseReference");
+
+        auto& atrRec = Glob::AllocRec::Get(global);
+
+        if (task.Rec.Idx != IDX_INVALID)
+            atrRec.SetFlag(task.Rec.Idx, REC_READY);
+
+        ThrowAssert(
+            !IsRef(task.FrameType)
+            && !ReleaseResource(atrRec, task.Rec)
+            , "task.Rec resource is invalid");
+
+        auto pDPBBeforeEnd = std::find_if_not(
+            task.DPB.Before, task.DPB.Before + Size(task.DPB.Before), isValid);
+        auto pDPBAfterEnd = std::find_if_not(
+            task.DPB.After, task.DPB.After + Size(task.DPB.After), isValid);
+        auto DPBFrameReleaseVerify = [&](DpbFrame& ref)
+        {
+            auto IsSameRecIdx = [&](DpbFrame& refA) { return refA.Rec.Idx == ref.Rec.Idx; };
+            return pDPBAfterEnd != std::find_if(task.DPB.After, pDPBAfterEnd, IsSameRecIdx)
+                || ReleaseResource(atrRec, ref.Rec);
+        };
+        auto nDPBFramesValid = std::count_if(task.DPB.Before, pDPBBeforeEnd, DPBFrameReleaseVerify);
+
+        ThrowAssert(nDPBFramesValid != (pDPBBeforeEnd - task.DPB.Before), "task.DPB.Before is invalid");
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Legacy::GetVideoParam(const FeatureBlocks& blocks, TPushGVP Push)
+{
+    Push(BLK_CopyConfigurable
+        , [this, &blocks](mfxVideoParam& out, StorageR& global) -> mfxStatus
+    {
+        return CopyConfigurable(blocks, Glob::VideoParam::Get(global), out);
+    });
+}
+
+IntraRefreshState GetIntraRefreshState(
+    const ExtBuffer::Param<mfxVideoParam> & par
+    , const mfxEncodeCtrl& ctrl
+    , mfxU32                frameOrderInGopDispOrder
+    , mfxU32                IntraRefreshBlockUnitSize)
+{
+    IntraRefreshState state={};
+    const mfxExtCodingOption2& CO2       = ExtBuffer::Get(par);
+    const mfxExtCodingOption3& CO3       = ExtBuffer::Get(par);
+    const mfxExtHEVCParam&     HEVCParam = ExtBuffer::Get(par);
+    const mfxExtCodingOption2* pCO2RT    = ExtBuffer::Get(ctrl);
+
+    mfxU32 refreshPeriod             = std::max<mfxU32>(CO3.IntRefCycleDist + (!CO3.IntRefCycleDist * CO2.IntRefCycleSize), 1);
+    mfxU32 offsetFromStartOfGop      = std::max<mfxU32>(!!CO3.IntRefCycleDist * refreshPeriod, 1); // 1st refresh cycle in GOP starts with offset
+    mfxI32 frameOrderMinusOffset     = frameOrderInGopDispOrder - offsetFromStartOfGop;
+    mfxU32 frameOrderInRefreshPeriod = frameOrderMinusOffset % refreshPeriod;
+
+    state.firstFrameInCycle = false;
+
+    bool bNoUpdate =
+        CO2.IntRefType == 0
+        || frameOrderMinusOffset < 0 // too early to start refresh
+        || frameOrderInRefreshPeriod >= CO2.IntRefCycleSize; // for current refresh period refresh cycle is already passed
+
+    if (bNoUpdate)
+        return state;
+
+    mfxU32 IRBlockSize = 1 << (3 + IntraRefreshBlockUnitSize);
+    // refreshing parts (stripes) in frame
+    mfxU32 refreshDimension = CO2.IntRefType == MFX_REFRESH_HORIZONTAL
+        ? CeilDiv<mfxU32>(HEVCParam.PicHeightInLumaSamples, IRBlockSize)
+        : CeilDiv<mfxU32>(HEVCParam.PicWidthInLumaSamples, IRBlockSize);
+
+    // In most cases number of refresh stripes is no aligned with number of frames for refresh.
+    // In head frames are refreshed min stripes (can be 0), in tail min+1
+    // min * head + (min+1) * tail == min * frames + tail == refreshDimension
+    mfxU32 frames   = CO2.IntRefCycleSize;          // frames to commit full refresh
+    mfxU32 minStr   = refreshDimension / frames;    // minimal refreshed stripes
+    mfxU32 tail     = refreshDimension % frames;    // tail frames have minStr+1 stripes
+    mfxU32 head     = frames - tail;                // head frames with minStr stripes
+
+    if (frameOrderInRefreshPeriod < head) // min, can be 0
+    {
+        if (!minStr)
+            return state; // actual refresh isn't started yet within current refresh cycle, no Intra column/row required for current frame
+
+        state.IntraSize     = (mfxU16)minStr;
+        state.IntraLocation = (mfxU16)(frameOrderInRefreshPeriod * minStr);
+    }
+    else
+    {
+        state.IntraSize     = (mfxU16)(minStr + 1);
+        state.IntraLocation = (mfxU16)(frameOrderInRefreshPeriod * minStr + (frameOrderInRefreshPeriod - head));
+    }
+
+    state.firstFrameInCycle = (frameOrderInRefreshPeriod == 0);
+    state.refrType          = CO2.IntRefType;
+
+    // set QP for Intra macroblocks within refreshing line
+    state.IntRefQPDelta = CO2.IntRefQPDelta;
+
+    bool bUpdateQPDelta = pCO2RT && pCO2RT->IntRefQPDelta <= 51 && pCO2RT->IntRefQPDelta >= -51;
+    if (bUpdateQPDelta)
+        state.IntRefQPDelta = pCO2RT->IntRefQPDelta;
+
+    return state;
+}
+
+mfxU8 GetCodingType(const TaskCommonPar & task)
+{
+    const mfxU8 I  = 1; // I picture.
+    const mfxU8 P  = 2; // P or GPB picture at base temporal level.
+    const mfxU8 B  = 3; // P, GPB or B picture at temporal level 1.
+    const mfxU8 B1 = 4; // P, GPB or B picture at temporal level 2.
+    const mfxU8 B2 = 5; // P, GPB or B picture at temporal level 3.
+
+    auto IsBX = [&](mfxU8 idx)
+    {
+        auto& ref = task.DPB.Active[idx];
+        return !ref.isLDB && ref.CodingType > B;
+    };
+    auto IsB0 = [&](mfxU8 idx)
+    {
+        auto& ref = task.DPB.Active[idx];
+        return !ref.isLDB && ref.CodingType == B;
+    };
+    mfxU8 type = 0;
+    type += I * IsI(task.FrameType);
+    type += P * (!type && IsP(task.FrameType));
+    type += B * (!type && task.isLDB);
+    type += B2 * (!type && std::any_of(task.RefPicList[0], task.RefPicList[0] + task.NumRefActive[0], IsBX));
+    type += B2 * (!type && std::any_of(task.RefPicList[1], task.RefPicList[1] + task.NumRefActive[1], IsBX));
+    type += B1 * (!type && std::any_of(task.RefPicList[0], task.RefPicList[0] + task.NumRefActive[0], IsB0));
+    type += B1 * (!type && std::any_of(task.RefPicList[1], task.RefPicList[1] + task.NumRefActive[1], IsB0));
+    type += B * !type;
+
+    return type;
+}
+
+class SkipMode
+{
+private:
+    eSkipMode m_mode;
+    mfxU32 m_cmd;
+
+    void SetCMD()
+    {
+        m_cmd = 0;
+        m_cmd |= NeedInputReplacement()     * SKIPCMD_NeedInputReplacement;
+        m_cmd |= NeedDriverCall()           * SKIPCMD_NeedDriverCall;
+        m_cmd |= NeedSkipSliceGen()         * SKIPCMD_NeedSkipSliceGen;
+        m_cmd |= NeedCurrentFrameSkipping() * SKIPCMD_NeedCurrentFrameSkipping;
+        m_cmd |= NeedNumSkipAdding()        * SKIPCMD_NeedNumSkipAdding;
+    }
+public:
+    SkipMode(eSkipMode mode = SKIPFRAME_NO)
+        : m_mode(mode)
+    {
+        SetCMD();
+    }
+
+    SkipMode(mfxU16 mode, bool bProtected)
+    {
+        SetMode(mode, bProtected);
+    }
+
+    void SetMode(mfxU16 skipModeMFX, bool bProtected)
+    {
+        m_mode = eSkipMode(
+            SKIPFRAME_INSERT_DUMMY_PROTECTED * (skipModeMFX == MFX_SKIPFRAME_INSERT_DUMMY && bProtected)
+            + SKIPFRAME_INSERT_DUMMY         * (skipModeMFX == MFX_SKIPFRAME_INSERT_DUMMY && !bProtected)
+            + SKIPFRAME_INSERT_NOTHING       * (skipModeMFX == MFX_SKIPFRAME_INSERT_NOTHING)
+            + SKIPFRAME_BRC_ONLY             * (skipModeMFX == MFX_SKIPFRAME_BRC_ONLY));
+        SetCMD();
+    }
+
+    void SetPseudoSkip()
+    {
+        m_mode = SKIPFRAME_EXT_PSEUDO;
+    }
+
+    eSkipMode GetMode() { return m_mode; }
+    mfxU32 GetCMD() { return m_cmd; }
+
+    bool NeedInputReplacement()
+    {
+        return m_mode == SKIPFRAME_EXT_PSEUDO;
+    }
+    bool NeedDriverCall()
+    {
+        return m_mode == SKIPFRAME_INSERT_DUMMY_PROTECTED
+            || m_mode == SKIPFRAME_EXT_PSEUDO
+            || m_mode == SKIPFRAME_NO
+            || m_mode == SKIPFRAME_EXT_PSEUDO;
+    }
+    bool NeedSkipSliceGen()
+    {
+        return m_mode == SKIPFRAME_INSERT_DUMMY_PROTECTED
+            || m_mode == SKIPFRAME_INSERT_DUMMY;
+    }
+    bool NeedCurrentFrameSkipping()
+    {
+        return m_mode == SKIPFRAME_INSERT_DUMMY_PROTECTED
+            || m_mode == SKIPFRAME_INSERT_DUMMY
+            || m_mode == SKIPFRAME_INSERT_NOTHING;
+    }
+    bool NeedNumSkipAdding()
+    {
+        return m_mode == SKIPFRAME_BRC_ONLY;
+    }
+};
+
+static void SetTaskQpY(
+    TaskCommonPar & task
+    , const ExtBuffer::Param<mfxVideoParam> & par
+    , const SPS& sps
+    , const Defaults::Param& dflts)
+{
+    const auto& hw = dflts.hw;
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+    const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+    const mfxU8 maxQP = mfxU8(51 + 6 * (CO3.TargetBitDepthLuma - 8));
+
+    if (par.mfx.RateControlMethod != MFX_RATECONTROL_CQP)
+    {
+        task.QpY &= 0xff * (par.mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT);
+        return;
+    }
+
+    bool bUseQPP = IsP(task.FrameType) || task.isLDB;
+    bool bUseQPB = !bUseQPP && IsB(task.FrameType);
+    bool bUseQPOffset =
+        (bUseQPB && CO2.BRefType == MFX_B_REF_PYRAMID)
+        || (bUseQPP && CO3.PRefType == MFX_P_REF_PYRAMID);
+
+    // set coding type and QP
+    if (bUseQPB)
+    {
+        task.QpY = (mfxI8)par.mfx.QPB;
+        if (bUseQPOffset)
+        {
+            task.QpY = (mfxI8)mfx::clamp<mfxI32>(
+                CO3.QPOffset[mfx::clamp<mfxI32>(task.PyramidLevel - 1, 0, 7)] + task.QpY
+                , 1, maxQP);
+        }
+    }
+    else if (bUseQPP)
+    {
+        // encode P as GPB
+        task.QpY = (mfxI8)par.mfx.QPP;
+
+        if (dflts.base.GetNumTemporalLayers(dflts) > 1)
+        {
+            task.QpY = (mfxI8)mfx::clamp<mfxI32>(CO3.QPOffset[task.TemporalID] + task.QpY, 1, maxQP);
+        }
+        else if (bUseQPOffset)
+        {
+            task.QpY = (mfxI8)mfx::clamp<mfxI32>(
+                CO3.QPOffset[std::min<size_t>(task.PyramidLevel, Size(CO3.QPOffset) - 1)] + task.QpY
+                , 1, maxQP);
+        }
+    }
+    else
+    {
+        assert(IsI(task.FrameType));
+        task.QpY = (mfxI8)par.mfx.QPI;
+    }
+
+    SetIf(task.QpY, !!task.ctrl.QP, (mfxI8)task.ctrl.QP);
+
+    task.QpY -= 6 * sps.bit_depth_luma_minus8;
+    task.QpY &= 0xff * !(task.QpY < 0 && (IsOn(par.mfx.LowPower) || (hw >= MFX_HW_KBL && hw <= MFX_HW_CNL)));
+}
+
+void Legacy::ConfigureTask(
+    TaskCommonPar & task
+    , const Defaults::Param& dflts
+    , const SPS& sps)
+{
+    auto&                      par = dflts.mvp;
+    const mfxExtCodingOption&  CO  = ExtBuffer::Get(par);
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+    const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+    const bool isI    = IsI(task.FrameType);
+    const bool isP    = IsP(task.FrameType);
+    const bool isIDR  = IsIdr(task.FrameType);
+
+    mfxExtAVCRefLists*    pExtLists    = ExtBuffer::Get(task.ctrl);
+    mfxExtAVCRefListCtrl* pExtListCtrl = ExtBuffer::Get(task.ctrl);
+
+    {
+        const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(task.ctrl);
+        SkipMode mode;
+
+        SetDefault(pCO2, &CO2);
+
+        mode.SetMode(mfxU16(!!task.ctrl.SkipFrame * pCO2->SkipFrame), !!par.Protected);
+
+        task.FrameType &= ~(MFX_FRAMETYPE_REF
+            * (mode.NeedCurrentFrameSkipping() && par.mfx.GopRefDist == 1 && isP));
+
+
+        if (IsRef(task.FrameType))
+        {
+            task.ctrl.SkipFrame = 0;
+            mode.SetMode(MFX_SKIPFRAME_NO_SKIP, !!par.Protected);
+        }
+
+        task.SkipCMD = mode.GetCMD();
+    }
+
+    task.ctrl.MfxNalUnitType &= 0xffff * IsOn(CO3.EnableNalUnitType);
+
+    const mfxExtMBQP *pMBQP = ExtBuffer::Get(task.ctrl);
+    task.bCUQPMap |= (pMBQP && pMBQP->NumQPAlloc > 0);
+
+    bool bUpdateIRState = task.TemporalID == 0 && CO2.IntRefType;
+    if (bUpdateIRState)
+    {
+        m_baseLayerOrder *= !isI;
+        task.IRState = GetIntraRefreshState(
+            par, task.ctrl, m_baseLayerOrder++, dflts.caps.IntraRefreshBlockUnitSize);
+    }
+
+    mfxU32 needRecoveryPointSei = (CO.RecoveryPointSEI == MFX_CODINGOPTION_ON
+        && (   (CO2.IntRefType && task.IRState.firstFrameInCycle && task.IRState.IntraLocation == 0)
+            || (CO2.IntRefType == 0 && isI)));
+    mfxU32 needCpbRemovalDelay = isIDR || needRecoveryPointSei;
+    const bool isRef = IsRef(task.FrameType);
+
+    // encode P as GPB
+    task.isLDB      = IsOn(CO3.GPB) && isP;
+    task.FrameType &= ~(MFX_FRAMETYPE_P * task.isLDB);
+    task.FrameType |= (MFX_FRAMETYPE_B * task.isLDB);
+
+    task.PrevIPoc = m_prevTask.PrevIPoc;
+    task.PrevRAP = m_prevTask.PrevRAP;
+    task.EncodedOrder = m_prevTask.EncodedOrder + 1;
+
+    InitDPB(task, m_prevTask, pExtListCtrl);
+
+    //construct ref lists
+    std::tie(task.NumRefActive[0], task.NumRefActive[1]) = dflts.base.GetFrameNumRefActive(dflts, task);
+
+    if (!isI)
+    {
+        ConstructRPL(dflts, task.DPB.Active, task, task.RefPicList, task.NumRefActive, pExtLists, pExtListCtrl);
+    }
+
+    SetTaskQpY(task, par, sps, dflts);
+    task.CodingType = GetCodingType(task);
+
+    task.InsertHeaders |= m_forceHeaders;
+    m_forceHeaders = 0;
+
+    task.InsertHeaders |= (INSERT_VPS | INSERT_SPS | INSERT_PPS) * isIDR;
+    task.InsertHeaders |= INSERT_BPSEI * (needCpbRemovalDelay && sps.vui.hrd_parameters_present_flag );
+    task.InsertHeaders |= INSERT_PTSEI
+                * (sps.vui.frame_field_info_present_flag
+                || sps.vui.hrd.nal_hrd_parameters_present_flag
+                || sps.vui.hrd.vcl_hrd_parameters_present_flag);
+    task.InsertHeaders |= INSERT_PPS * IsOn(CO2.RepeatPPS);
+    task.InsertHeaders |= INSERT_AUD * IsOn(CO.AUDelimiter);
+
+    // update dpb
+    std::copy(task.DPB.Active, task.DPB.Active + Size(task.DPB.Active), task.DPB.After);
+    Remove(task.DPB.After, 0, MAX_DPB_SIZE * isIDR);
+
+    if (isRef)
+    {
+        task.PrevIPoc = isI * task.POC + !isI * task.PrevIPoc;
+
+        UpdateDPB(dflts, task, task.DPB.After, pExtListCtrl);
+
+        using TRLtrDesc = decltype(pExtListCtrl->LongTermRefList[0]);
+        auto IsCurFrame = [&](TRLtrDesc ltr)
+        {
+            return ltr.FrameOrder == task.DisplayOrder;
+        };
+
+        task.isLTR |=
+            pExtListCtrl
+            && std::any_of(
+                std::begin(pExtListCtrl->LongTermRefList)
+                , std::end(pExtListCtrl->LongTermRefList)
+                , IsCurFrame);
+    }
+
+    task.SliceNUT = dflts.base.GetSHNUT(dflts, task, true);
+
+    bool bRAP =
+        task.SliceNUT == CRA_NUT
+        || task.SliceNUT == IDR_W_RADL
+        || task.SliceNUT == IDR_N_LP;
+
+    task.PrevRAP = bRAP * task.POC + !bRAP * task.PrevRAP;
+
+    task.StatusReportId = std::max<mfxU32>(1, m_prevTask.StatusReportId + 1);
+    task.bForceSync = !!(task.InsertHeaders & INSERT_BPSEI);
+
+    m_prevTask = task;
+}
+
+static mfxU32 CountL1(DpbArray const & dpb, mfxI32 poc)
+{
+    mfxU32 c = 0;
+    for (mfxU32 i = 0; !isDpbEnd(dpb, i); i++)
+        c += dpb[i].POC > poc;
+    return c;
+}
+
+static mfxU32 GetEncodingOrder(
+    mfxU32 displayOrder
+    , mfxU32 begin
+    , mfxU32 end
+    , mfxU32 &level
+    , mfxU32 before
+    , bool & ref)
+{
+    assert(displayOrder >= begin);
+    assert(displayOrder <  end);
+
+    ref = (end - begin > 1);
+
+    mfxU32 pivot = (begin + end) / 2;
+    if (displayOrder == pivot)
+        return level + before;
+
+    level++;
+    if (displayOrder < pivot)
+        return GetEncodingOrder(displayOrder, begin, pivot, level, before, ref);
+    else
+        return GetEncodingOrder(displayOrder, pivot + 1, end, level, before + pivot - begin, ref);
+}
+
+mfxU32 Legacy::GetBiFrameLocation(mfxU32 i, mfxU32 num, bool &ref, mfxU32 &level)
+{
+    ref = false;
+    level = 1;
+    return GetEncodingOrder(i, 0, num, level, 0, ref);
+}
+
+Legacy::TItWrapIt Legacy::BPyrReorder(TItWrapIt begin, TItWrapIt end)
+{
+    using TRef = std::iterator_traits<TItWrapIt>::reference;
+
+    mfxU32 num = mfxU32(std::distance(begin, end));
+    bool bSetOrder = num && (*begin)->BPyramidOrder == mfxU32(MFX_FRAMEORDER_UNKNOWN);
+
+    if (bSetOrder)
+    {
+        mfxU32 i = 0;
+        std::for_each(begin, end, [&](TRef bref)
+        {
+            bool bRef = false;
+            bref->BPyramidOrder = Legacy::GetBiFrameLocation(i++, num, bRef, bref->PyramidLevel);
+            bref->FrameType |= mfxU16(MFX_FRAMETYPE_REF * bRef);
+        });
+    }
+
+    return std::min_element(begin, end
+        , [](TRef a, TRef b) { return a->BPyramidOrder < b->BPyramidOrder; });
+}
+
+Legacy::TItWrap Legacy::Reorder(
+    ExtBuffer::Param<mfxVideoParam> const & par
+    , DpbArray const & dpb
+    , TItWrap begin
+    , TItWrap end
+    , bool flush)
+{
+    using TRef = TItWrap::reference;
+
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+    bool isBPyramid = (CO2.BRefType == MFX_B_REF_PYRAMID);
+    TItWrap top = begin;
+    std::list<TItWrap> brefs;
+    auto IsB = [](TRef f) { return HEVCEHW::IsB(f.FrameType); };
+    auto NoL1 = [&](TItWrap& f) { return !CountL1(dpb, f->POC); };
+
+    std::generate_n(
+        std::back_inserter(brefs)
+        , std::distance(begin, std::find_if_not(begin, end, IsB))
+        , [&]() { return top++; });
+
+    brefs.remove_if(NoL1);
+
+    bool bNoPyramidB = !isBPyramid && !brefs.empty();
+    if (bNoPyramidB)
+    {
+        auto B0POC = brefs.front()->POC;
+        auto RefB = [B0POC](TItWrap& f)
+        {
+            return IsRef(f->FrameType) && (f->POC - B0POC < 2);
+        };
+        TItWrapIt BCand[2] =
+        {
+            std::find_if(brefs.begin() , brefs.end(), RefB)
+            , brefs.begin()
+        };
+
+        return *BCand[BCand[0] == brefs.end()];
+    }
+
+    if (!brefs.empty())
+        return *BPyrReorder(brefs.begin(), brefs.end());
+
+    bool bForcePRef = flush && top == end && begin != end;
+    if (bForcePRef)
+    {
+        --top;
+        top->FrameType = mfxU16(MFX_FRAMETYPE_P | MFX_FRAMETYPE_REF);
+    }
+
+    return top;
+}
+
+std::tuple<mfxStatus, mfxU16, mfxU16>
+Legacy::GetCUQPMapBlockSize(
+    mfxU16 frameWidth
+    , mfxU16 frameHeight
+    , mfxU16 CUQPWidth
+    , mfxU16 CUHeight)
+{
+    bool bValid = CUQPWidth && CUHeight;
+
+    if (bValid)
+    {
+        const mfxU16 BlkSizes[] = { 4, 8, 16, 32, 64 };
+        auto itBlkWidth = std::lower_bound(BlkSizes, std::end(BlkSizes), frameWidth / CUQPWidth);
+        auto itBlkHeight = std::lower_bound(BlkSizes, std::end(BlkSizes), frameHeight / CUHeight);
+
+        bValid =
+            itBlkWidth != std::end(BlkSizes)
+            && itBlkHeight != std::end(BlkSizes)
+            && (*itBlkWidth   * (CUQPWidth - 1) < frameWidth)
+            && (*itBlkHeight  * (CUHeight - 1) < frameHeight);
+
+        if (bValid)
+            return std::make_tuple(MFX_ERR_NONE, *itBlkWidth, *itBlkHeight);
+    }
+
+    return std::make_tuple(MFX_ERR_UNDEFINED_BEHAVIOR, mfxU16(0), mfxU16(0));
+}
+
+mfxU32 Legacy::GetMinBsSize(
+    const mfxVideoParam & par
+    , const mfxExtHEVCParam& HEVCParam
+    , const mfxExtCodingOption2& CO2
+    , const mfxExtCodingOption3& CO3)
+{
+    mfxU32 size = HEVCParam.PicHeightInLumaSamples * HEVCParam.PicWidthInLumaSamples;
+    
+    SetDefault(size, par.mfx.FrameInfo.Width * par.mfx.FrameInfo.Height);
+
+    bool b10bit = (CO3.TargetBitDepthLuma == 10);
+    bool b422   = (CO3.TargetChromaFormatPlus1 == (MFX_CHROMAFORMAT_YUV422 + 1));
+    bool b444   = (CO3.TargetChromaFormatPlus1 == (MFX_CHROMAFORMAT_YUV444 + 1));
+
+    mfxF64 k = 2.0
+        + (b10bit * 0.3)
+        + (b422   * 0.5)
+        + (b444   * 1.5);
+
+    size = mfxU32(k * size);
+
+    bool bUseAvgSize =
+        par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+        && IsSWBRC(par, &CO2)
+        && par.mfx.FrameInfo.FrameRateExtD != 0;
+
+    if (!bUseAvgSize)
+        return size;
+
+    mfxU32 avgSize = TargetKbps(par.mfx) * 1000 * par.mfx.FrameInfo.FrameRateExtD / (par.mfx.FrameInfo.FrameRateExtN * 8);
+
+    return std::max<mfxU32>(size, avgSize * 2);
+}
+
+bool Legacy::GetRecInfo(
+    const mfxVideoParam& par
+    , const mfxExtCodingOption3& CO3
+    , eMFXHWType hw
+    , mfxFrameInfo& rec)
+{
+    static const std::map<mfxU16, std::function<void(mfxFrameInfo&, eMFXHWType)>> ModRec[2] =
+    {
+        { //8b
+            {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV444)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_AYUV;
+                    /* Pitch = 4*W for AYUV format
+                       Pitch need to align on 512
+                       So, width aligment is 512/4 = 128 */
+                    rec.Width  = mfx::align2_value<mfxU16>(rec.Width, 512 / 4);
+                    rec.Height = mfx::align2_value<mfxU16>(rec.Height *3/4, 8);
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV422)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_YUY2;
+                    rec.Width /= 2;
+                    rec.Height *= 2;
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV420)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_NV12;
+                }
+            }
+        }
+        , { //10b
+            {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV444)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_Y410;
+                    /* Pitch = 4*W for Y410 format
+                       Pitch need to align on 256
+                       So, width aligment is 256/4 = 64 */
+                    rec.Width  = mfx::align2_value<mfxU16>(rec.Width, 256 / 4);
+                    rec.Height = mfx::align2_value<mfxU16>(rec.Height * 3 / 2, 8);
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV422)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_Y210;
+                    rec.Width /= 2;
+                    rec.Height *= 2;
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV420)
+                , [](mfxFrameInfo& rec, eMFXHWType)
+                {
+                    rec.FourCC = MFX_FOURCC_P010;
+                }
+            }
+        }
+    };
+    rec = par.mfx.FrameInfo;
+
+    auto& rModRec  = ModRec[CO3.TargetBitDepthLuma == 10];
+    auto  itModRec = rModRec.find(CO3.TargetChromaFormatPlus1);
+    bool bUndef =
+        (CO3.TargetBitDepthLuma != 8 && CO3.TargetBitDepthLuma != 10)
+        || (itModRec == rModRec.end());
+
+    if (bUndef)
+    {
+        return false;
+    }
+
+    itModRec->second(rec, hw);
+
+    rec.ChromaFormat   = CO3.TargetChromaFormatPlus1 - 1;
+    rec.BitDepthLuma   = CO3.TargetBitDepthLuma;
+    rec.BitDepthChroma = CO3.TargetBitDepthChroma;
+
+    return true;
+}
+
+void Legacy::SetVPS(
+    const Defaults::Param& dflts
+    , VPS& vps)
+{
+    auto&                  par       = dflts.mvp;
+    const mfxExtHEVCParam& HEVCParam = ExtBuffer::Get(par);
+    mfxU16                 NumTL     = dflts.base.GetNumTemporalLayers(dflts);
+    PTL&                   general   = vps.general;
+    SubLayerOrdering&      slo       = vps.sub_layer[NumTL - 1];
+
+    vps = VPS{};
+    vps.video_parameter_set_id                  = 0;
+    vps.reserved_three_2bits                    = 3;
+    vps.max_layers_minus1                       = 0;
+    vps.max_sub_layers_minus1                   = mfxU16(NumTL - 1);
+    vps.temporal_id_nesting_flag                = 1;
+    vps.reserved_0xffff_16bits                  = 0xFFFF;
+    vps.sub_layer_ordering_info_present_flag    = 0;
+
+    vps.timing_info_present_flag        = 1;
+    vps.num_units_in_tick               = par.mfx.FrameInfo.FrameRateExtD;
+    vps.time_scale                      = par.mfx.FrameInfo.FrameRateExtN;
+    vps.poc_proportional_to_timing_flag = 0;
+    vps.num_hrd_parameters              = 0;
+
+    general.profile_space                   = 0;
+    general.tier_flag                       = !!(par.mfx.CodecLevel & MFX_TIER_HEVC_HIGH);
+    general.profile_idc                     = mfxU8(par.mfx.CodecProfile);
+    general.profile_compatibility_flags     = 1 << (31 - general.profile_idc);
+    general.progressive_source_flag         = !!(par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
+    general.interlaced_source_flag          = !(par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
+    general.non_packed_constraint_flag      = 0;
+    general.frame_only_constraint_flag      = 0;
+    general.level_idc                       = mfxU8((par.mfx.CodecLevel & 0xFF) * 3);
+
+    if (par.mfx.CodecProfile == MFX_PROFILE_HEVC_REXT)
+    {
+        general.rext_constraint_flags_0_31  = (mfxU32)(HEVCParam.GeneralConstraintFlags & 0xffffffff);
+        general.rext_constraint_flags_32_42 = (mfxU32)(HEVCParam.GeneralConstraintFlags >> 32);
+    }
+
+    auto numReorderFrames = dflts.base.GetNumReorderFrames(dflts);
+    slo.max_dec_pic_buffering_minus1 = par.mfx.NumRefFrame;
+    slo.max_num_reorder_pics         = std::min<mfxU8>(numReorderFrames, slo.max_dec_pic_buffering_minus1);
+    slo.max_latency_increase_plus1   = 0;
+}
+
+typedef std::remove_reference<decltype(((mfxExtAVCRefListCtrl*)nullptr)->PreferredRefList[0])>::type TLCtrlRLE;
+
+void Legacy::InitDPB(
+    TaskCommonPar &        task,
+    TaskCommonPar const &  prevTask,
+    const mfxExtAVCRefListCtrl* pLCtrl)
+{
+    bool b1stTrail =
+        task.POC > task.PrevRAP
+        && prevTask.POC <= prevTask.PrevRAP;
+
+    if (b1stTrail)
+    {
+        Remove(task.DPB.Active, 0, MAX_DPB_SIZE);
+
+        // TODO: add mode to disable this check
+        std::copy_if(
+            prevTask.DPB.After
+            , prevTask.DPB.After + Size(prevTask.DPB.After)
+            , task.DPB.Active
+            , [&](const DpbFrame& ref)
+        {
+            return isValid(ref) && (ref.POC == task.PrevRAP || ref.isLTR);
+        });
+    }
+    else
+    {
+        std::copy_n(prevTask.DPB.After, Size(prevTask.DPB.After), task.DPB.Active);
+    }
+
+    std::copy_n(prevTask.DPB.After, Size(prevTask.DPB.After), task.DPB.Before);
+
+    DpbArray& dpb = task.DPB.Active;
+    auto dpbEnd = std::find_if_not(dpb, dpb + Size(dpb), isValid);
+
+    dpbEnd = RemoveIf(dpb, dpbEnd
+        , [&](const DpbFrame& ref)
+    {
+        return ref.TemporalID > 0 && ref.TemporalID >= task.TemporalID;
+    });
+
+    if (pLCtrl)
+    {
+        std::list<mfxU16> rejectIDX;
+
+        auto rejectedEnd = std::find_if(
+            pLCtrl->RejectedRefList
+            , pLCtrl->RejectedRefList + Size(pLCtrl->RejectedRefList)
+            , [](const TLCtrlRLE& ref)
+        {
+            return ref.FrameOrder == mfxU32(MFX_FRAMEORDER_UNKNOWN);
+        });
+
+        std::transform(
+            pLCtrl->RejectedRefList
+            , rejectedEnd
+            , std::back_inserter(rejectIDX)
+            , [&](const TLCtrlRLE& lt)
+        {
+            mfxU16 idx = GetDPBIdxByFO(dpb, lt.FrameOrder);
+            idx += !dpb[idx].isLTR * MAX_DPB_SIZE;
+            return std::min<mfxU16>(idx, MAX_DPB_SIZE);
+        });
+
+        rejectIDX.sort();
+        rejectIDX.remove(mfxU16(MAX_DPB_SIZE));
+
+        std::for_each(rejectIDX.begin(), rejectIDX.end()
+            , [&](mfxU16 idx)
+        {
+            Remove(dpb, idx);
+        });
+    }
+}
+
+mfxU16 Legacy::UpdateDPB(
+    const Defaults::Param& def
+    , const DpbFrame& task
+    , DpbArray & dpb
+    , const mfxExtAVCRefListCtrl * pLCtrl)
+{
+    auto& par = def.mvp;
+    const mfxExtCodingOption2& CO2  = ExtBuffer::Get(par);
+    bool isBPyramid                 = (CO2.BRefType == MFX_B_REF_PYRAMID);
+    mfxU16 end                      = 0; // DPB end
+    mfxU16 st0                      = 0; // first ST ref in DPB
+    bool bClearCodingType           = isBPyramid && (task.isLDB || task.CodingType < CODING_TYPE_B);
+    auto ClearCodingType            = [](DpbFrame& ref) { ref.CodingType = 0; };
+    auto IsLTR                      = [](DpbFrame& f) { return f.isLTR; };
+    auto POCLess                    = [](DpbFrame& l, DpbFrame& r) { return l.POC < r.POC; };
+
+    end = mfxU16(std::find_if_not(dpb, dpb + Size(dpb), isValid) - dpb);
+    st0 = mfxU16(std::find_if_not(dpb, dpb + end, IsLTR) - dpb);
+
+    // frames stored in DPB in POC ascending order,
+    // LTRs before STRs (use LTR-candidate as STR as long as it is possible)
+    std::sort(dpb, dpb + st0, POCLess);
+    std::sort(dpb + st0, dpb + end, POCLess);
+
+    // sliding window over STRs
+    bool bRunSlidingWindow = end && end == par.mfx.NumRefFrame;
+    if (bRunSlidingWindow)
+    {
+        st0 = mfxU16(def.base.GetWeakRef(def, task, dpb + st0, dpb + end) - dpb);
+
+        Remove(dpb, st0 * (st0 < end));
+        --end;
+    }
+
+    ThrowAssert(end >= MAX_DPB_SIZE, "DPB overflow, no space for new frame");
+
+    //don't keep coding types for prev. mini-GOP
+    std::for_each(dpb, dpb + (end * bClearCodingType), ClearCodingType);
+
+    dpb[end++] = task;
+
+    if (pLCtrl)
+    {
+        st0 = mfxU16(std::find_if_not(dpb, dpb + end, IsLTR) - dpb);
+
+        auto lctrlLtrEnd = std::find_if(
+            pLCtrl->LongTermRefList
+            , pLCtrl->LongTermRefList + Size(pLCtrl->LongTermRefList)
+            , [](const TLCtrlRLE& lt) { return lt.FrameOrder == mfxU32(MFX_FRAMEORDER_UNKNOWN); });
+
+        std::list<mfxU16> markLTR;
+
+        std::transform(pLCtrl->LongTermRefList, lctrlLtrEnd, std::back_inserter(markLTR)
+            , [&](const TLCtrlRLE& lt)
+        {
+            mfxU16 idx = GetDPBIdxByFO(dpb, lt.FrameOrder);
+            idx += !!dpb[idx].isLTR * MAX_DPB_SIZE;
+            return std::min<mfxU16>(idx, MAX_DPB_SIZE);
+        });
+
+        markLTR.sort();
+        markLTR.remove(mfxU16(MAX_DPB_SIZE));
+
+        std::for_each(markLTR.begin(), markLTR.end()
+            , [&](mfxU16 idx)
+        {
+            DpbFrame ltr = dpb[idx];
+            ltr.isLTR = true;
+            Remove(dpb, idx);
+            Insert(dpb, st0, ltr);
+            st0++;
+        });
+
+        std::sort(dpb, dpb + st0, POCLess);
+    }
+
+    return end;
+}
+
+void Legacy::ConstructRPL(
+    const Defaults::Param& dflts
+    , const DpbArray & DPB
+    , const FrameBaseInfo& cur
+    , mfxU8(&RPL)[2][MAX_DPB_SIZE]
+    , mfxU8(&numRefActive)[2]
+    , const mfxExtAVCRefLists * pExtLists
+    , const mfxExtAVCRefListCtrl * pLCtrl)
+{
+    auto GetRPLFromExt = [&]()
+    {
+        return dflts.base.GetRPLFromExt(
+            dflts
+            , DPB
+            , numRefActive[0]
+            , numRefActive[1]
+            , *pExtLists
+            , RPL);
+    };
+    auto GetRPLFromCtrl = [&]()
+    {
+        return dflts.base.GetRPLFromCtrl (
+            dflts
+            , DPB
+            , numRefActive[0]
+            , numRefActive[1]
+            , cur
+            , *pLCtrl
+            , RPL);
+    };
+
+    std::tuple<mfxU8, mfxU8> nRef(mfxU8(0), mfxU8(0));
+
+    SetIf(nRef, !!pExtLists, GetRPLFromExt);
+
+    SetIf(nRef, !std::get<0>(nRef)
+        , dflts.base.GetRPL
+        , dflts
+        , DPB
+        , numRefActive[0]
+        , numRefActive[1]
+        , cur
+        , RPL);
+
+    SetIf(nRef, !!pLCtrl, GetRPLFromCtrl);
+    ThrowAssert(!std::get<0>(nRef), "L0 is empty");
+
+    nRef = dflts.base.GetRPLMod(
+        dflts
+        , DPB
+        , numRefActive[0]
+        , numRefActive[1]
+        , cur
+        , RPL);
+
+    numRefActive[0] = std::get<0>(nRef);
+    numRefActive[1] = std::get<1>(nRef);
+}
+
+void Legacy::ConstructSTRPS(
+    const DpbArray & DPB
+    , const mfxU8(&RPL)[2][MAX_DPB_SIZE]
+    , const mfxU8(&numRefActive)[2]
+    , mfxI32 poc
+    , STRPS& rps)
+{
+    mfxU32 i, nRef;
+
+    for (i = 0, nRef = 0; !isDpbEnd(DPB, i); i ++)
+    {
+        if (DPB[i].isLTR)
+            continue;
+
+        rps.pic[nRef].DeltaPocSX = (mfxI16)(DPB[i].POC - poc);
+        rps.pic[nRef].used_by_curr_pic_sx_flag = IsCurrRef(DPB, RPL, numRefActive, DPB[i].POC);
+
+        rps.num_negative_pics += rps.pic[nRef].DeltaPocSX < 0;
+        rps.num_positive_pics += rps.pic[nRef].DeltaPocSX > 0;
+        nRef ++;
+    }
+
+    std::sort(rps.pic, rps.pic + nRef
+        , [](decltype(rps.pic[0]) l, decltype(rps.pic[0]) r) { return l.DeltaPocSX < r.DeltaPocSX; });
+    std::sort(rps.pic, rps.pic + rps.num_negative_pics
+        , [](decltype(rps.pic[0]) l, decltype(rps.pic[0]) r) { return l.DeltaPocSX > r.DeltaPocSX; });
+
+    for (i = 0; i < nRef; i ++)
+    {
+        mfxI16 prev  = (!i || i == rps.num_negative_pics) ? 0 : rps.pic[i-1].DeltaPocSX;
+        rps.pic[i].delta_poc_sx_minus1 = mfxU16(abs(rps.pic[i].DeltaPocSX - prev) - 1);
+    }
+}
+
+mfxU32 EstimateRpsBits(const STRPS* pSpsRps, mfxU8 nSet, const STRPS & rps, mfxU8 idx)
+{
+    auto NBitsUE = [](mfxU32 b) -> mfxU32
+    {
+        return CeilLog2(b + 2) * 2 - 1;
+    };
+    auto IsNotUsed = [](const STRPSPic& pic)
+    {
+        return !pic.used_by_curr_pic_flag;
+    };
+    auto AccNBitsDPoc = [&](mfxU32 x, const STRPSPic& pic)
+    {
+        return std::move(x) + NBitsUE(pic.delta_poc_sx_minus1) + 1;
+    };
+    mfxU32 n = (idx != 0);
+
+    if (!rps.inter_ref_pic_set_prediction_flag)
+    {
+        mfxU32 nPic = mfxU32(rps.num_negative_pics + rps.num_positive_pics);
+
+        n += NBitsUE(rps.num_negative_pics);
+        n += NBitsUE(rps.num_positive_pics);
+
+        return std::accumulate(rps.pic, rps.pic + nPic, n, AccNBitsDPoc);
+    }
+
+    assert(idx > rps.delta_idx_minus1);
+    STRPS const & ref = pSpsRps[idx - rps.delta_idx_minus1 - 1];
+    mfxU32 nPic = mfxU32(ref.num_negative_pics + ref.num_positive_pics);
+
+    if (idx == nSet)
+        n += NBitsUE(rps.delta_idx_minus1);
+
+    n += 1;
+    n += NBitsUE(rps.abs_delta_rps_minus1);
+    n += nPic;
+    n += mfxU32(std::count_if(rps.pic, rps.pic + nPic + 1, IsNotUsed));
+
+    return n;
+}
+
+bool GetInterRps(STRPS const & refRPS, STRPS& rps, mfxU8 dIdxMinus1)
+{
+    auto oldRPS = rps;
+    auto newRPS = oldRPS;
+    newRPS.inter_ref_pic_set_prediction_flag = 1;
+    newRPS.delta_idx_minus1 = dIdxMinus1;
+
+    std::list<mfxI16> dPocs[2];
+    auto AddDPoc = [&dPocs](mfxI16 dPoc)
+    {
+        if (dPoc)
+            dPocs[dPoc > 0].push_back(dPoc);
+    };
+
+    std::for_each(oldRPS.pic, oldRPS.pic + oldRPS.num_negative_pics + oldRPS.num_positive_pics
+        , [&](STRPSPic& oldPic)
+    {
+        AddDPoc(oldPic.DeltaPocSX);
+
+        std::for_each(refRPS.pic, refRPS.pic + refRPS.num_negative_pics + refRPS.num_positive_pics
+            , [&](const STRPSPic& refPic)
+        {
+            AddDPoc(oldPic.DeltaPocSX - refPic.DeltaPocSX);
+        });
+    });
+
+    dPocs[0].sort(std::greater<mfxI16>());
+    dPocs[1].sort(std::less<mfxI16>());
+    dPocs[0].unique();
+    dPocs[1].unique();
+
+    mfxI16 dPoc = 0;
+    bool bDPocFound = false;
+    auto NextDPock = [&]()
+    {
+        return ((!dPocs[0].empty() || !dPocs[1].empty()) && !bDPocFound);
+    };
+
+    while (NextDPock())
+    {
+        dPoc *= -1;
+        bool bPositive = (dPoc > 0 && !dPocs[1].empty()) || dPocs[0].empty();
+        dPoc = dPocs[bPositive].front();
+        dPocs[bPositive].pop_front();
+
+        std::for_each(newRPS.pic
+            , newRPS.pic + refRPS.num_negative_pics + refRPS.num_positive_pics + 1
+            , [&](STRPSPic& newPic)
+        {
+            newPic.used_by_curr_pic_flag = 0;
+            newPic.use_delta_flag = 0;
+        });
+
+        auto pOldPic = oldRPS.pic;
+        auto UseDelta = [&pOldPic, dPoc](STRPSPic& newPic, mfxI16 refDeltaPocSX, mfxI16 sign)
+        {
+            bool bUse =
+                ((pOldPic->DeltaPocSX * sign) > 0)
+                && ((pOldPic->DeltaPocSX - refDeltaPocSX) == dPoc);
+
+            newPic.used_by_curr_pic_flag =
+                (bUse && pOldPic->used_by_curr_pic_sx_flag)
+                || (!bUse && newPic.used_by_curr_pic_flag);
+            newPic.use_delta_flag = bUse || (!bUse && newPic.use_delta_flag);
+            pOldPic += bUse;
+        };
+
+        auto pRefPic = refRPS.pic + refRPS.num_negative_pics + refRPS.num_positive_pics - 1;
+
+        std::for_each(
+            MakeRIter(newRPS.pic + refRPS.num_negative_pics + refRPS.num_positive_pics)
+            , MakeRIter(newRPS.pic + refRPS.num_negative_pics)
+            , [&](STRPSPic& newPic)
+        {
+            UseDelta(newPic, pRefPic->DeltaPocSX, -1);
+            --pRefPic;
+        });
+
+        UseDelta(newRPS.pic[refRPS.num_negative_pics + refRPS.num_positive_pics], 0, (dPoc < 0) * -1);
+
+        pRefPic = refRPS.pic;
+
+        std::for_each(newRPS.pic, newRPS.pic + refRPS.num_negative_pics
+            , [&](STRPSPic& newPic)
+        {
+            UseDelta(newPic, pRefPic->DeltaPocSX, -1);
+            ++pRefPic;
+        });
+
+        if (pOldPic != (oldRPS.pic + oldRPS.num_negative_pics))
+            continue;
+
+        pRefPic = refRPS.pic + refRPS.num_negative_pics - 1;
+
+        std::for_each(
+            MakeRIter(newRPS.pic + refRPS.num_negative_pics)
+            , MakeRIter(newRPS.pic)
+            , [&](STRPSPic& newPic)
+        {
+            UseDelta(newPic, pRefPic->DeltaPocSX, +1);
+            --pRefPic;
+        });
+
+        UseDelta(newRPS.pic[refRPS.num_negative_pics + refRPS.num_positive_pics], 0, dPoc > 0);
+
+        pRefPic = refRPS.pic + refRPS.num_negative_pics;
+
+        std::for_each(
+            newRPS.pic + refRPS.num_negative_pics
+            , newRPS.pic + refRPS.num_negative_pics + refRPS.num_positive_pics
+            , [&](STRPSPic& newPic)
+        {
+            UseDelta(newPic, pRefPic->DeltaPocSX, +1);
+            ++pRefPic;
+        });
+
+        bDPocFound = (pOldPic == (oldRPS.pic + oldRPS.num_negative_pics + oldRPS.num_positive_pics));
+    }
+
+    newRPS.delta_rps_sign       = (dPoc < 0);
+    newRPS.abs_delta_rps_minus1 = mfxU16(abs(dPoc) - 1);
+
+    SetIf(rps, bDPocFound, newRPS);
+
+    return bDPocFound;
+}
+
+void OptimizeSTRPS(const STRPS* pSpsRps, mfxU8 n, STRPS& oldRPS, mfxU8 idx)
+{
+    auto  IsEnoughPics   = [&](const STRPS& refRPS)
+    {
+        return (refRPS.num_negative_pics + refRPS.num_positive_pics + 1)
+            < (oldRPS.num_negative_pics + oldRPS.num_positive_pics);
+    };
+    auto  itRBegin       = MakeRIter(pSpsRps + idx);
+    auto  itREnd         = MakeRIter(pSpsRps + ((idx < n && idx > 1) * (idx - 1)));
+    auto  itSearchRBegin = std::find_if_not(itRBegin, itREnd, IsEnoughPics);
+    mfxU8 dIdxMinus1     = mfxU8(std::distance(itRBegin, itSearchRBegin));
+    auto  UpdateRPS      = [&](const STRPS& refRPS)
+    {
+        STRPS newRPS = oldRPS;
+        bool bUpdateRps =
+            GetInterRps(refRPS, newRPS, dIdxMinus1++)
+            && (EstimateRpsBits(pSpsRps, n, newRPS, idx) < EstimateRpsBits(pSpsRps, n, oldRPS, idx));
+        SetIf(oldRPS, bUpdateRps, newRPS);
+    };
+    auto    itSearchREnd = itREnd;
+    bool    b1Ref = (idx < n) && (itSearchRBegin != itREnd);
+
+    SetIf(itSearchREnd, b1Ref, std::next(itSearchRBegin, b1Ref));
+    std::for_each(itSearchRBegin, itSearchREnd, UpdateRPS);
+}
+
+bool Equal(const STRPS & l, const STRPS & r)
+{
+    //ignore inter_ref_pic_set_prediction_flag, check only DeltaPocSX
+    auto IsSame = [](const STRPSPic & l, const STRPSPic & r)
+    {
+        return
+            l.DeltaPocSX == r.DeltaPocSX
+            && l.used_by_curr_pic_sx_flag == r.used_by_curr_pic_sx_flag;
+    };
+    auto nPic = l.num_negative_pics + l.num_positive_pics;
+
+    return
+        l.num_negative_pics == r.num_negative_pics
+        && l.num_positive_pics == r.num_positive_pics
+        && (std::mismatch(l.pic, l.pic + nPic, r.pic, IsSame) == std::make_pair(l.pic + nPic, r.pic + nPic));
+}
+
+void Legacy::SetSTRPS(
+    const Defaults::Param& dflts
+    , SPS& sps
+    , const Reorderer& reorder)
+{
+    std::list<StorageRW> frames;
+    auto&     par        = dflts.mvp;
+    STRPS     sets[65]   = {};
+    auto      pSetsBegin = sets;
+    auto      pSetsEnd   = pSetsBegin;
+    bool      bTL        = dflts.base.GetNumTemporalLayers(dflts) > 1;
+    mfxI32    nGops      = par.mfx.IdrInterval + !par.mfx.IdrInterval * 4;
+    mfxI32    stDist     = std::min<mfxI32>(par.mfx.GopPicSize * nGops, 128);
+    mfxI32    lastIPoc   = 0;
+    bool      bDone      = false;
+    mfxI32    i          = 0;
+    Reorderer localReorder;
+    DpbArray  dpb;
+
+    localReorder        = reorder;
+    localReorder.DPB    = &dpb; //use own DPB
+
+    do
+    {
+        {
+            FrameBaseInfo fi;
+            auto sts = dflts.base.GetPreReorderInfo(dflts, fi, nullptr, nullptr, 0, lastIPoc, mfxU32(i));
+            ThrowIf(!!sts, "failed at GetPreReorderInfo");
+
+            frames.push_back(StorageRW());
+            frames.back().Insert(Task::Common::Key, new FrameBaseInfo(fi));
+        }
+
+        auto frIt  = localReorder(frames.begin(), frames.end(), false);
+        bool bNext = frIt == frames.end();
+
+        FrameBaseInfo* cur = nullptr;
+        SetIf(cur, !bNext, [&]() { return &frIt->Write<FrameBaseInfo>(Task::Common::Key); });
+
+        bDone =
+            (i > 0 && !bNext && IsIdr(cur->FrameType))
+            || (!bNext && cur->POC >= stDist)
+            || (pSetsEnd + 1) >= std::end(sets);
+
+        bNext |= bDone;
+
+        if (!bNext)
+        {
+            RemoveIf(dpb, dpb + Size(dpb) * bTL
+                , [&](DpbFrame& ref)
+            {
+                return
+                    isValid(ref)
+                    && ref.TemporalID > 0
+                    && ref.TemporalID >= cur->TemporalID;
+            });
+
+            bool bIDR = IsIdr(cur->FrameType);
+            bool bI   = IsI(cur->FrameType);
+            bool bB   = IsB(cur->FrameType);
+            bool bP   = IsP(cur->FrameType);
+            bool bRef = IsRef(cur->FrameType);
+
+            if (!bIDR)
+            {
+                mfxU8 nRef[2] = {};
+                mfxU8 rpl[2][MAX_DPB_SIZE];
+
+                std::fill_n(rpl[0], Size(rpl[0]), IDX_INVALID);
+                std::fill_n(rpl[1], Size(rpl[1]), IDX_INVALID);
+
+                auto SetRPL = [&]()
+                {
+                    ConstructRPL(dflts, dpb, *cur, rpl, nRef);
+                    return true;
+                };
+
+                std::tie(nRef[0], nRef[1]) = dflts.base.GetFrameNumRefActive(dflts, *cur);
+
+                bool bRPL =
+                       (bB && nRef[0] && SetRPL())
+                    || (bP && nRef[0] && SetRPL())
+                    || (bI); //I picture is not using any refs, but saves them in RPS to be used by future pics.
+
+                ThrowAssert(!bRPL, "failed to construct RPL");
+
+                STRPS rps = {};
+                ConstructSTRPS(dpb, rpl, nRef, cur->POC, rps);
+
+                auto pCurSet = std::find_if(pSetsBegin, pSetsEnd
+                    , [&](const STRPS& x) { return Equal(x, rps); });
+
+                pSetsEnd += SetIf(*pCurSet, pSetsEnd == pCurSet, rps);
+                ++pCurSet->WeightInGop;
+            }
+
+            SetIf(lastIPoc, bI, cur->POC);
+
+            DpbFrame tmp;
+            (FrameBaseInfo&)tmp = *cur;
+            tmp.Rec.Idx += bRef;
+            ThrowAssert(bRef && !UpdateDPB(dflts, tmp, dpb), "failed to UpdateDPB");
+
+            frames.erase(frIt);
+        }
+
+        ++i;
+    } while (!bDone);
+
+    mfxU8 nSet         = mfxU8(std::distance(pSetsBegin, pSetsEnd));
+    auto  IsRpsOptimal = [&nSet, &par, pSetsBegin](const STRPS& curRps)
+    {
+        STRPS  rps   = curRps;
+        mfxU32 n     = curRps.WeightInGop; //current RPS used for N frames
+        //bits for RPS in SPS and SSHs
+        mfxU32 bits0 = 
+            EstimateRpsBits(pSetsBegin, nSet, rps, nSet - 1) //bits for RPS in SPS
+            + (CeilLog2(nSet) - CeilLog2(nSet - 1)) //diff of bits for STRPS num in SPS
+            + (nSet > 1) * (par.mfx.NumSlice * CeilLog2(nSet) * n); //bits for RPS idx in SSHs
+
+        //emulate removal of current RPS from SPS
+        --nSet;
+        rps.inter_ref_pic_set_prediction_flag = 0;
+        OptimizeSTRPS(pSetsBegin, nSet, rps, nSet);
+
+        //bits for RPS in SSHs (no RPS in SPS)
+        mfxU32 bits1 =
+            EstimateRpsBits(pSetsBegin, nSet, rps, nSet)
+            * par.mfx.NumSlice
+            * n;
+
+        return bits0 <= bits1;
+    };
+
+    std::sort(pSetsBegin, pSetsEnd
+        , [&](const STRPS& l, const STRPS& r) { return l.WeightInGop > r.WeightInGop; });
+
+    i = 0;
+    std::for_each(pSetsBegin, pSetsEnd
+        , [&](STRPS& sf) { OptimizeSTRPS(sets, nSet, sf, mfxU8(i++)); });
+    
+    auto ritLastRps = std::find_if(MakeRIter(pSetsEnd), MakeRIter(pSetsBegin), IsRpsOptimal);
+
+    sps.num_short_term_ref_pic_sets = mfxU8(std::distance(ritLastRps, MakeRIter(pSetsBegin)));
+    
+    std::copy_n(pSetsBegin, sps.num_short_term_ref_pic_sets, sps.strps);
+}
+
+mfxStatus Legacy::CheckSPS(const SPS& sps, const ENCODE_CAPS_HEVC& caps, eMFXHWType hw)
+{
+    MFX_CHECK_COND(
+           sps.log2_min_luma_coding_block_size_minus3 == 0
+        && sps.separate_colour_plane_flag == 0
+        && sps.pcm_enabled_flag == 0);
+
+    if (hw >= MFX_HW_CNL)
+    {
+        MFX_CHECK_COND(sps.amp_enabled_flag == 1);
+    }
+    else
+    {
+        MFX_CHECK_COND(sps.amp_enabled_flag == 0);
+        MFX_CHECK_COND(sps.sample_adaptive_offset_enabled_flag == 0);
+    }
+
+    MFX_CHECK_COND(
+      !(   (!caps.YUV444ReconSupport && (sps.chroma_format_idc == 3))
+        || (!caps.YUV422ReconSupport && (sps.chroma_format_idc == 2))
+        || (caps.Color420Only && (sps.chroma_format_idc != 1))));
+
+    MFX_CHECK_COND(
+      !(   sps.pic_width_in_luma_samples > caps.MaxPicWidth
+        || sps.pic_height_in_luma_samples > caps.MaxPicHeight));
+
+    MFX_CHECK_COND(
+      !(   (caps.MaxEncodedBitDepth == 0 || caps.BitDepth8Only)
+        && (sps.bit_depth_luma_minus8 != 0 || sps.bit_depth_chroma_minus8 != 0)));
+
+    MFX_CHECK_COND(
+      !(   (caps.MaxEncodedBitDepth == 2 || caps.MaxEncodedBitDepth == 1 || !caps.BitDepth8Only)
+        && ( !(sps.bit_depth_luma_minus8 == 0
+            || sps.bit_depth_luma_minus8 == 2
+            || sps.bit_depth_luma_minus8 == 4)
+          || !(sps.bit_depth_chroma_minus8 == 0
+            || sps.bit_depth_chroma_minus8 == 2
+            || sps.bit_depth_chroma_minus8 == 4))));
+
+    MFX_CHECK_COND(
+      !(   caps.MaxEncodedBitDepth == 2
+        && ( !(sps.bit_depth_luma_minus8 == 0
+            || sps.bit_depth_luma_minus8 == 2
+            || sps.bit_depth_luma_minus8 == 4)
+          || !(sps.bit_depth_chroma_minus8 == 0
+            || sps.bit_depth_chroma_minus8 == 2
+            || sps.bit_depth_chroma_minus8 == 4))));
+
+    MFX_CHECK_COND(
+      !(   caps.MaxEncodedBitDepth == 3
+        && ( !(sps.bit_depth_luma_minus8 == 0
+            || sps.bit_depth_luma_minus8 == 2
+            || sps.bit_depth_luma_minus8 == 4
+            || sps.bit_depth_luma_minus8 == 8)
+          || !(sps.bit_depth_chroma_minus8 == 0
+            || sps.bit_depth_chroma_minus8 == 2
+            || sps.bit_depth_chroma_minus8 == 4
+            || sps.bit_depth_chroma_minus8 == 8))));
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckPPS(const PPS& pps, const ENCODE_CAPS_HEVC& caps, eMFXHWType /*hw*/)
+{
+    if (pps.tiles_enabled_flag)
+    {
+        MFX_CHECK_COND(pps.loop_filter_across_tiles_enabled_flag);
+    }
+
+    MFX_CHECK_COND(!((mfxU32)(((pps.num_tile_columns_minus1 + 1) * (pps.num_tile_rows_minus1 + 1)) > 1) > caps.TileSupport));
+
+    return MFX_ERR_NONE;
+}
+
+void SetDefaultFormat(
+    mfxVideoParam& par
+    , const Defaults::Param& defPar
+    , mfxExtCodingOption3* pCO3)
+{
+    auto& fi = par.mfx.FrameInfo;
+
+    assert(fi.FourCC);
+
+    SetDefault(fi.BitDepthLuma, [&]() { return defPar.base.GetMaxBitDepth(defPar); });
+    SetDefault(fi.BitDepthChroma, fi.BitDepthLuma);
+
+    if (pCO3)
+    {
+        pCO3->TargetChromaFormatPlus1 = defPar.base.GetTargetChromaFormat(defPar);
+        pCO3->TargetBitDepthLuma = defPar.base.GetTargetBitDepthLuma(defPar);
+        SetDefault(pCO3->TargetBitDepthChroma, pCO3->TargetBitDepthLuma);
+    }
+}
+
+void SetDefaultSize(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar
+    , mfxExtHEVCParam* pHEVC)
+{
+    auto& fi = par.mfx.FrameInfo;
+    mfxU16 PicWidthInLumaSamples = defPar.base.GetCodedPicWidth(defPar);
+    mfxU16 PicHeightInLumaSamples = defPar.base.GetCodedPicHeight(defPar);
+
+    if (pHEVC)
+    {
+        SetDefault(pHEVC->PicWidthInLumaSamples, PicWidthInLumaSamples);
+        SetDefault(pHEVC->PicHeightInLumaSamples, PicHeightInLumaSamples);
+    }
+
+    SetDefault(fi.CropW, mfxU16(PicWidthInLumaSamples - fi.CropX));
+    SetDefault(fi.CropH, mfxU16(PicHeightInLumaSamples - fi.CropY));
+    SetDefault(fi.AspectRatioW, mfxU16(1));
+    SetDefault(fi.AspectRatioH, mfxU16(1));
+
+    std::tie(fi.FrameRateExtN, fi.FrameRateExtD) = defPar.base.GetFrameRate(defPar);
+}
+
+void SetDefaultGOP(
+    mfxVideoParam& par
+    , const Defaults::Param& defPar
+    , mfxExtCodingOption2* pCO2
+    , mfxExtCodingOption3* pCO3)
+{
+    par.mfx.GopPicSize = defPar.base.GetGopPicSize(defPar);
+    par.mfx.GopRefDist = defPar.base.GetGopRefDist(defPar);
+
+    SetIf(pCO2->BRefType, pCO2 && !pCO2->BRefType, [&]() { return defPar.base.GetBRefType(defPar); });
+    SetIf(pCO3->PRefType, pCO3 && !pCO3->PRefType, [&]() { return defPar.base.GetPRefType(defPar); });
+
+    par.mfx.NumRefFrame = defPar.base.GetNumRefFrames(defPar);
+
+    if (pCO3)
+    {
+        SetDefault<mfxU16>(pCO3->GPB, MFX_CODINGOPTION_ON);
+
+        defPar.base.GetNumRefActive(
+            defPar
+            , &pCO3->NumRefActiveP
+            , &pCO3->NumRefActiveBL0
+            , &pCO3->NumRefActiveBL1);
+    }
+}
+
+void SetDefaultBRC(
+    mfxVideoParam& par
+    , const Defaults::Param& defPar
+    , mfxExtCodingOption2* pCO2
+    , mfxExtCodingOption3* pCO3)
+{
+    par.mfx.RateControlMethod = defPar.base.GetRateControlMethod(defPar);
+    BufferSizeInKB(par.mfx) = defPar.base.GetBufferSizeInKB(defPar);
+
+    if (pCO2)
+        pCO2->MBBRC = defPar.base.GetMBBRC(defPar);
+
+    bool bSetQP = par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+        && !(par.mfx.QPI && par.mfx.QPP && par.mfx.QPB);
+    bool bSetRCPar = (par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_VCM
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT);
+    bool bSetICQ  = (par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ);
+    bool bSetQVBR = (par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR && pCO3);
+
+    if (bSetQP)
+    {
+        std::tie(par.mfx.QPI, par.mfx.QPP, par.mfx.QPB) = defPar.base.GetQPMFX(defPar);
+    }
+
+    if (bSetRCPar)
+    {
+        TargetKbps(par.mfx) = defPar.base.GetTargetKbps(defPar);
+        SetDefault<mfxU16>(par.mfx.MaxKbps, par.mfx.TargetKbps);
+        SetDefault<mfxU16>(par.mfx.InitialDelayInKB
+            , par.mfx.BufferSizeInKB * (2 + (par.mfx.RateControlMethod == MFX_RATECONTROL_VBR && Legacy::IsSWBRC(par, ExtBuffer::Get(par)))) / 4);
+    }
+
+    if (bSetICQ)
+        SetDefault<mfxU16>(par.mfx.ICQQuality, 26);
+
+    if (bSetQVBR)
+        SetDefault<mfxU16>(pCO3->QVBRQuality, 26);
+
+    if (pCO3)
+    {
+        SetDefault<mfxU16>(pCO3->LowDelayBRC, MFX_CODINGOPTION_OFF);
+
+        pCO3->EnableQPOffset = defPar.base.GetQPOffset(defPar, &pCO3->QPOffset);
+
+        SetDefault<mfxU16>(pCO3->EnableMBQP
+            , Bool2CO(
+              !(   par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+                || Legacy::IsSWBRC(par, pCO2)
+                || !defPar.caps.MbQpDataSupport)));
+
+        bool bSetWinBRC = pCO3->WinBRCSize || pCO3->WinBRCMaxAvgKbps;
+
+        if (bSetWinBRC)
+        {
+            SetDefault<mfxU16>(pCO3->WinBRCSize
+                , (mfxU16)CeilDiv(par.mfx.FrameInfo.FrameRateExtN, par.mfx.FrameInfo.FrameRateExtD));
+            SetDefault<mfxU16>(pCO3->WinBRCMaxAvgKbps, par.mfx.MaxKbps);
+        }
+
+        SetDefault<mfxU16>(pCO3->BRCPanicMode, Bool2CO(defPar.caps.HRDConformanceSupport));
+    }
+}
+
+void SetDefaultEsOptions(
+    mfxVideoParam& par
+    , const Defaults::Param& defPar
+    , mfxExtHEVCParam* pHEVC
+    , mfxExtCodingOption* pCO
+    , mfxExtCodingOption2* pCO2
+    , mfxExtCodingOption3* pCO3)
+{
+    if (pCO)
+    {
+        bool bHRDConformance = defPar.base.GetHRDConformanceON(defPar);
+
+        SetDefault(pCO->NalHrdConformance, Bool2CO(bHRDConformance));
+        SetDefault(pCO->VuiNalHrdParameters, Bool2CO(bHRDConformance));
+        SetDefault(pCO->AUDelimiter, mfxU16(MFX_CODINGOPTION_OFF));
+
+        pCO->PicTimingSEI = defPar.base.GetPicTimingSEI(defPar);
+    }
+
+    if (pCO2)
+        SetDefault(pCO2->RepeatPPS, mfxU16(MFX_CODINGOPTION_OFF));
+
+    if (pCO3)
+    {
+        SetDefault(pCO3->TransformSkip, mfxU16(MFX_CODINGOPTION_ON * (defPar.hw >= MFX_HW_ICL)));
+        SetDefault(pCO3->TransformSkip, mfxU16(MFX_CODINGOPTION_OFF));
+        SetDefault(pCO3->EnableNalUnitType, Bool2CO(!!par.mfx.EncodedOrder));
+    }
+
+    if (pHEVC)
+    {
+        bool bNoSAO =
+            SetDefault(pHEVC->SampleAdaptiveOffset, mfxU16(MFX_SAO_ENABLE_LUMA | MFX_SAO_ENABLE_CHROMA))
+            && defPar.base.CheckSAO(defPar, par);
+
+        pHEVC->SampleAdaptiveOffset *= !bNoSAO;
+        SetDefault(pHEVC->SampleAdaptiveOffset, mfxU16(MFX_SAO_DISABLE));
+    }
+}
+
+void Legacy::SetDefaults(
+    mfxVideoParam& par
+    , const Defaults::Param& defPar
+    , bool bExternalFrameAllocator)
+{
+    auto&                    fi            = par.mfx.FrameInfo;
+    mfxExtHEVCParam*         pHEVC         = ExtBuffer::Get(par);
+    mfxExtHEVCTiles*         pTile         = ExtBuffer::Get(par);
+    mfxExtAvcTemporalLayers* pTL           = ExtBuffer::Get(par);
+    mfxExtCodingOption*      pCO           = ExtBuffer::Get(par);
+    mfxExtCodingOption2*     pCO2          = ExtBuffer::Get(par);
+    mfxExtCodingOption3*     pCO3          = ExtBuffer::Get(par);
+    mfxU16                   IOPByAlctr[2] = { MFX_IOPATTERN_IN_SYSTEM_MEMORY, MFX_IOPATTERN_IN_VIDEO_MEMORY };
+    auto GetNumSlices = [&]()
+    {
+        std::vector<SliceInfo> slices;
+        return defPar.base.GetSlices(defPar, slices);
+    };
+    auto GetDefaultLevel = [&]()
+    {
+        mfxU16 nCol, nRow;
+        std::tie(nCol, nRow) = defPar.base.GetNumTiles(defPar);
+
+        return GetMinLevel(
+            fi.FrameRateExtN
+            , fi.FrameRateExtD
+            , defPar.base.GetCodedPicWidth(defPar)
+            , defPar.base.GetCodedPicHeight(defPar)
+            , par.mfx.NumRefFrame
+            , nCol
+            , nRow
+            , par.mfx.NumSlice
+            , BufferSizeInKB(par.mfx)
+            , MaxKbps(par.mfx)
+            , MFX_LEVEL_HEVC_1);
+    };
+
+    if (pHEVC)
+    {
+        pHEVC->LCUSize = defPar.base.GetLCUSize(defPar);
+    }
+
+    SetDefaultFormat(par, defPar, pCO3);
+    SetDefault(par.mfx.CodecProfile, defPar.base.GetProfile(defPar));
+    SetDefault(par.AsyncDepth, defPar.base.GetAsyncDepth(defPar));
+    SetDefault(par.IOPattern, IOPByAlctr[!!bExternalFrameAllocator]);
+    SetDefault(par.mfx.TargetUsage, mfxU16(4)) && CheckTU(par, defPar.caps);
+
+    if (pTile)
+    {
+        std::tie(pTile->NumTileColumns, pTile->NumTileRows) = defPar.base.GetNumTiles(defPar);
+    }
+
+    SetDefault(par.mfx.NumSlice, GetNumSlices);
+
+    SetDefaultSize(par, defPar, pHEVC);
+    SetDefaultGOP(par, defPar, pCO2, pCO3);
+    SetDefaultBRC(par, defPar, pCO2, pCO3);
+
+    if (pTL)
+    {
+        SetDefault(pTL->Layer[0].Scale, mfxU16(1));
+    }
+
+    SetDefault(par.mfx.CodecLevel, GetDefaultLevel);
+
+    SetDefaultEsOptions(par, defPar, pHEVC, pCO, pCO2, pCO3);
+
+    if (pCO2)
+    {
+        auto minQP = defPar.base.GetMinQPMFX(defPar);
+        auto maxQP = defPar.base.GetMaxQPMFX(defPar);
+
+        SetDefault(pCO2->IntRefCycleSize, mfxU16(CeilDiv(fi.FrameRateExtN, fi.FrameRateExtD) * !!pCO2->IntRefType));
+
+        SetDefault(pCO2->MinQPI, minQP);
+        SetDefault(pCO2->MinQPP, minQP);
+        SetDefault(pCO2->MinQPB, minQP);
+        SetDefault(pCO2->MaxQPI, maxQP);
+        SetDefault(pCO2->MaxQPP, maxQP);
+        SetDefault(pCO2->MaxQPB, maxQP);
+    }
+
+    bool bSetConstr = pHEVC && (par.mfx.CodecProfile >= MFX_PROFILE_HEVC_REXT && !pHEVC->GeneralConstraintFlags);
+
+    if (bSetConstr)
+    {
+        auto& constr = pHEVC->GeneralConstraintFlags;
+        mfxU16 bdY = defPar.base.GetTargetBitDepthLuma(defPar);
+        mfxU16 cf = defPar.base.GetTargetChromaFormat(defPar) - 1;
+
+        constr |= MFX_HEVC_CONSTR_REXT_MAX_422CHROMA * (cf <= MFX_CHROMAFORMAT_YUV422);
+        constr |= MFX_HEVC_CONSTR_REXT_MAX_420CHROMA * (cf <= MFX_CHROMAFORMAT_YUV420);
+        constr |= MFX_HEVC_CONSTR_REXT_MAX_12BIT * (bdY <= 12);
+        constr |= MFX_HEVC_CONSTR_REXT_MAX_10BIT * (bdY <= 10);
+        //there is no Main 4:2:2 in current standard spec.(2016/12), only Main 4:2:2 10
+        constr |= MFX_HEVC_CONSTR_REXT_MAX_8BIT * (bdY <= 8 && (cf != MFX_CHROMAFORMAT_YUV422));
+        constr |= MFX_HEVC_CONSTR_REXT_LOWER_BIT_RATE;
+    }
+}
+
+mfxStatus Legacy::CheckLevelConstraints(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    MFX_CHECK(par.mfx.CodecLevel, MFX_ERR_NONE);
+
+    mfxU16 PicWidthInLumaSamples    = defPar.base.GetCodedPicWidth(defPar);
+    mfxU16 PicHeightInLumaSamples   = defPar.base.GetCodedPicHeight(defPar);
+    mfxU16 MinRef                   = defPar.base.GetNumRefFrames(defPar);
+    mfxU32 NumSlice                 = defPar.base.GetNumSlices(defPar);
+    mfxU32 BufferSizeInKB           = defPar.base.GetBufferSizeInKB(defPar);
+    mfxU32 MaxKbps                  = 0;
+    mfxU16 rc                       = defPar.base.GetRateControlMethod(defPar);
+    auto   tiles                    = defPar.base.GetNumTiles(defPar);
+    auto   frND                     = defPar.base.GetFrameRate(defPar);
+
+    SetIf(MaxKbps
+        , rc != MFX_RATECONTROL_CQP && rc != MFX_RATECONTROL_ICQ
+        , [&]() { return defPar.base.GetMaxKbps(defPar); });
+
+    mfxU16 minLevel = GetMinLevel(
+          std::get<0>(frND)
+        , std::get<1>(frND)
+        , PicWidthInLumaSamples
+        , PicHeightInLumaSamples
+        , MinRef
+        , std::get<0>(tiles)
+        , std::get<1>(tiles)
+        , NumSlice
+        , BufferSizeInKB
+        , MaxKbps
+        , par.mfx.CodecLevel);
+
+    MFX_CHECK(!CheckMinOrClip(par.mfx.CodecLevel, minLevel), MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckESPackParam(mfxVideoParam & par, eMFXHWType hw)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption*     pCO = ExtBuffer::Get(par);
+    mfxExtCodingOption2*    pCO2 = ExtBuffer::Get(par);
+    mfxExtCodingOption3*    pCO3 = ExtBuffer::Get(par);
+    mfxExtVideoSignalInfo*  pVSI = ExtBuffer::Get(par);
+
+    if (pCO)
+    {
+        bool bNoHRD = par.mfx.RateControlMethod != MFX_RATECONTROL_CBR
+            && par.mfx.RateControlMethod != MFX_RATECONTROL_VBR
+            && par.mfx.RateControlMethod != MFX_RATECONTROL_VCM
+            && par.mfx.RateControlMethod != MFX_RATECONTROL_QVBR;
+
+        changed += CheckOrZero<mfxU16>(
+            pCO->NalHrdConformance
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !bNoHRD));
+
+        changed += CheckOrZero<mfxU16>(
+            pCO->VuiNalHrdParameters
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !(bNoHRD || IsOff(pCO->NalHrdConformance))));
+
+        changed += CheckTriStateOrZero(pCO->PicTimingSEI);
+        changed += CheckTriStateOrZero(pCO->AUDelimiter);
+    }
+
+    if (pCO2)
+        changed += CheckTriStateOrZero(pCO2->RepeatPPS);
+
+    if (pVSI)
+    {
+        changed += CheckRangeOrSetDefault<mfxU16>(pVSI->VideoFormat, 0, 8, 5);
+        changed += CheckRangeOrSetDefault<mfxU16>(pVSI->ColourPrimaries, 0, 255, 2);
+        changed += CheckRangeOrSetDefault<mfxU16>(pVSI->TransferCharacteristics, 0, 255, 2);
+        changed += CheckRangeOrSetDefault<mfxU16>(pVSI->MatrixCoefficients, 0, 255, 2);
+        changed += CheckOrZero<mfxU16, 0, 1>(pVSI->VideoFullRange);
+        changed += CheckOrZero<mfxU16, 0, 1>(pVSI->ColourDescriptionPresent);
+    }
+
+    if (pCO3)
+    {
+        changed += CheckOrZero<mfxU16>(
+            pCO3->TransformSkip
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * (hw >= MFX_HW_CNL)));
+
+        changed += CheckOrZero<mfxU16>(
+            pCO3->EnableNalUnitType
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !!par.mfx.EncodedOrder));
+
+#if MFX_VERSION >= MFX_VERSION_NEXT
+        changed += CheckRangeOrSetDefault<mfxI16>(pCO3->DeblockingAlphaTcOffset, -12, 12, 0);
+        changed += CheckRangeOrSetDefault<mfxI16>(pCO3->DeblockingBetaOffset, -12, 12, 0);
+#endif
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckGPB(mfxVideoParam & par)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    if (pCO3)
+    {
+        changed += CheckOrZero<mfxU16>(
+            pCO3->GPB
+            , mfxU16(MFX_CODINGOPTION_ON)
+            , mfxU16(MFX_CODINGOPTION_OFF * !!m_pQWCDefaults->caps.msdk.PSliceSupport)
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN));
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckSkipFrame(mfxVideoParam & par)
+{
+    mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+
+    if (pCO2 && CheckOrZero<mfxU16
+        , MFX_SKIPFRAME_NO_SKIP
+        , MFX_SKIPFRAME_INSERT_DUMMY
+        , MFX_SKIPFRAME_INSERT_NOTHING>
+        (pCO2->SkipFrame))
+        return MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckIntraRefresh(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxStatus sts = MFX_ERR_NONE;
+    mfxU32 changed = 0;
+    mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    if (pCO2)
+    {
+        MFX_CHECK_NO_RET(
+            !CheckMaxOrClip(pCO2->IntRefType, MFX_REFRESH_HORIZONTAL)
+            , sts, MFX_ERR_UNSUPPORTED);
+
+        MFX_CHECK_NO_RET(
+            defPar.caps.RollingIntraRefresh
+            || !CheckOrZero<mfxU16>(pCO2->IntRefType, MFX_REFRESH_NO)
+            , sts, MFX_ERR_UNSUPPORTED);
+
+        MFX_CHECK_NO_RET(
+            defPar.caps.RollingIntraRefresh
+            || !CheckOrZero<mfxU16>(pCO2->IntRefCycleSize, 0)
+            , sts, MFX_ERR_UNSUPPORTED);
+
+        MFX_CHECK_NO_RET(
+            defPar.caps.RollingIntraRefresh
+            || !pCO3
+            || !CheckOrZero<mfxU16>(pCO3->IntRefCycleDist, 0)
+            , sts, MFX_ERR_UNSUPPORTED);
+
+        // refresh cycle length shouldn't be greater or equal to GOP size
+        bool bInvalidCycle =
+            pCO2->IntRefCycleSize != 0
+            && par.mfx.GopPicSize != 0
+            && pCO2->IntRefCycleSize >= par.mfx.GopPicSize;
+
+        pCO2->IntRefType *= !bInvalidCycle;
+        pCO2->IntRefCycleSize *= !bInvalidCycle;
+        changed += bInvalidCycle;
+
+        // refresh period shouldn't be greater than refresh cycle size
+        bool bInvalidDist =
+            pCO3
+            && pCO3->IntRefCycleDist != 0
+            && pCO2->IntRefCycleSize != 0
+            && pCO2->IntRefCycleSize > pCO3->IntRefCycleDist;
+
+        if (bInvalidDist)
+        {
+            pCO3->IntRefCycleDist = 0;
+            ++changed;
+        }
+
+        mfxI16 qpDiff = defPar.base.GetMaxQPMFX(defPar) - defPar.base.GetMinQPMFX(defPar);
+
+        changed += CheckRangeOrSetDefault(pCO2->IntRefQPDelta, mfxI16(-qpDiff), qpDiff, mfxI16(0));
+    }
+    MFX_CHECK_STS(sts);
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckTemporalLayers(mfxVideoParam & par)
+{
+    mfxU32 changed = 0;
+    mfxExtAvcTemporalLayers* pTL = ExtBuffer::Get(par);
+
+    MFX_CHECK(pTL, MFX_ERR_NONE);
+    MFX_CHECK(!CheckOrZero<mfxU16>(pTL->Layer[0].Scale, 0, 1), MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(!CheckOrZero<mfxU16>(pTL->Layer[7].Scale, 0), MFX_ERR_UNSUPPORTED);
+
+    mfxU16 nTL = 1;
+
+    for (mfxU16 i = 1, prev = 0; i < 7; ++i)
+    {
+        if (!pTL->Layer[i].Scale)
+            continue;
+
+        auto& scaleCurr = pTL->Layer[i].Scale;
+        auto  scalePrev = pTL->Layer[prev].Scale;
+
+        MFX_CHECK(!CheckMinOrZero(scaleCurr, scalePrev + 1), MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(!CheckOrZero(scaleCurr, mfxU16(scaleCurr - (scaleCurr % scalePrev))), MFX_ERR_UNSUPPORTED);
+
+        prev = i;
+        ++nTL;
+    }
+
+    changed += CheckOrZero<mfxU16>(par.mfx.GopRefDist, 0, 1, par.mfx.GopRefDist * (nTL <= 1));
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckPPyramid(mfxVideoParam & par)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    if (pCO3)
+    {
+        changed += CheckOrZero<mfxU16
+            , MFX_P_REF_DEFAULT
+            , MFX_P_REF_SIMPLE
+            , MFX_P_REF_PYRAMID>
+            (pCO3->PRefType);
+
+        if (pCO3->PRefType == MFX_P_REF_PYRAMID && par.mfx.GopRefDist > 1)
+        {
+            pCO3->PRefType = MFX_P_REF_DEFAULT;
+            changed++;
+        }
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckBPyramid(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+
+    if (pCO2)
+    {
+        mfxU16 minRefForPyramid = 3;
+
+        if (par.mfx.GopRefDist)
+            minRefForPyramid = defPar.base.GetMinRefForBPyramid(defPar);
+
+        bool bNoBPyramid =
+            par.mfx.GopRefDist > 0
+            && (   par.mfx.GopRefDist < 2
+                || minRefForPyramid > 16
+                || (par.mfx.NumRefFrame
+                    && (minRefForPyramid > par.mfx.NumRefFrame)
+                    && !defPar.base.GetNonStdReordering(defPar)));
+
+        changed += CheckOrZero(pCO2->BRefType
+            , mfxU16(MFX_B_REF_UNKNOWN)
+            , mfxU16(MFX_B_REF_OFF)
+            , mfxU16(MFX_B_REF_PYRAMID * !bNoBPyramid));
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckSlices(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+    bool bCheckNMB = pCO2 && pCO2->NumMbPerSlice;
+
+    if (bCheckNMB)
+    {
+        auto   tiles            = defPar.base.GetNumTiles(defPar);
+        mfxU16 W                = defPar.base.GetCodedPicWidth(defPar);
+        mfxU16 H                = defPar.base.GetCodedPicHeight(defPar);
+        mfxU16 LCUSize          = defPar.base.GetLCUSize(defPar);
+        mfxU32 nLCU             = CeilDiv(W, LCUSize) * CeilDiv(H, LCUSize);
+        mfxU32 nTile            = std::get<0>(tiles) * std::get<1>(tiles);
+        mfxU32 maxSlicesPerTile = MAX_SLICES / nTile;
+        mfxU32 maxSlicesTotal   = maxSlicesPerTile * nTile;
+        mfxU32 maxNumMbPerSlice = CeilDiv(nLCU, nTile);
+        mfxU32 minNumMbPerSlice = CeilDiv(nLCU, maxSlicesTotal);
+
+        changed += CheckMinOrClip(pCO2->NumMbPerSlice, minNumMbPerSlice);
+        changed += CheckMaxOrClip(pCO2->NumMbPerSlice, maxNumMbPerSlice);
+    }
+
+    std::vector<SliceInfo> slices;
+
+    changed += CheckOrZero(par.mfx.NumSlice, defPar.base.GetSlices(defPar, slices), 0);
+
+    if (bCheckNMB)
+    {
+        auto itMaxSlice = std::max_element(slices.begin(), slices.end()
+            , [](SliceInfo a, SliceInfo b){ return a.NumLCU < b.NumLCU; });
+        changed += CheckMinOrClip(pCO2->NumMbPerSlice, itMaxSlice->NumLCU);
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckNumRefFrame(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxU32 changed = 0;
+
+    changed += CheckMaxOrClip(par.mfx.NumRefFrame, defPar.base.GetMaxDPB(defPar) - 1);
+    changed += SetIf(
+        par.mfx.NumRefFrame
+        , (par.mfx.GopRefDist > 1
+            && par.mfx.NumRefFrame == 1
+            && !defPar.base.GetNonStdReordering(defPar))
+        , defPar.base.GetMinRefForBNoPyramid(defPar));
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckFrameRate(mfxVideoParam & par)
+{
+    auto& fi = par.mfx.FrameInfo;
+
+    if (fi.FrameRateExtN && fi.FrameRateExtD) // FR <= 300
+    {
+        if (fi.FrameRateExtN > mfxU32(300 * fi.FrameRateExtD))
+        {
+            fi.FrameRateExtN = fi.FrameRateExtD = 0;
+            return MFX_ERR_UNSUPPORTED;
+        }
+    }
+
+    if ((fi.FrameRateExtN == 0) != (fi.FrameRateExtD == 0))
+    {
+        fi.FrameRateExtN = 0;
+        fi.FrameRateExtD = 0;
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+bool Legacy::IsInVideoMem(const mfxVideoParam & par, const mfxExtOpaqueSurfaceAlloc* pOSA)
+{
+    if (par.IOPattern == MFX_IOPATTERN_IN_VIDEO_MEMORY)
+        return true;
+
+    if (par.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY)
+        return (!pOSA || (pOSA->In.Type & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET)));
+
+    return false;
+}
+
+mfxStatus Legacy::CheckShift(mfxVideoParam & par, mfxExtOpaqueSurfaceAlloc* pOSA)
+{
+    auto& fi = par.mfx.FrameInfo;
+    bool bVideoMem = IsInVideoMem(par, pOSA);
+
+    if (bVideoMem && !fi.Shift)
+    {
+        if (fi.FourCC == MFX_FOURCC_P010 || fi.FourCC == MFX_FOURCC_P210)
+        {
+            fi.Shift = 1;
+            return MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+        }
+    }
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckCrops(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxU32 changed = 0;
+
+    auto W = defPar.base.GetCodedPicWidth(defPar);
+    auto H = defPar.base.GetCodedPicHeight(defPar);
+    auto& fi = par.mfx.FrameInfo;
+
+    changed += CheckMaxOrClip(fi.CropX, W);
+    changed += CheckMaxOrClip(fi.CropW, W - fi.CropX);
+    changed += CheckMaxOrClip(fi.CropY, H);
+    changed += CheckMaxOrClip(fi.CropH, H - fi.CropY);
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+bool Legacy::IsSWBRC(mfxVideoParam const & par, const mfxExtCodingOption2* pCO2)
+{
+    return
+        (      pCO2 && IsOn(pCO2->ExtBRC)
+            && (   par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+                || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR))
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT;
+}
+
+bool CheckBufferSizeInKB(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar
+    , mfxU16 bd)
+{
+    mfxU32 changed = 0;
+    auto W = defPar.base.GetCodedPicWidth(defPar);
+    auto H = defPar.base.GetCodedPicHeight(defPar);
+    mfxU16 cf = defPar.base.GetTargetChromaFormat(defPar) - 1;
+
+    mfxU32 rawBytes = Legacy::GetRawBytes(W, H, cf, bd) / 1000;
+
+    bool bCqpOrIcq =
+        par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ;
+
+    bool bSetToRaw = bCqpOrIcq && BufferSizeInKB(par.mfx) < rawBytes;
+
+    if (bSetToRaw)
+    {
+        BufferSizeInKB(par.mfx) = rawBytes;
+        changed++;
+    }
+    else if (!bCqpOrIcq)
+    {
+        mfxU32 frN, frD;
+
+        std::tie(frN, frD) = defPar.base.GetFrameRate(defPar);
+        mfxU32 avgFS = Ceil((mfxF64)TargetKbps(par.mfx) * frD / frN / 8);
+
+        if (BufferSizeInKB(par.mfx) < avgFS * 2 + 1)
+        {
+            BufferSizeInKB(par.mfx) = avgFS * 2 + 1;
+            changed++;
+        }
+
+        if (par.mfx.CodecLevel)
+        {
+            mfxU32 maxCPB = GetMaxCpbInKBByLevel(par);
+
+            if (BufferSizeInKB(par.mfx) > maxCPB)
+            {
+                BufferSizeInKB(par.mfx) = maxCPB;
+                changed++;
+            }
+        }
+    }
+
+    return !!changed;
+}
+
+mfxStatus Legacy::CheckBRC(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxU32 changed = 0;
+    mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR)
+    {
+        par.mfx.RateControlMethod = MFX_RATECONTROL_VBR;
+        par.mfx.Accuracy          = 0;
+        par.mfx.Convergence       = 0;
+        changed++;
+    }
+
+    MFX_CHECK(!CheckOrZero<mfxU16>(par.mfx.RateControlMethod
+        , 0
+        , !!defPar.caps.msdk.CBRSupport * MFX_RATECONTROL_CBR
+        , !!defPar.caps.msdk.VBRSupport * MFX_RATECONTROL_VBR
+        , !!defPar.caps.msdk.CQPSupport * MFX_RATECONTROL_CQP
+        , MFX_RATECONTROL_LA_EXT
+        , !!defPar.caps.msdk.ICQSupport * MFX_RATECONTROL_ICQ
+        , !!defPar.caps.VCMBitRateControl * MFX_RATECONTROL_VCM
+        , !!defPar.caps.QVBRBRCSupport * MFX_RATECONTROL_QVBR), MFX_ERR_UNSUPPORTED);
+
+    MFX_CHECK(par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ
+        || !CheckMaxOrZero(par.mfx.ICQQuality, 51), MFX_ERR_UNSUPPORTED);
+
+    changed += ((   par.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+                 || par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR
+                 || par.mfx.RateControlMethod == MFX_RATECONTROL_VCM)
+                && par.mfx.MaxKbps != 0
+                && par.mfx.TargetKbps != 0)
+        && CheckMinOrClip(par.mfx.MaxKbps, par.mfx.TargetKbps)
+        && CheckMaxOrClip(par.mfx.TargetKbps, par.mfx.MaxKbps);
+
+    auto bd = defPar.base.GetTargetBitDepthLuma(defPar);
+    auto minQP = defPar.base.GetMinQPMFX(defPar);
+    auto maxQP = defPar.base.GetMaxQPMFX(defPar);
+
+    if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP)
+    {
+        changed += CheckMinOrClip<mfxU16>(par.mfx.QPI, minQP);
+        changed += CheckMaxOrClip<mfxU16>(par.mfx.QPI, maxQP);
+        changed += CheckMinOrClip<mfxU16>(par.mfx.QPP, minQP);
+        changed += CheckMaxOrClip<mfxU16>(par.mfx.QPP, maxQP);
+        changed += CheckMinOrClip<mfxU16>(par.mfx.QPB, minQP);
+        changed += CheckMaxOrClip<mfxU16>(par.mfx.QPB, maxQP);
+
+        changed += !par.mfx.QPI && (par.mfx.QPP || par.mfx.QPB);
+        par.mfx.QPP *= !!par.mfx.QPI;
+        par.mfx.QPB *= !!par.mfx.QPI;
+    }
+
+    changed += par.mfx.BufferSizeInKB && CheckBufferSizeInKB(par, defPar, bd);
+    
+    if (pCO3)
+    {
+        MFX_CHECK(par.mfx.RateControlMethod != MFX_RATECONTROL_QVBR
+            || !CheckMaxOrZero(pCO3->QVBRQuality, 51), MFX_ERR_UNSUPPORTED);
+
+        auto    GopRefDist  = defPar.base.GetGopRefDist(defPar);
+        mfxU16  QPPB[2]     = { par.mfx.QPP, par.mfx.QPB };
+        mfxI16  QPX         = QPPB[GopRefDist != 1] * (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP);
+        bool    bNoQpOffset = (par.mfx.RateControlMethod != MFX_RATECONTROL_CQP)
+            || (GopRefDist > 1 && defPar.base.GetBRefType(defPar) == MFX_B_REF_OFF)
+            || (GopRefDist == 1 && defPar.base.GetPRefType(defPar) == MFX_P_REF_SIMPLE);
+
+        changed += CheckOrZero<mfxU16>(pCO3->EnableQPOffset
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !bNoQpOffset));
+
+        auto CheckQPOffset = [&](mfxI16& QPO)
+        {
+            return
+                CheckMinOrClip(QPO, minQP - QPX)
+                + CheckMaxOrClip(QPO, maxQP - QPX);
+        };
+
+        changed +=
+            IsOn(pCO3->EnableQPOffset)
+            && QPX
+            && std::count_if(std::begin(pCO3->QPOffset), std::end(pCO3->QPOffset), CheckQPOffset);
+
+        changed += CheckOrZero(pCO3->EnableMBQP
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !!(defPar.caps.MbQpDataSupport)));
+
+        auto sts = defPar.base.CheckWinBRC(defPar, par);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        changed += (sts > MFX_ERR_NONE);
+
+        changed += CheckOrZero(pCO3->BRCPanicMode
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * !!(defPar.caps.HRDConformanceSupport)));
+    }
+
+    if (pCO2)
+    {
+        changed += CheckTriStateOrZero(pCO2->MBBRC);
+        changed += (   defPar.caps.MBBRCSupport == 0
+                    || par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+                    || IsSWBRC(par, pCO2))
+                && CheckOrZero<mfxU16, 0, MFX_CODINGOPTION_OFF>(pCO2->MBBRC);
+
+        changed += !defPar.caps.SliceByteSizeCtrl && CheckOrZero<mfxU32, 0>(pCO2->MaxSliceSize);
+
+        bool bMinMaxQpAllowed = par.mfx.RateControlMethod != MFX_RATECONTROL_CQP && IsSWBRC(par, pCO2);
+
+        if (bMinMaxQpAllowed)
+        {
+            changed += pCO2->MinQPI && CheckRangeOrSetDefault<mfxU8>(pCO2->MinQPI,                        minQP,  maxQP, 0);
+            changed += pCO2->MaxQPI && CheckRangeOrSetDefault<mfxU8>(pCO2->MaxQPI, std::max(pCO2->MinQPI, minQP), maxQP, 0);
+            changed += pCO2->MinQPP && CheckRangeOrSetDefault<mfxU8>(pCO2->MinQPP,                        minQP,  maxQP, 0);
+            changed += pCO2->MaxQPP && CheckRangeOrSetDefault<mfxU8>(pCO2->MaxQPP, std::max(pCO2->MinQPP, minQP), maxQP, 0);
+            changed += pCO2->MinQPB && CheckRangeOrSetDefault<mfxU8>(pCO2->MinQPB,                        minQP,  maxQP, 0);
+            changed += pCO2->MaxQPB && CheckRangeOrSetDefault<mfxU8>(pCO2->MaxQPB, std::max(pCO2->MinQPB, minQP), maxQP, 0);
+        }
+        else
+        {
+            changed += CheckOrZero<mfxU8>(pCO2->MinQPI, 0, minQP);
+            changed += CheckOrZero<mfxU8>(pCO2->MaxQPI, 0, maxQP);
+            changed += CheckOrZero<mfxU8>(pCO2->MinQPP, 0, minQP);
+            changed += CheckOrZero<mfxU8>(pCO2->MaxQPP, 0, maxQP);
+            changed += CheckOrZero<mfxU8>(pCO2->MinQPB, 0, minQP);
+            changed += CheckOrZero<mfxU8>(pCO2->MaxQPB, 0, maxQP);
+        }
+    }
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+    return MFX_ERR_NONE;
+}
+
+mfxU32 Legacy::GetRawBytes(mfxU16 w, mfxU16 h, mfxU16 ChromaFormat, mfxU16 BitDepth)
+{
+    mfxU32 s = w * h;
+
+    if (ChromaFormat == MFX_CHROMAFORMAT_YUV420)
+        s = s * 3 / 2;
+    else if (ChromaFormat == MFX_CHROMAFORMAT_YUV422)
+        s *= 2;
+    else if (ChromaFormat == MFX_CHROMAFORMAT_YUV444)
+        s *= 3;
+
+    assert(BitDepth >= 8);
+    if (BitDepth != 8)
+        s = (s * BitDepth + 7) / 8;
+
+    return s;
+}
+mfxStatus Legacy::CheckIOPattern(mfxVideoParam & par)
+{
+    bool check_result = Check<mfxU16
+                            , MFX_IOPATTERN_IN_VIDEO_MEMORY
+                            , MFX_IOPATTERN_IN_SYSTEM_MEMORY
+                            , MFX_IOPATTERN_IN_OPAQUE_MEMORY>
+                            (par.IOPattern);
+
+    MFX_CHECK(!check_result, MFX_ERR_INVALID_VIDEO_PARAM);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckGopRefDist(mfxVideoParam & par, const ENCODE_CAPS_HEVC& caps)
+{
+    MFX_CHECK(par.mfx.GopRefDist, MFX_ERR_NONE);
+
+    mfxU16 maxRefDist = std::max<mfxU16>(1, !caps.SliceIPOnly * (par.mfx.GopPicSize - 1));
+    MFX_CHECK(!CheckMaxOrClip(par.mfx.GopRefDist, maxRefDist), MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckTU(mfxVideoParam & par, const ENCODE_CAPS_HEVC& caps)
+{
+    auto& tu = par.mfx.TargetUsage;
+
+    if (CheckMaxOrZero(tu, 7u))
+        return MFX_ERR_UNSUPPORTED;
+
+    if (!tu)
+        return MFX_ERR_NONE;
+
+    auto support = caps.TUSupport;
+    mfxI16 abs_diff = 0;
+    bool   sign = 0;
+    mfxI16 newtu = tu;
+
+    do
+    {
+        newtu = tu + (1 - 2 * sign) * abs_diff;
+        abs_diff += !sign;
+        sign = !sign;
+    } while (!(support & (1 << (newtu - 1))) && newtu > 0);
+
+    if (tu != newtu)
+    {
+        tu = newtu;
+        return MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+    }
+
+    return MFX_ERR_NONE;
+
+}
+
+mfxStatus Legacy::CheckTiles(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxExtHEVCTiles* pTile = ExtBuffer::Get(par);
+    MFX_CHECK(pTile, MFX_ERR_NONE);
+
+    mfxU16
+        MaxTileColumns = MAX_NUM_TILE_COLUMNS
+        , MaxTileRows    = MAX_NUM_TILE_ROWS
+        , changed = 0;
+
+    if (!defPar.caps.TileSupport)
+    {
+        MaxTileColumns = 1;
+        MaxTileRows = 1;
+    }
+    else
+    {
+        mfxU32 minTileWidth  = MIN_TILE_WIDTH_IN_SAMPLES;
+        mfxU32 minTileHeight = MIN_TILE_HEIGHT_IN_SAMPLES;
+        
+        // min 2x2 lcu is supported on VDEnc
+        // TODO: replace indirect NumScalablePipesMinus1 by platform
+        SetIf(minTileHeight, defPar.caps.NumScalablePipesMinus1 > 0 && IsOn(par.mfx.LowPower), 128);
+
+        mfxU16 maxCol = std::max<mfxU16>(1, std::min<mfxU16>(MaxTileColumns, mfxU16(defPar.base.GetCodedPicWidth(defPar) / minTileWidth)));
+        mfxU16 maxRow = std::max<mfxU16>(1, std::min<mfxU16>(MaxTileRows, mfxU16(defPar.base.GetCodedPicHeight(defPar) / minTileHeight)));
+
+        changed += CheckMaxOrClip(pTile->NumTileColumns, maxCol);
+        changed += CheckMaxOrClip(pTile->NumTileRows, maxRow);
+
+        // for ICL VDEnc only 1xN or Nx1 configurations are allowed for single pipe
+        // we ignore "Rows" condition
+        bool bForce1Row =
+            (defPar.hw == MFX_HW_ICL || defPar.hw == MFX_HW_ICL_LP)
+            && IsOn(par.mfx.LowPower)
+            && pTile->NumTileColumns > 1
+            && pTile->NumTileRows > 1;
+
+        changed += bForce1Row && CheckMaxOrClip(pTile->NumTileRows, 1);
+    }
+
+    MFX_CHECK(!CheckMaxOrZero(pTile->NumTileColumns, MaxTileColumns), MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(!CheckMaxOrZero(pTile->NumTileRows, MaxTileRows), MFX_ERR_UNSUPPORTED);
+
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+    return MFX_ERR_NONE;
+}
+
+void Legacy::CheckQuery0(const ParamSupport& sprt, mfxVideoParam& par)
+{
+    std::vector<mfxU8> onesBuf(sizeof(par), 1);
+
+    auto ExtParam    = par.ExtParam;
+    auto NumExtParam = par.NumExtParam;
+
+    par = mfxVideoParam{};
+
+    for (auto& copy : sprt.m_mvpCopySupported)
+        copy((mfxVideoParam*)onesBuf.data(), &par);
+
+    par.ExtParam    = ExtParam;
+    par.NumExtParam = NumExtParam;
+
+    if (par.ExtParam)
+    {
+        for (mfxU32 i = 0; i < par.NumExtParam; i++)
+        {
+            if (!par.ExtParam[i])
+                continue;
+
+            mfxExtBuffer header = *par.ExtParam[i];
+
+            memset(par.ExtParam[i], 0, header.BufferSz);
+            *par.ExtParam[i] = header;
+
+            auto it = sprt.m_ebCopySupported.find(header.BufferId);
+
+            if (it != sprt.m_ebCopySupported.end())
+            {
+                if (onesBuf.size() < header.BufferSz)
+                    onesBuf.insert(onesBuf.end(), header.BufferSz - mfxU32(onesBuf.size()), 1);
+
+                auto pSrc = (mfxExtBuffer*)onesBuf.data();
+                *pSrc = header;
+
+                for (auto& copy : it->second)
+                    copy(pSrc, par.ExtParam[i]);
+            }
+        }
+    }
+}
+
+mfxStatus Legacy::CheckBuffers(const ParamSupport& sprt, const mfxVideoParam& in, const mfxVideoParam* out)
+{
+    MFX_CHECK(!(!in.NumExtParam && (!out || !out->NumExtParam)), MFX_ERR_NONE);
+    MFX_CHECK(in.ExtParam, MFX_ERR_UNDEFINED_BEHAVIOR);
+    MFX_CHECK(!(out && (!out->ExtParam || out->NumExtParam != in.NumExtParam))
+        , MFX_ERR_UNDEFINED_BEHAVIOR);
+
+    std::map<mfxU32, mfxU32> detected[2];
+    mfxU32 dId = 0;
+
+    for (auto pPar : { &in, out })
+    {
+        if (!pPar)
+            continue;
+
+        for (mfxU32 i = 0; i < pPar->NumExtParam; i++)
+        {
+            MFX_CHECK_NULL_PTR1(pPar->ExtParam[i]);
+
+            auto id = pPar->ExtParam[i]->BufferId;
+
+            MFX_CHECK(sprt.m_ebCopySupported.find(id) != sprt.m_ebCopySupported.end(), MFX_ERR_UNSUPPORTED);
+            MFX_CHECK(!(detected[dId][id]++), MFX_ERR_UNDEFINED_BEHAVIOR);
+        }
+        dId++;
+    }
+
+    MFX_CHECK(!(out && detected[0] != detected[1]), MFX_ERR_UNDEFINED_BEHAVIOR);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CopyConfigurable(const ParamSupport& sprt, const mfxVideoParam& in, mfxVideoParam& out)
+{
+    using TFnCopyMVP = std::function<void(const mfxVideoParam*, mfxVideoParam*)>;
+    using TFnCopyEB  = std::function<void(const mfxExtBuffer*, mfxExtBuffer*)>;
+
+    auto CopyMVP = [&](const mfxVideoParam& src, mfxVideoParam& dst)
+    {
+        std::for_each(sprt.m_mvpCopySupported.begin(), sprt.m_mvpCopySupported.end()
+            , [&](const TFnCopyMVP& copy)
+        {
+            copy(&src, &dst);
+        });
+    };
+    auto CopyEB = [](const std::list<TFnCopyEB>& copyList, const mfxExtBuffer* pIn, mfxExtBuffer* pOut)
+    {
+        std::for_each(copyList.begin(), copyList.end()
+            , [&](const TFnCopyEB& copy)
+        {
+            copy(pIn, pOut);
+        });
+    };
+    mfxVideoParam tmpMVP = {};
+
+    CopyMVP(in, tmpMVP);
+
+    tmpMVP.NumExtParam  = out.NumExtParam;
+    tmpMVP.ExtParam     = out.ExtParam;
+
+    out = tmpMVP;
+
+    std::list<mfxExtBuffer*> outBufs(out.ExtParam, out.ExtParam + out.NumExtParam);
+    outBufs.sort();
+    outBufs.remove(nullptr);
+
+    std::for_each(outBufs.begin(), outBufs.end()
+        , [&](mfxExtBuffer* pEbOut)
+    {
+        std::vector<mfxU8> ebTmp(pEbOut->BufferSz, mfxU8(0));
+        auto               pEbIn      = ExtBuffer::Get(in, pEbOut->BufferId);
+        auto               copyIt     = sprt.m_ebCopySupported.find(pEbOut->BufferId);
+        auto               copyPtrsIt = sprt.m_ebCopyPtrs.find(pEbOut->BufferId);
+        mfxExtBuffer*      pEbTmp     = (mfxExtBuffer*)ebTmp.data();
+        bool               bCopyPar   = pEbIn && copyIt != sprt.m_ebCopySupported.end();
+        bool               bCopyPtr   = copyPtrsIt != sprt.m_ebCopyPtrs.end();
+
+        *pEbTmp = *pEbOut;
+
+        if (bCopyPtr)
+        {
+            CopyEB(copyPtrsIt->second, pEbOut, pEbTmp);
+        }
+
+        if (bCopyPar)
+        {
+            CopyEB(copyIt->second, pEbIn, pEbTmp);
+        }
+
+        std::copy_n(ebTmp.data(), ebTmp.size(), (mfxU8*)pEbOut);
+    });
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Legacy::CheckCodedPicSize(
+    mfxVideoParam & par
+    , const Defaults::Param& defPar)
+{
+    mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
+    MFX_CHECK(pHEVC, MFX_ERR_NONE);
+
+    auto alignment = defPar.base.GetCodedPicAlignment(defPar);
+    auto& W = pHEVC->PicWidthInLumaSamples;
+    auto& H = pHEVC->PicHeightInLumaSamples;
+    auto AW = mfx::align2_value(W, alignment);
+    auto AH = mfx::align2_value(H, alignment);
+
+    MFX_CHECK(!CheckMaxOrZero(W, par.mfx.FrameInfo.Width), MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(!CheckMaxOrZero(H, par.mfx.FrameInfo.Height), MFX_ERR_UNSUPPORTED);
+
+    if ((W != AW) || (H != AH))
+    {
+        W = AW;
+        H = AH;
+        return MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+mfxU16 FrameType2SliceType(mfxU32 ft)
+{
+    bool bB = IsB(ft);
+    bool bP = !bB && IsP(ft);
+    return 1 * bP + 2 * !(bB || bP);
+}
+
+bool isCurrLt(
+    DpbArray const & DPB,
+    mfxU8 const (&RPL)[2][MAX_DPB_SIZE],
+    mfxU8 const (&numRefActive)[2],
+    mfxI32 poc)
+{
+    for (mfxU32 i = 0; i < 2; i++)
+        for (mfxU32 j = 0; j < numRefActive[i]; j++)
+            if (poc == DPB[RPL[i][j]].POC)
+                return DPB[RPL[i][j]].isLTR;
+    return false;
+}
+
+inline bool isCurrLt(const TaskCommonPar & task, mfxI32 poc)
+{
+    return isCurrLt(task.DPB.Active, task.RefPicList, task.NumRefActive, poc);
+}
+
+template<class T> inline T Lsb(T val, mfxU32 maxLSB)
+{
+    if (val >= 0)
+        return val % maxLSB;
+    return (maxLSB - ((-val) % maxLSB)) % maxLSB;
+}
+
+bool isForcedDeltaPocMsbPresent(
+    const TaskCommonPar & prevTask,
+    mfxI32 poc,
+    mfxU32 MaxPocLsb)
+{
+    DpbArray const & DPB = prevTask.DPB.Active;
+
+    if (Lsb(prevTask.POC, MaxPocLsb) == Lsb(poc, MaxPocLsb))
+        return true;
+
+    for (mfxU16 i = 0; !isDpbEnd(DPB, i); i++)
+        if (DPB[i].POC != poc && Lsb(DPB[i].POC, MaxPocLsb) == Lsb(poc, MaxPocLsb))
+            return true;
+
+    return false;
+}
+
+mfxU16 GetSliceHeaderLTRs(
+    const TaskCommonPar& task
+    , const TaskCommonPar& prevTask
+    , const DpbArray & DPB
+    , const SPS& sps
+    , mfxI32 (&LTR)[MAX_NUM_LONG_TERM_PICS]
+    , Slice & s)
+{
+    mfxU16 nLTR = 0;
+    size_t nDPBLT = 0;
+    mfxU32 MaxPocLsb  = (1<<(sps.log2_max_pic_order_cnt_lsb_minus4+4));
+    mfxU32 dPocCycleMSBprev = 0;
+    mfxI32 DPBLT[MAX_DPB_SIZE] = {};
+    mfxI32 InvalidPOC = -9000;
+
+    std::transform(DPB, DPB + Size(DPB), DPBLT
+        , [InvalidPOC](const DpbFrame& x) { return (x.isLTR && isValid(x)) ? x.POC : InvalidPOC; });
+
+    nDPBLT = std::remove_if(DPBLT, DPBLT + Size(DPBLT)
+        , [InvalidPOC](mfxI32 x) { return x == InvalidPOC; }) - DPBLT;
+
+    std::sort(DPBLT, DPBLT + nDPBLT, std::greater<mfxI32>()); // sort for DeltaPocMsbCycleLt (may only increase)
+
+    // insert LTR using lt_ref_pic_poc_lsb_sps
+    std::for_each(DPBLT, DPBLT + nDPBLT, [&](mfxI32& ltpoc) {
+        mfxU32 dPocCycleMSB = (task.POC / MaxPocLsb - ltpoc / MaxPocLsb);
+        mfxU32 dPocLSB      = ltpoc - (task.POC - dPocCycleMSB * MaxPocLsb - s.pic_order_cnt_lsb);
+
+        size_t ltId = std::find_if(
+            sps.lt_ref_pic_poc_lsb_sps
+            , sps.lt_ref_pic_poc_lsb_sps + sps.num_long_term_ref_pics_sps
+            , [&](const mfxU16& ltPocLsb) {
+            return dPocLSB == ltPocLsb
+                &&     isCurrLt(task, DPBLT[ltpoc])
+                    == !!sps.used_by_curr_pic_lt_sps_flag[sps.lt_ref_pic_poc_lsb_sps - &ltPocLsb]
+                && dPocCycleMSB >= dPocCycleMSBprev;
+        }) - sps.lt_ref_pic_poc_lsb_sps;
+
+        if (ltId >= sps.num_long_term_ref_pics_sps)
+            return;
+
+        auto& curlt = s.lt[s.num_long_term_sps];
+
+        curlt.lt_idx_sps                    = ltId;
+        curlt.used_by_curr_pic_lt_flag      = !!sps.used_by_curr_pic_lt_sps_flag[ltId];
+        curlt.poc_lsb_lt                    = sps.lt_ref_pic_poc_lsb_sps[ltId];
+        curlt.delta_poc_msb_cycle_lt        = dPocCycleMSB - dPocCycleMSBprev;
+        curlt.delta_poc_msb_present_flag    =
+            !!curlt.delta_poc_msb_cycle_lt || isForcedDeltaPocMsbPresent(prevTask, ltpoc, MaxPocLsb);
+        dPocCycleMSBprev                    = dPocCycleMSB;
+
+        ++s.num_long_term_sps;
+
+        if (curlt.used_by_curr_pic_lt_flag)
+        {
+            assert(nLTR < MAX_NUM_LONG_TERM_PICS);
+            LTR[nLTR++] = ltpoc;
+        }
+
+        ltpoc = InvalidPOC;
+    });
+
+    nDPBLT = std::remove_if(DPBLT, DPBLT + nDPBLT
+        , [InvalidPOC](mfxI32 x) { return x == InvalidPOC; }) - DPBLT;
+    dPocCycleMSBprev = 0;
+
+    std::for_each(DPBLT, DPBLT + nDPBLT, [&](mfxI32 ltpoc) {
+        auto& curlt = s.lt[s.num_long_term_sps + s.num_long_term_pics];
+        mfxU32 dPocCycleMSB = (task.POC / MaxPocLsb - ltpoc / MaxPocLsb);
+        mfxU32 dPocLSB      = ltpoc - (task.POC - dPocCycleMSB * MaxPocLsb - s.pic_order_cnt_lsb);
+
+        assert(dPocCycleMSB >= dPocCycleMSBprev);
+
+        curlt.used_by_curr_pic_lt_flag      = isCurrLt(task, ltpoc);
+        curlt.poc_lsb_lt                    = dPocLSB;
+        curlt.delta_poc_msb_cycle_lt        = dPocCycleMSB - dPocCycleMSBprev;
+        curlt.delta_poc_msb_present_flag    =
+            !!curlt.delta_poc_msb_cycle_lt || isForcedDeltaPocMsbPresent(prevTask, ltpoc, MaxPocLsb);
+        dPocCycleMSBprev                    = dPocCycleMSB;
+
+        ++s.num_long_term_pics;
+
+        if (curlt.used_by_curr_pic_lt_flag)
+        {
+            if (nLTR < MAX_NUM_LONG_TERM_PICS) //KW
+                LTR[nLTR++] = ltpoc;
+            else
+                assert(!"too much LTRs");
+        }
+    });
+
+    return nLTR;
+}
+
+void GetSliceHeaderRPLMod(
+    const TaskCommonPar& task
+    , const DpbArray & DPB
+    , const mfxI32 (&STR)[2][MAX_DPB_SIZE]
+    , const mfxU16 (&nSTR)[2]
+    , const mfxI32 LTR[MAX_NUM_LONG_TERM_PICS]
+    , mfxU16 nLTR
+    , Slice & s)
+{
+    auto& RPL = task.RefPicList;
+    auto ModLX = [&](mfxU16 lx, mfxU16 NumRpsCurrTempListX)
+    {
+        mfxU16 rIdx = 0;
+        mfxI32 RPLTempX[16] = {}; // default ref. list without modifications
+        auto AddRef = [&](mfxI32 ref) { RPLTempX[rIdx++] = ref; };
+
+        while (rIdx < NumRpsCurrTempListX)
+        {
+            std::for_each(STR[lx], STR[lx] + std::min<mfxU16>(nSTR[lx], NumRpsCurrTempListX - rIdx), AddRef);
+            std::for_each(STR[!lx], STR[!lx] + std::min<mfxU16>(nSTR[!lx], NumRpsCurrTempListX - rIdx), AddRef);
+            std::for_each(LTR, LTR + std::min<mfxU16>(nLTR, NumRpsCurrTempListX - rIdx), AddRef);
+        }
+
+        for (rIdx = 0; rIdx < task.NumRefActive[lx]; rIdx++)
+        {
+            auto pRef = std::find_if(RPLTempX, RPLTempX + NumRpsCurrTempListX
+                , [&](mfxI32 ref) {return DPB[RPL[lx][rIdx]].POC == ref; });
+            s.list_entry_lx[lx][rIdx] = mfxU8(pRef - RPLTempX);
+            s.ref_pic_list_modification_flag_lx[lx] |= (s.list_entry_lx[lx][rIdx] != rIdx);
+        }
+    };
+
+    ModLX(0, std::max<mfxU16>(nSTR[0] + nSTR[1] + nLTR, task.NumRefActive[0]));
+    ModLX(1, std::max<mfxU16>(nSTR[0] + nSTR[1] + nLTR, task.NumRefActive[1]));
+}
+
+mfxStatus Legacy::GetSliceHeader(
+    const ExtBuffer::Param<mfxVideoParam> & par
+    , const TaskCommonPar& task
+    , const SPS& sps
+    , const PPS& pps
+    , Slice & s)
+{
+    bool isP = IsP(task.FrameType);
+    bool isB = IsB(task.FrameType);
+    bool isI = IsI(task.FrameType);
+
+    ThrowAssert(isP + isB + isI != 1, "task.FrameType is invalid");
+
+    s = {};
+
+    s.first_slice_segment_in_pic_flag = 1;
+    s.no_output_of_prior_pics_flag    = 0;
+    s.pic_parameter_set_id            = pps.pic_parameter_set_id;
+    s.type                            = FrameType2SliceType(task.FrameType);
+    s.pic_output_flag                 = !!pps.output_flag_present_flag;
+
+    assert(0 == sps.separate_colour_plane_flag);
+
+    bool bNonIdrNut = task.SliceNUT != IDR_W_RADL && task.SliceNUT != IDR_N_LP;
+    if (bNonIdrNut)
+    {
+        mfxU16 nLTR = 0, nSTR[2] = {};
+        mfxI32 STR[2][MAX_DPB_SIZE] = {};         // used short-term references
+        mfxI32 LTR[MAX_NUM_LONG_TERM_PICS] = {};  // used long-term references
+        const auto& DPB = task.DPB.Active;        // DPB before encoding
+        const auto& RPL = task.RefPicList;        // Ref. Pic. List
+        auto IsSame     = [&s](const STRPS& x)      { return Equal(x, s.strps); };
+        auto IsLTR      = [](const DpbFrame& ref)   { return isValid(ref) && ref.isLTR; };
+        auto IsL0Pic    = [](const STRPSPic& pic)   { return pic.used_by_curr_pic_sx_flag && (pic.DeltaPocSX <= 0); };
+        auto IsL1Pic    = [](const STRPSPic& pic)   { return pic.used_by_curr_pic_sx_flag && (pic.DeltaPocSX > 0); };
+        auto PicToPOC   = [&](const STRPSPic& pic)  { return (task.POC + pic.DeltaPocSX); };
+
+        ConstructSTRPS(DPB, RPL, task.NumRefActive, task.POC, s.strps);
+
+        s.pic_order_cnt_lsb = (task.POC & ~(0xFFFFFFFF << (sps.log2_max_pic_order_cnt_lsb_minus4 + 4)));
+
+        s.short_term_ref_pic_set_idx      = mfxU8(std::find_if(sps.strps, sps.strps + sps.num_short_term_ref_pic_sets, IsSame) - sps.strps);
+        s.short_term_ref_pic_set_sps_flag = (s.short_term_ref_pic_set_idx < sps.num_short_term_ref_pic_sets);
+
+        if (!s.short_term_ref_pic_set_sps_flag)
+            OptimizeSTRPS(sps.strps, sps.num_short_term_ref_pic_sets, s.strps, sps.num_short_term_ref_pic_sets);
+
+        std::list<STRPSPic> picsUsed[2];
+        auto itStrpsPicsBegin = s.strps.pic;
+        auto itStrpsPicsEnd   = s.strps.pic + mfxU32(s.strps.num_negative_pics + s.strps.num_positive_pics);
+
+        std::copy_if(itStrpsPicsBegin, itStrpsPicsEnd, std::back_inserter(picsUsed[0]), IsL0Pic);
+        std::copy_if(itStrpsPicsBegin, itStrpsPicsEnd, std::back_inserter(picsUsed[1]), IsL1Pic);
+
+        nSTR[0] = mfxU16(std::transform(picsUsed[0].begin(), picsUsed[0].end(), STR[0], PicToPOC) - STR[0]);
+        nSTR[1] = mfxU16(std::transform(picsUsed[1].begin(), picsUsed[1].end(), STR[1], PicToPOC) - STR[1]);
+
+        if (std::any_of(DPB, DPB + Size(DPB), IsLTR))
+        {
+            assert(sps.long_term_ref_pics_present_flag);
+            nLTR = GetSliceHeaderLTRs(task, m_prevTask, DPB, sps, LTR, s);
+        }
+
+
+        if (pps.lists_modification_present_flag)
+        {
+            GetSliceHeaderRPLMod(task, DPB, STR, nSTR, LTR, nLTR, s);
+        }
+    }
+
+    s.temporal_mvp_enabled_flag = !!sps.temporal_mvp_enabled_flag;
+
+    if (sps.sample_adaptive_offset_enabled_flag)
+    {
+        const mfxExtHEVCParam* rtHEVCParam = ExtBuffer::Get(task.ctrl);
+        const mfxExtHEVCParam& HEVCParam   = ExtBuffer::Get(par);
+        mfxU16 FrameSAO = (rtHEVCParam && rtHEVCParam->SampleAdaptiveOffset)
+            ? rtHEVCParam->SampleAdaptiveOffset
+            : HEVCParam.SampleAdaptiveOffset;
+
+        s.sao_luma_flag   = !!(FrameSAO & MFX_SAO_ENABLE_LUMA);
+        s.sao_chroma_flag = !!(FrameSAO & MFX_SAO_ENABLE_CHROMA);
+    }
+
+    if (!isI)
+    {
+        s.num_ref_idx_active_override_flag =
+           (   pps.num_ref_idx_l0_default_active_minus1 + 1 != task.NumRefActive[0]
+            || (isB && pps.num_ref_idx_l1_default_active_minus1 + 1 != task.NumRefActive[1]));
+
+        s.num_ref_idx_l0_active_minus1  = task.NumRefActive[0] - 1;
+        s.num_ref_idx_l1_active_minus1  = isB * (task.NumRefActive[1] - 1);
+        s.mvd_l1_zero_flag              &= !isB;
+        s.cabac_init_flag               = 0;
+        s.collocated_from_l0_flag       = !!s.temporal_mvp_enabled_flag;
+        s.five_minus_max_num_merge_cand = 0;
+    }
+
+    bool bSetQPd =
+        par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT;
+    s.slice_qp_delta     = mfxI8((task.QpY - (pps.init_qp_minus26 + 26)) * bSetQPd);
+    s.slice_cb_qp_offset = 0;
+    s.slice_cr_qp_offset = 0;
+
+    const mfxExtCodingOption2& CO2  = ExtBuffer::Get(par);
+    const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(task.ctrl);
+
+    SetDefault(pCO2, &CO2);
+
+    s.deblocking_filter_disabled_flag = !!pCO2->DisableDeblockingIdc;
+    s.deblocking_filter_override_flag = (s.deblocking_filter_disabled_flag != pps.deblocking_filter_disabled_flag);
+    s.beta_offset_div2                = pps.beta_offset_div2;
+    s.tc_offset_div2                  = pps.tc_offset_div2;
+#if MFX_VERSION >= MFX_VERSION_NEXT
+    const mfxExtCodingOption3&   CO3 = ExtBuffer::Get(par);
+    const mfxExtCodingOption3  *pCO3 = ExtBuffer::Get(task.ctrl);
+
+    SetDefault(pCO3, &CO3);
+
+    s.beta_offset_div2 = mfxI8(pCO3->DeblockingBetaOffset * 0.5 * !s.deblocking_filter_disabled_flag);
+    s.tc_offset_div2   = mfxI8(pCO3->DeblockingAlphaTcOffset * 0.5 * !s.deblocking_filter_disabled_flag);
+
+    s.deblocking_filter_override_flag |=
+        !s.deblocking_filter_disabled_flag
+        && (s.beta_offset_div2 != pps.beta_offset_div2
+            || s.tc_offset_div2 != pps.tc_offset_div2);
+#endif
+
+    s.loop_filter_across_slices_enabled_flag = pps.loop_filter_across_slices_enabled_flag;
+    s.num_entry_point_offsets *= !(pps.tiles_enabled_flag || pps.entropy_coding_sync_enabled_flag);
+
+    return MFX_ERR_NONE;
+}
+
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy.h
@@ -1,0 +1,342 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_ddi.h"
+#include "hevcehw_g11_data.h"
+#include <tuple>
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class Legacy
+        : public FeatureBase
+    {
+    public:
+
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Query0               )\
+    DECL_BLOCK(SetDefaultsCallChain )\
+    DECL_BLOCK(PreCheckCodecId      )\
+    DECL_BLOCK(PreCheckChromaFormat )\
+    DECL_BLOCK(PreCheckExtBuffers   )\
+    DECL_BLOCK(CopyConfigurable     )\
+    DECL_BLOCK(SetLowPowerDefault   )\
+    DECL_BLOCK(SetGUID              )\
+    DECL_BLOCK(CheckHeaders         )\
+    DECL_BLOCK(CheckLCUSize         )\
+    DECL_BLOCK(CheckFormat          )\
+    DECL_BLOCK(CheckLowDelayBRC     )\
+    DECL_BLOCK(CheckLevel           )\
+    DECL_BLOCK(CheckSurfSize        )\
+    DECL_BLOCK(CheckCodedPicSize    )\
+    DECL_BLOCK(CheckTiles           )\
+    DECL_BLOCK(CheckTU              )\
+    DECL_BLOCK(CheckTemporalLayers  )\
+    DECL_BLOCK(CheckGopRefDist      )\
+    DECL_BLOCK(CheckNumRefFrame     )\
+    DECL_BLOCK(CheckIOPattern       )\
+    DECL_BLOCK(CheckBRC             )\
+    DECL_BLOCK(CheckCrops           )\
+    DECL_BLOCK(CheckShift           )\
+    DECL_BLOCK(CheckFrameRate       )\
+    DECL_BLOCK(CheckSlices          )\
+    DECL_BLOCK(CheckBPyramid        )\
+    DECL_BLOCK(CheckPPyramid        )\
+    DECL_BLOCK(CheckIntraRefresh    )\
+    DECL_BLOCK(CheckSkipFrame       )\
+    DECL_BLOCK(CheckGPB             )\
+    DECL_BLOCK(CheckESPackParam     )\
+    DECL_BLOCK(CheckNumRefActive    )\
+    DECL_BLOCK(CheckSAO             )\
+    DECL_BLOCK(CheckProfile         )\
+    DECL_BLOCK(CheckLevelConstraints)\
+    DECL_BLOCK(CheckVideoParam      )\
+    DECL_BLOCK(SetDefaults          )\
+    DECL_BLOCK(SetFrameAllocRequest )\
+    DECL_BLOCK(SetVPS               )\
+    DECL_BLOCK(SetSPS               )\
+    DECL_BLOCK(NestSTRPS            )\
+    DECL_BLOCK(SetSTRPS             )\
+    DECL_BLOCK(SetPPS               )\
+    DECL_BLOCK(SetSlices            )\
+    DECL_BLOCK(SetReorder           )\
+    DECL_BLOCK(AllocRaw             )\
+    DECL_BLOCK(AllocRec             )\
+    DECL_BLOCK(AllocBS              )\
+    DECL_BLOCK(AllocMBQP            )\
+    DECL_BLOCK(ResetInit            )\
+    DECL_BLOCK(ResetCheck           )\
+    DECL_BLOCK(ResetState           )\
+    DECL_BLOCK(CheckSurf            )\
+    DECL_BLOCK(CheckBS              )\
+    DECL_BLOCK(AllocTask            )\
+    DECL_BLOCK(InitTask             )\
+    DECL_BLOCK(PrepareTask          )\
+    DECL_BLOCK(ConfigureTask        )\
+    DECL_BLOCK(SkipFrame            )\
+    DECL_BLOCK(GetRawHDL            )\
+    DECL_BLOCK(CopySysToRaw         )\
+    DECL_BLOCK(FillCUQPSurf         )\
+    DECL_BLOCK(CopyBS               )\
+    DECL_BLOCK(DoPadding            )\
+    DECL_BLOCK(UpdateBsInfo         )\
+    DECL_BLOCK(SetRecInfo           )\
+    DECL_BLOCK(FreeTask             )
+#define DECL_FEATURE_NAME "G11_Legacy"
+#include "hevcehw_decl_blocks.h"
+
+        Legacy(mfxU32 id)
+            : FeatureBase(id)
+        {
+        }
+
+    protected:
+        TaskCommonPar m_prevTask;
+        mfxU32
+            m_frameOrder
+            , m_lastIDR
+            , m_baseLayerOrder
+            , m_forceHeaders = 0;
+        mfxU16
+            m_CUQPBlkW
+            , m_CUQPBlkH;
+        std::function<std::tuple<mfxU16, mfxU16>(const mfxVideoParam&)> m_GetMaxRef;
+        std::unique_ptr<Defaults::Param> m_pQWCDefaults;
+        NotNull<Defaults*> m_pQNCDefaults;
+        eMFXHWType m_hw = MFX_HW_UNKNOWN;
+
+        void ResetState()
+        {
+            m_frameOrder     = mfxU32(-1);
+            m_lastIDR        = 0;
+            m_baseLayerOrder = 0;
+            Invalidate(m_prevTask);
+        }
+
+    public:
+        virtual void SetSupported(ParamSupport& par) override;
+        virtual void SetInherited(ParamInheritance& par) override;
+        virtual void Query0(const FeatureBlocks& blocks, TPushQ0 Push) override;
+        virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+        virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+        virtual void SetDefaults(const FeatureBlocks& blocks, TPushSD Push) override;
+        virtual void QueryIOSurf(const FeatureBlocks& blocks, TPushQIS Push) override;
+        virtual void InitExternal(const FeatureBlocks& blocks, TPushIE Push) override;
+        virtual void InitInternal(const FeatureBlocks& blocks, TPushII Push) override;
+        virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+        virtual void FrameSubmit(const FeatureBlocks& blocks, TPushFS Push) override;
+        virtual void AllocTask(const FeatureBlocks& blocks, TPushAT Push) override;
+        virtual void InitTask(const FeatureBlocks& blocks, TPushIT Push) override;
+        virtual void PreReorderTask(const FeatureBlocks& blocks, TPushPreRT Push) override;
+        virtual void PostReorderTask(const FeatureBlocks& blocks, TPushPostRT Push) override;
+        virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+        virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+        virtual void FreeTask(const FeatureBlocks& blocks, TPushFT Push) override;
+        virtual void GetVideoParam(const FeatureBlocks& blocks, TPushGVP Push) override;
+        virtual void Reset(const FeatureBlocks& blocks, TPushR Push) override;
+        virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+
+        static void PushDefaults(Defaults& df);
+
+        void CheckQuery0(const ParamSupport& sprt, mfxVideoParam& par);
+        mfxStatus CheckBuffers(const ParamSupport& sprt, const mfxVideoParam& in, const mfxVideoParam* out = nullptr);
+        mfxStatus CopyConfigurable(const ParamSupport& sprt, const mfxVideoParam& in, mfxVideoParam& out);
+
+        mfxStatus CheckCodedPicSize(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckTiles(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckTU(mfxVideoParam & par, const ENCODE_CAPS_HEVC& caps);
+        mfxStatus CheckGopRefDist(mfxVideoParam & par, const ENCODE_CAPS_HEVC& caps);
+        mfxStatus CheckIOPattern(mfxVideoParam & par);
+        mfxStatus CheckBRC(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckCrops(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckShift(mfxVideoParam & par, mfxExtOpaqueSurfaceAlloc* pOSA);
+        mfxStatus CheckFrameRate(mfxVideoParam & par);
+        mfxStatus CheckNumRefFrame(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckSlices(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckBPyramid(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckPPyramid(mfxVideoParam & par);
+        mfxStatus CheckTemporalLayers(mfxVideoParam & par);
+        mfxStatus CheckIntraRefresh(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckSkipFrame(mfxVideoParam & par);
+        mfxStatus CheckGPB(mfxVideoParam & par);
+        mfxStatus CheckESPackParam(mfxVideoParam & par, eMFXHWType hw);
+        mfxStatus CheckLevelConstraints(
+            mfxVideoParam & par
+            , const Defaults::Param& defPar);
+        mfxStatus CheckSPS(const SPS& sps, const ENCODE_CAPS_HEVC& caps, eMFXHWType hw);
+        mfxStatus CheckPPS(const PPS& sps, const ENCODE_CAPS_HEVC& caps, eMFXHWType hw);
+
+        void SetDefaults(
+            mfxVideoParam& par
+            , const Defaults::Param& defPar
+            , bool bExternalFrameAllocator);
+
+        void SetVPS(
+            const Defaults::Param& dflts
+            , VPS& vps);
+
+        void SetSTRPS(
+            const Defaults::Param& dflts
+            , SPS& sps
+            , const Reorderer& reorder);
+
+        void ConfigureTask(
+            TaskCommonPar & task
+            , const Defaults::Param& dflts
+            , const SPS& sps);
+        mfxStatus GetSliceHeader(
+            const ExtBuffer::Param<mfxVideoParam> & par
+            , const TaskCommonPar& task
+            , const SPS& sps
+            , const PPS& pps
+            , Slice & s);
+        static mfxU32 GetRawBytes(mfxU16 w, mfxU16 h, mfxU16 ChromaFormat, mfxU16 BitDepth);
+        static bool IsSWBRC(mfxVideoParam const & par, const mfxExtCodingOption2* pCO2);
+        static bool IsInVideoMem(const mfxVideoParam & par, const mfxExtOpaqueSurfaceAlloc* pOSA);
+
+        mfxU16 GetMaxRaw(const mfxVideoParam & par)
+        {
+            return par.AsyncDepth + (par.mfx.GopRefDist - 1) + (par.AsyncDepth > 1);
+        }
+        mfxU16 GetMaxRec(mfxVideoParam const & par)
+        {
+            return par.AsyncDepth + par.mfx.NumRefFrame + (par.AsyncDepth > 1);
+        }
+        mfxU16 GetMaxBS(mfxVideoParam const & par)
+        {
+            return par.AsyncDepth + (par.AsyncDepth > 1);
+        }
+        bool GetRecInfo(
+            const mfxVideoParam& par
+            , const mfxExtCodingOption3& CO3
+            , eMFXHWType hw
+            , mfxFrameInfo& rec);
+        mfxU32 GetMinBsSize(
+            const mfxVideoParam & par
+            , const mfxExtHEVCParam& HEVCParam
+            , const mfxExtCodingOption2& CO2
+            , const mfxExtCodingOption3& CO3);
+        std::tuple<mfxStatus, mfxU16, mfxU16> GetCUQPMapBlockSize(
+            mfxU16 frameWidth, mfxU16 frameHeight,
+            mfxU16 CUQPWidth, mfxU16 CUHeight);
+
+        void ConstructRPL(
+            const Defaults::Param& dflts
+            , const DpbArray & DPB
+            , const FrameBaseInfo& cur
+            , mfxU8(&RPL)[2][MAX_DPB_SIZE]
+            , mfxU8(&numRefActive)[2]
+            , const mfxExtAVCRefLists * pExtLists = nullptr
+            , const mfxExtAVCRefListCtrl * pLCtrl = nullptr);
+
+        void ConstructSTRPS(
+            const DpbArray & DPB
+            , const mfxU8(&RPL)[2][MAX_DPB_SIZE]
+            , const mfxU8 (&numRefActive)[2]
+            , mfxI32 poc
+            , STRPS& rps);
+
+        void InitDPB(
+            TaskCommonPar &        task,
+            TaskCommonPar const &  prevTask,
+            const mfxExtAVCRefListCtrl* pLCtrl);
+
+        mfxU16 UpdateDPB(
+            const Defaults::Param& dflts
+            , const DpbFrame& task
+            , DpbArray & dpb
+            , const mfxExtAVCRefListCtrl * pLCtrl = nullptr);
+
+        static bool IsCurrRef(
+            const DpbArray & DPB
+            , const mfxU8 (&RPL)[2][MAX_DPB_SIZE]
+            , const mfxU8 (&numRefActive)[2]
+            , mfxI32 poc)
+        {
+            for (mfxU32 i = 0; i < 2; i++)
+                for (mfxU32 j = 0; j < numRefActive[i]; j++)
+                    if (poc == DPB[RPL[i][j]].POC)
+                        return true;
+            return false;
+        }
+        static mfxU8 GetDPBIdxByFO(DpbArray const & DPB, mfxU32 fo)
+        {
+            for (mfxU8 i = 0; !isDpbEnd(DPB, i); i++)
+                if (DPB[i].DisplayOrder == fo)
+                    return i;
+            return mfxU8(MAX_DPB_SIZE);
+        }
+        static mfxU8 GetDPBIdxByPoc(DpbArray const & DPB, mfxI32 poc)
+        {
+            for (mfxU8 i = 0; !isDpbEnd(DPB, i); i++)
+                if (DPB[i].POC == poc)
+                    return i;
+            return mfxU8(MAX_DPB_SIZE);
+        }
+        static mfxU32 GetBiFrameLocation(mfxU32 i, mfxU32 num, bool &ref, mfxU32 &level);
+        Defaults::Param GetRTDefaults(StorageR& strg)
+        {
+            return Defaults::Param(
+                Glob::VideoParam::Get(strg)
+                , Glob::EncodeCaps::Get(strg)
+                , m_hw
+                , Glob::Defaults::Get(strg));
+        }
+
+        using TItWrap = TaskItWrap<FrameBaseInfo, Task::Common::Key>;
+        using TItWrapIt = std::list<TItWrap>::iterator;
+
+        static TItWrapIt BPyrReorder(TItWrapIt begin, TItWrapIt end);
+        static TItWrap Reorder(
+            ExtBuffer::Param<mfxVideoParam> const & par
+            , DpbArray const & dpb
+            , TItWrap begin
+            , TItWrap end
+            , bool flush);
+
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_legacy_defaults.cpp
@@ -1,0 +1,2694 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_legacy.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_constraints.h"
+#include <numeric>
+#include <set>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+class TemporalLayers
+{
+public:
+    TemporalLayers()
+        : m_numTL(1)
+    {
+        m_TL[0].Scale = 1;
+    }
+    TemporalLayers(const mfxExtAvcTemporalLayers& tl)
+    {
+        SetTL(tl);
+    }
+
+    ~TemporalLayers() {}
+
+    static mfxU16 CountTL(const mfxExtAvcTemporalLayers& tl);
+
+    void SetTL(mfxExtAvcTemporalLayers const & tl)
+    {
+        m_numTL = 0;
+        memset(&m_TL, 0, sizeof(m_TL));
+        m_TL[0].Scale = 1;
+
+        for (mfxU8 i = 0; i < 7; i++)
+        {
+            if (tl.Layer[i].Scale)
+            {
+                m_TL[m_numTL].TId = i;
+                m_TL[m_numTL].Scale = (mfxU8)tl.Layer[i].Scale;
+                m_numTL++;
+            }
+        }
+
+        m_numTL = std::max<mfxU8>(m_numTL, 1);
+    }
+
+    mfxU8 NumTL() const { return m_numTL; }
+
+    mfxU8 GetTId(mfxU32 frameOrder) const
+    {
+        mfxU16 i;
+
+        if (m_numTL < 1 || m_numTL > 8)
+            return 0;
+
+        for (i = 0; i < m_numTL && (frameOrder % (m_TL[m_numTL - 1].Scale / m_TL[i].Scale)); i++);
+
+        return (i < m_numTL) ? m_TL[i].TId : 0;
+    }
+
+    mfxU8 HighestTId() const
+    {
+        mfxU8 htid = m_TL[m_numTL - 1].TId;
+        return mfxU8(htid + !htid * -1);
+    }
+
+private:
+    mfxU8 m_numTL;
+
+    struct
+    {
+        mfxU8 TId = 0;
+        mfxU8 Scale = 0;
+    }m_TL[8];
+};
+
+mfxU16 TemporalLayers::CountTL(const mfxExtAvcTemporalLayers& tl)
+{
+    typedef decltype(tl.Layer[0]) TRLayer;
+    return std::max<mfxU16>(1, (mfxU16)std::count_if(
+        tl.Layer, tl.Layer + Size(tl.Layer), [](TRLayer l) { return !!l.Scale; }));
+}
+
+class GetDefault
+{
+public:
+    static mfxU16 CodedPicAlignment(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        return mfxU16((2 - (par.hw >= MFX_HW_CNL)) * 8);
+    }
+
+    static mfxU16 CodedPicWidth(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par.mvp);
+
+        if (pHEVC && pHEVC->PicWidthInLumaSamples)
+        {
+            return pHEVC->PicWidthInLumaSamples;
+        }
+
+        auto&   fi          = par.mvp.mfx.FrameInfo;
+        bool    bCropsValid = fi.CropW > 0;
+        mfxU16  W           = mfxU16(bCropsValid * (fi.CropW + fi.CropX) + !bCropsValid * fi.Width);
+
+        return mfx::align2_value(W, par.base.GetCodedPicAlignment(par));
+    }
+
+    static mfxU16 CodedPicHeight(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par.mvp);
+
+        if (pHEVC && pHEVC->PicHeightInLumaSamples)
+        {
+            return pHEVC->PicHeightInLumaSamples;
+        }
+
+        auto&   fi          = par.mvp.mfx.FrameInfo;
+        bool    bCropsValid = fi.CropH > 0;
+        mfxU16  H           = mfxU16(bCropsValid * (fi.CropH + fi.CropY) + !bCropsValid * fi.Height);
+
+        return mfx::align2_value(H, par.base.GetCodedPicAlignment(par));
+    }
+
+    static mfxU16 MaxDPB(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        if (!par.mvp.mfx.CodecLevel)
+        {
+            return 16;
+        }
+        auto W = par.base.GetCodedPicWidth(par);
+        auto H = par.base.GetCodedPicHeight(par);
+        return GetMaxDpbSizeByLevel(par.mvp, W * H);
+    }
+
+    static mfxU16 GopPicSize(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        if (par.mvp.mfx.GopPicSize)
+        {
+            return par.mvp.mfx.GopPicSize;
+        }
+        if (par.mvp.mfx.CodecProfile == MFX_PROFILE_HEVC_MAINSP)
+        {
+            return 1;
+        }
+        return mfxU16(GOP_INFINITE);
+    }
+
+    static mfxU16 GopRefDist(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        if (par.mvp.mfx.GopRefDist)
+        {
+            return par.mvp.mfx.GopRefDist;
+        }
+        auto GopPicSize = par.base.GetGopPicSize(par);
+        bool bNoB =
+            par.base.GetNumTemporalLayers(par) > 1
+            || par.caps.SliceIPOnly
+            || GopPicSize < 3
+            || par.mvp.mfx.NumRefFrame == 1;
+        bool bCQP =
+            par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+            || Legacy::IsSWBRC(par.mvp, ExtBuffer::Get(par.mvp));
+
+        if (bNoB)
+        {
+            return 1;
+        }
+
+        return std::min<mfxU16>(GopPicSize - 1, 4 * (1 + bCQP));
+    }
+
+    static mfxU16 NumBPyramidLayers(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU16 refB = (par.base.GetGopRefDist(par) - 1) / 2;
+        mfxU16 x    = refB;
+
+        while (x > 2)
+        {
+            x = (x - 1) / 2;
+            refB -= x;
+        }
+
+        return refB + 1;
+    }
+
+    static mfxU16 NumRefBPyramid(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU16 NumRefActiveP[8], NumRefActiveBL0[8], NumRefActiveBL1[8];
+        mfxU16 NumLayers = par.base.GetNumBPyramidLayers(par);
+        mfxU16 NumRefFrame = par.base.GetMinRefForBPyramid(par);
+        bool bExternalNRef = par.base.GetNumRefActive(par, &NumRefActiveP, &NumRefActiveBL0, &NumRefActiveBL1);
+
+        SetIf(NumRefFrame, bExternalNRef, [&]() -> mfxU16
+        {
+            auto maxBL0idx = std::max_element(NumRefActiveBL0, NumRefActiveBL0 + NumLayers) - NumRefActiveBL0;
+            auto maxBL1idx = std::max_element(NumRefActiveBL1, NumRefActiveBL1 + NumLayers) - NumRefActiveBL1;
+            mfxU16 maxBL0 = mfxU16((NumRefActiveBL0[maxBL0idx] + maxBL0idx + 1) * (maxBL0idx < NumLayers));
+            mfxU16 maxBL1 = mfxU16((NumRefActiveBL1[maxBL1idx] + maxBL1idx + 1) * (maxBL1idx < NumLayers));
+            return std::max<mfxU16>({ NumRefFrame, NumRefActiveP[0], maxBL0, maxBL1 });
+        });
+
+        return NumRefFrame;
+    }
+
+    static mfxU16 NumRefPPyramid(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU16 NumRefActiveP[8];
+        par.base.GetNumRefActive(par, &NumRefActiveP, nullptr, nullptr);
+        mfxU16 RefActiveP = *std::max_element(NumRefActiveP, NumRefActiveP + Size(NumRefActiveP));
+        return std::max<mfxU16>(DEFAULT_PPYR_INTERVAL, RefActiveP);
+    }
+
+    static mfxU16 NumRefNoPyramid(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU16 NumRefActiveP[8], NumRefActiveBL0[8];
+        par.base.GetNumRefActive(par, &NumRefActiveP, &NumRefActiveBL0, nullptr);
+        mfxU16 RefActiveP = *std::max_element(NumRefActiveP, NumRefActiveP + Size(NumRefActiveP));
+        mfxU16 RefActiveBL0 = *std::max_element(NumRefActiveBL0, NumRefActiveBL0 + Size(NumRefActiveBL0));
+        return mfxU16(std::max<mfxU16>(RefActiveP, RefActiveBL0) + (par.base.GetGopRefDist(par) > 1) * RefActiveBL0);
+    }
+
+    static mfxU16 NumRefFrames(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        auto NumRefBPyramid = [&]() { return par.base.GetNumRefBPyramid(par); };
+        auto NumRefPPyramid = [&]() { return par.base.GetNumRefPPyramid(par); };
+        auto NumRefDefault = [&]() { return par.base.GetNumRefNoPyramid(par); };
+
+        bool bUsrValue = !!par.mvp.mfx.NumRefFrame;
+        bool bBPyramid = !bUsrValue && (par.base.GetBRefType(par) == MFX_B_REF_PYRAMID);
+        bool bPPyramyd = !bUsrValue && !bBPyramid && (par.base.GetPRefType(par) == MFX_P_REF_PYRAMID);
+        bool bDefault = !bUsrValue && !bBPyramid && !bPPyramyd;
+
+        mfxU16 NumRefFrame = par.mvp.mfx.NumRefFrame;
+        SetIf(NumRefFrame, bBPyramid, NumRefBPyramid);
+        SetIf(NumRefFrame, bPPyramyd, NumRefPPyramid);
+        SetIf(NumRefFrame, bDefault, NumRefDefault);
+
+        SetIf(NumRefFrame, !bUsrValue, [&]()
+        {
+            return std::min<mfxU16>(
+                par.base.GetMaxDPB(par) - 1
+                , std::max<mfxU16>(par.base.GetNumTemporalLayers(par) - 1, NumRefFrame));
+        });
+
+        return NumRefFrame;
+    }
+
+    static mfxU16 MinRefForBPyramid(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        return par.base.GetNumBPyramidLayers(par) + 1;
+    }
+
+    static mfxU16 MinRefForBNoPyramid(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& /*par*/)
+    {
+        return 2;
+    }
+
+    static bool NumRefActive(
+        Defaults::TGetNumRefActive::TExt
+        , const Defaults::Param& par
+        , mfxU16(*pP)[8]
+        , mfxU16(*pBL0)[8]
+        , mfxU16(*pBL1)[8])
+    {
+        bool bExternal = false;
+        mfxU16 maxFwd, maxBwd;
+        std::tie(maxFwd, maxBwd) = par.base.GetMaxNumRef(par);
+
+        auto SetDefaultNRef =
+            [](const mfxU16(*extRef)[8], mfxU16 defaultRef, mfxU16(*NumRefActive)[8])
+        {
+            bool bExternal = false;
+            bool bDone = false;
+
+            bDone |= !NumRefActive;
+            bDone |= !bDone && !extRef && std::fill_n(*NumRefActive, 8, defaultRef);
+            bDone |= !bDone && std::transform(
+                *extRef
+                , std::end(*extRef)
+                , *NumRefActive
+                , [&](mfxU16 ext)
+            {
+                bExternal |= SetIf(defaultRef, !!ext, ext);
+                return defaultRef;
+            });
+
+            return bExternal;
+        };
+
+        const mfxU16(*extRefP  )[8] = nullptr;
+        const mfxU16(*extRefBL0)[8] = nullptr;
+        const mfxU16(*extRefBL1)[8] = nullptr;
+
+        if (const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp))
+        {
+            extRefP   = &pCO3->NumRefActiveP;
+            extRefBL0 = &pCO3->NumRefActiveBL0;
+            extRefBL1 = &pCO3->NumRefActiveBL1;
+        }
+
+        bExternal |= SetDefaultNRef(extRefP, maxFwd, pP);
+        bExternal |= SetDefaultNRef(extRefBL0, maxFwd, pBL0);
+        bExternal |= SetDefaultNRef(extRefBL1, maxBwd, pBL1);
+
+        return bExternal;
+    }
+
+    static mfxU16 BRefType(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par.mvp);
+        bool bSet = pCO2 && pCO2->BRefType;
+
+        if (bSet)
+            return pCO2->BRefType;
+
+        const mfxU16 BPyrCand[2] = { mfxU16(MFX_B_REF_OFF), mfxU16(MFX_B_REF_PYRAMID) };
+        bool bValid =
+            par.base.GetGopRefDist(par) > 3
+            && (par.mvp.mfx.NumRefFrame == 0
+                || par.base.GetMinRefForBPyramid(par) <= par.mvp.mfx.NumRefFrame);
+
+        return BPyrCand[bValid];
+    }
+
+    static mfxU16 PRefType(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp);
+        bool bSet = pCO3 && pCO3->PRefType;
+        if (bSet)
+            return pCO3->PRefType;
+
+        static const mfxU16 PRefType[3] = { mfxU16(MFX_P_REF_DEFAULT), mfxU16(MFX_P_REF_SIMPLE), mfxU16(MFX_P_REF_PYRAMID) };
+        const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par.mvp);
+        auto GopRefDist = par.base.GetGopRefDist(par);
+        mfxI32 idx = GopRefDist == 1;
+        idx += idx && (par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_CQP || Legacy::IsSWBRC(par.mvp, pCO2));
+
+        return PRefType[idx];
+    }
+
+    static std::tuple<mfxU32, mfxU32> FrameRate(
+        Defaults::TChain<std::tuple<mfxU32, mfxU32>>::TExt
+        , const Defaults::Param& par)
+    {
+        auto& fi = par.mvp.mfx.FrameInfo;
+
+        if (fi.FrameRateExtN && fi.FrameRateExtD)
+        {
+            return std::make_tuple(fi.FrameRateExtN, fi.FrameRateExtD);
+        }
+
+        mfxU32 frN = 30, frD = 1;
+        mfxF64 frMax = 30.;
+
+        if (par.mvp.mfx.CodecLevel)
+        {
+            auto W = par.base.GetCodedPicWidth(par);
+            auto H = par.base.GetCodedPicHeight(par);
+            frMax = GetMaxFrByLevel(par.mvp, W * H);
+        }
+
+        bool bFrByLevel = frN > (frMax * frD);
+        frN = mfxU32(frN * !bFrByLevel + (frMax * 1001) * bFrByLevel);
+        frD = mfxU32(frD * !bFrByLevel + 1001 * bFrByLevel);
+
+        return std::make_tuple(frN, frD);
+    }
+
+    static mfxU16 MaxBitDepthByFourCC(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        auto FourCC = par.mvp.mfx.FrameInfo.FourCC;
+        bool b4CCMax10 =
+            FourCC == MFX_FOURCC_A2RGB10
+            || FourCC == MFX_FOURCC_P010
+            || FourCC == MFX_FOURCC_P210
+            || FourCC == MFX_FOURCC_Y210
+            || FourCC == MFX_FOURCC_Y410;
+        return mfxU16(8 + 2 * b4CCMax10);
+    }
+
+    static mfxU16 MaxChromaByFourCC(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        auto fcc = par.mvp.mfx.FrameInfo.FourCC;
+        bool bMax420 =
+            fcc == MFX_FOURCC_NV12
+            || fcc == MFX_FOURCC_P010
+            || (IsOn(par.mvp.mfx.LowPower) && (fcc == MFX_FOURCC_Y210 || fcc == MFX_FOURCC_YUY2));
+
+        bool bMax422 =
+            fcc == MFX_FOURCC_YUY2
+            || fcc == MFX_FOURCC_Y210
+            || fcc == MFX_FOURCC_P210;
+        bool bMax444 = !(bMax422 || bMax420);
+
+        return mfxU16(
+            bMax420 * MFX_CHROMAFORMAT_YUV420
+            + bMax422 * MFX_CHROMAFORMAT_YUV422
+            + bMax444 * MFX_CHROMAFORMAT_YUV444);
+    }
+
+    static mfxU16 MaxBitDepth(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        auto profile = par.mvp.mfx.CodecProfile;
+        const mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par.mvp);
+        bool bCheckConstraints = profile >= MFX_PROFILE_HEVC_REXT && pHEVC;
+        bool bMax8 =
+            profile == MFX_PROFILE_HEVC_MAIN
+            || profile == MFX_PROFILE_HEVC_MAINSP
+            || (bCheckConstraints && (pHEVC->GeneralConstraintFlags & MFX_HEVC_CONSTR_REXT_MAX_8BIT));
+        bool bMax10 =
+            profile == MFX_PROFILE_HEVC_MAIN10
+            || (bCheckConstraints && (pHEVC->GeneralConstraintFlags & MFX_HEVC_CONSTR_REXT_MAX_10BIT));
+        bool bMax12 =
+            (bCheckConstraints && (pHEVC->GeneralConstraintFlags & MFX_HEVC_CONSTR_REXT_MAX_12BIT));
+
+        std::list<mfxU16> maxBD({
+            mfxU16(8 + !!par.caps.MaxEncodedBitDepth * (1 << par.caps.MaxEncodedBitDepth))
+            , mfxU16(bMax8 * 8)
+            , mfxU16(bMax10 * 10)
+            , mfxU16(bMax12 * 12)
+            , par.mvp.mfx.FrameInfo.BitDepthLuma
+            , par.base.GetMaxBitDepthByFourCC(par)
+            });
+
+        maxBD.sort();
+        maxBD.remove(0);
+
+        return maxBD.front();
+    }
+
+    static mfxU16 MaxChroma(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par.mvp);
+        mfxU32 profile = par.mvp.mfx.CodecProfile;
+        bool bCheckConstraints = profile >= MFX_PROFILE_HEVC_REXT && pHEVC;
+        bool bMax420 =
+            profile == MFX_PROFILE_HEVC_MAIN
+            || profile == MFX_PROFILE_HEVC_MAINSP
+            || profile == MFX_PROFILE_HEVC_MAIN10
+            || (bCheckConstraints && (pHEVC->GeneralConstraintFlags & MFX_HEVC_CONSTR_REXT_MAX_420CHROMA));
+
+        bool bMax422 =
+            (bCheckConstraints && (pHEVC->GeneralConstraintFlags & MFX_HEVC_CONSTR_REXT_MAX_422CHROMA));
+        bMax422 &= !bMax420;
+
+        bool bMax444 = !(bMax422 || bMax420);
+
+        mfxU16 maxCf = mfxU16(
+            bMax420 * MFX_CHROMAFORMAT_YUV420
+            + bMax422 * MFX_CHROMAFORMAT_YUV422
+            + bMax444 * MFX_CHROMAFORMAT_YUV444);
+
+        return std::min<mfxU16>(maxCf, par.base.GetMaxChromaByFourCC(par));
+    }
+
+    static mfxU16 TargetBitDepthLuma(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp);
+
+        if (pCO3 && pCO3->TargetBitDepthLuma)
+        {
+            return pCO3->TargetBitDepthLuma;
+        }
+        return par.base.GetMaxBitDepth(par);
+    }
+
+    static mfxU16 TargetChromaFormat(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp);
+
+        if (pCO3 && pCO3->TargetChromaFormatPlus1)
+        {
+            return pCO3->TargetChromaFormatPlus1;
+        }
+        //For RGB4 use illogical default 420 for backward compatibility
+        if (par.mvp.mfx.FrameInfo.FourCC == MFX_FOURCC_RGB4)
+        {
+            return mfxU16(MFX_CHROMAFORMAT_YUV420 + 1);
+        }
+        return mfxU16(par.base.GetMaxChroma(par) + 1);
+    }
+
+    static mfxU32 TargetKbps(
+        Defaults::TChain<mfxU32>::TExt
+        , const Defaults::Param& par)
+    {
+        auto& mfx = par.mvp.mfx;
+
+        if (mfx.TargetKbps)
+        {
+            return mfx.TargetKbps * std::max<const mfxU32>(1, mfx.BRCParamMultiplier);
+        }
+
+        mfxU32 frN, frD, maxBR = 0xffffffff;
+
+        SetIf(maxBR, !!mfx.CodecLevel, [&]() { return GetMaxKbpsByLevel(par.mvp); });
+
+        mfxU16 W = par.base.GetCodedPicWidth(par);
+        mfxU16 H = par.base.GetCodedPicHeight(par);
+        std::tie(frN, frD) = par.base.GetFrameRate(par);
+
+        mfxU16 bd = par.base.GetTargetBitDepthLuma(par);
+        mfxU16 cf = par.base.GetTargetChromaFormat(par) - 1;
+        mfxU32 rawBits = (Legacy::GetRawBytes(W, H, cf, bd) << 3);
+
+        return std::min<mfxU32>(maxBR, rawBits * frN / frD / 150000);
+    }
+
+    static mfxU32 MaxKbps(
+        Defaults::TChain<mfxU32>::TExt
+        , const Defaults::Param& par)
+    {
+        auto& mfx = par.mvp.mfx;
+
+        if (mfx.MaxKbps && mfx.RateControlMethod != MFX_RATECONTROL_CQP && mfx.RateControlMethod != MFX_RATECONTROL_CBR)
+        {
+            return mfx.MaxKbps * std::max<const mfxU32>(1, mfx.BRCParamMultiplier);
+        }
+        return par.base.GetTargetKbps(par);
+    }
+
+    static mfxU32 BufferSizeInKB(
+        Defaults::TChain<mfxU32>::TExt
+        , const Defaults::Param& par)
+    {
+        auto& mfx = par.mvp.mfx;
+
+        if (mfx.BufferSizeInKB)
+        {
+            return mfx.BufferSizeInKB * std::max<const mfxU32>(1, mfx.BRCParamMultiplier);
+        }
+
+        bool bUseMaxKbps =
+            mfx.RateControlMethod == MFX_RATECONTROL_CBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_VBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_QVBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_VCM
+            || mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT;
+        mfxU32 maxCPB             = 0xffffffff;
+        mfxU32 minCPB             = bUseMaxKbps * InitialDelayInKB(par.mvp.mfx);
+        mfxU32 defaultCPB         = 0;
+        auto   GetMaxCPBByLevel   = [&]() { return GetMaxCpbInKBByLevel(par.mvp); };
+        auto   GetCPBFromMaxKbps  = [&]() { return par.base.GetMaxKbps(par) / 4; };
+        auto   GetCPBFromRawBytes = [&]()
+        {
+            mfxU16 bd = par.base.GetTargetBitDepthLuma(par);
+            mfxU16 W  = par.base.GetCodedPicWidth(par);
+            mfxU16 H  = par.base.GetCodedPicWidth(par);
+            mfxU16 cf = par.base.GetTargetChromaFormat(par) - 1;
+            return Legacy::GetRawBytes(W, H, cf, bd) / 1000;
+        };
+
+        SetIf(maxCPB, !!mfx.CodecLevel, GetMaxCPBByLevel);
+        SetIf(defaultCPB, bUseMaxKbps, GetCPBFromMaxKbps);
+        SetDefault(defaultCPB, GetCPBFromRawBytes);
+
+        return std::max<mfxU32>(minCPB, std::min<mfxU32>(maxCPB, defaultCPB));
+    }
+
+    static std::tuple<mfxU16, mfxU16> MaxNumRef(
+        Defaults::TChain<std::tuple<mfxU16, mfxU16>>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU16 tu = par.mvp.mfx.TargetUsage;
+        CheckRangeOrSetDefault<mfxU16>(tu, 1, 7, 4);
+        bool bGen9  = (par.hw < MFX_HW_CNL);
+        bool bLP    = IsOn(par.mvp.mfx.LowPower);
+        bool bTU7   = (tu == 7);
+        --tu;
+
+        static const mfxU16 nRefs[2][2][7] =
+        {
+            {// VME
+                  { 4, 4, 3, 3, 3, 1, 1 }
+                , { 2, 2, 1, 1, 1, 1, 1 }
+            }
+            , {// VDENC
+                  { 3, 3, 2, 2, 2, 1, 1 }
+                , { 3, 3, 2, 2, 2, 1, 1 }
+            }
+        };
+
+        mfxU16 nRefL0 = mfxU16(
+            bGen9 * (par.caps.MaxNum_Reference0 * !bTU7 + bTU7)
+            + !bGen9 * nRefs[bLP][0][tu]);
+        mfxU16 nRefL1 = mfxU16(
+            bGen9 * (par.caps.MaxNum_Reference1 * !bTU7 + bTU7)
+            + !bGen9 * nRefs[bLP][1][tu]);
+
+        mfxU16 numRefFrame = par.mvp.mfx.NumRefFrame + !par.mvp.mfx.NumRefFrame * 16;
+
+        return std::make_tuple(
+            std::min<mfxU16>({ nRefL0, par.caps.MaxNum_Reference0, numRefFrame })
+            , std::min<mfxU16>({ nRefL1, par.caps.MaxNum_Reference1, numRefFrame }));
+    }
+
+    static mfxU16 RateControlMethod(
+        Defaults::TChain< mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        if (par.mvp.mfx.RateControlMethod)
+        {
+            return par.mvp.mfx.RateControlMethod;
+        }
+        return mfxU16(MFX_RATECONTROL_CQP);
+    }
+
+    static mfxU8 MinQPMFX(
+        Defaults::TChain< mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        // negative QP for CQP VME only;
+        bool bPositive =
+            !par.caps.NegativeQPSupport
+            || IsOn(par.mvp.mfx.LowPower) // remove when caps.NegativeQPSupport is correctly set in driver
+            || par.mvp.mfx.RateControlMethod != MFX_RATECONTROL_CQP;
+        bool bMin10 = IsOn(par.mvp.mfx.LowPower) && !Legacy::IsSWBRC(par.mvp, ExtBuffer::Get(par.mvp)); // 10 is min QP for VDENC
+
+        return mfxU8(std::max(1, (bMin10 * 10) + (bPositive * (6 * (par.base.GetTargetBitDepthLuma(par) - 8)))));
+    }
+
+    static mfxU8 MaxQPMFX(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        return 51 + 6 * mfxU8(std::max<mfxU16>(8, par.base.GetTargetBitDepthLuma(par)) - 8);
+    }
+
+    static std::tuple<mfxU16, mfxU16, mfxU16> QPMFX(
+        Defaults::TChain<std::tuple<mfxU16, mfxU16, mfxU16>>::TExt
+        , const Defaults::Param& par)
+    {
+        bool bCQP = (par.base.GetRateControlMethod(par) == MFX_RATECONTROL_CQP);
+
+        mfxU16 QPI = bCQP * par.mvp.mfx.QPI;
+        mfxU16 QPP = bCQP * par.mvp.mfx.QPP;
+        mfxU16 QPB = bCQP * par.mvp.mfx.QPB;
+
+        bool bValid = (QPI && QPP && QPB);
+
+        if (bValid)
+            return std::make_tuple(QPI, QPP, QPB);
+
+        auto maxQP = par.base.GetMaxQPMFX(par);
+
+        SetDefault(QPI, std::max<mfxU16>(par.base.GetMinQPMFX(par), (maxQP + 1) / 2));
+        SetDefault(QPP, std::min<mfxU16>(QPI + 2, maxQP));
+        SetDefault(QPB, std::min<mfxU16>(QPP + 2, maxQP));
+
+        return std::make_tuple(QPI, QPP, QPB);
+    }
+
+    static mfxU16 QPOffset(
+        Defaults::TGetQPOffset::TExt
+        , const Defaults::Param& par
+        , mfxI16(*pQPOffset)[8])
+    {
+        mfxU16 EnableQPOffset = 0;
+
+        if (const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp))
+        {
+            EnableQPOffset = pCO3->EnableQPOffset;
+        }
+
+        if (!EnableQPOffset)
+        {
+            bool bCQP  = par.base.GetRateControlMethod(par) == MFX_RATECONTROL_CQP;
+            bool bBPyr = bCQP && par.base.GetBRefType(par) == MFX_B_REF_PYRAMID;
+            bool bPPyr = bCQP && !bBPyr && par.base.GetPRefType(par) == MFX_P_REF_PYRAMID;
+
+            EnableQPOffset = Bool2CO(bBPyr || bPPyr);
+
+            bool bGenerate = IsOn(EnableQPOffset) && pQPOffset;
+
+            if (bGenerate)
+            {
+                mfxI16 QPX = 0, i = 0, maxQPOffset = 0, minQPOffset = 0;
+
+                SetIf(QPX, bBPyr, [&]() { return std::get<2>(par.base.GetQPMFX(par)); });
+                SetIf(QPX, bPPyr, [&]() { return std::get<1>(par.base.GetQPMFX(par)); });
+
+                maxQPOffset = mfxI16(par.base.GetMaxQPMFX(par) - QPX);
+                minQPOffset = mfxI16(par.base.GetMinQPMFX(par) - QPX);
+
+                std::generate_n(*pQPOffset, 8
+                    , [&]() { return mfx::clamp<mfxI16>(i++ + bBPyr, minQPOffset, maxQPOffset); });
+            }
+        }
+
+        bool bZeroOffset = IsOff(EnableQPOffset) && pQPOffset;
+        std::fill_n(*pQPOffset, 8 * bZeroOffset, mfxI16(0));
+
+        return EnableQPOffset;
+    }
+
+    static mfxU16 Profile(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        bool bPassThrough = !!par.mvp.mfx.CodecProfile;
+
+        mfxU16 bd = 0, cf = 0;
+        SetIf(bd, !bPassThrough, [&]() { return par.base.GetTargetBitDepthLuma(par); });
+        SetIf(cf, !bPassThrough, [&]() { return mfxU16(par.base.GetTargetChromaFormat(par) - 1); });
+
+        bool bRext = !bPassThrough && (cf != MFX_CHROMAFORMAT_YUV420 || bd > 10);
+        bool bMain10 = !bPassThrough && !bRext && bd == 10;
+        bool bMain = !bPassThrough && !bRext && !bMain10;
+
+        return
+            bPassThrough * par.mvp.mfx.CodecProfile
+            + bRext * MFX_PROFILE_HEVC_REXT
+            + bMain10 * MFX_PROFILE_HEVC_MAIN10
+            + bMain * MFX_PROFILE_HEVC_MAIN;
+    }
+
+    static bool GUID(
+        Defaults::TGetGUID::TExt
+        , const Defaults::Param& par
+        , ::GUID& guid)
+    {
+        const std::map<mfxU16, std::map<mfxU16, ::GUID>> GUIDSupported[2] =
+        {
+            //LowPower = OFF
+            {
+                {
+                    mfxU16(8),
+                    {
+                          {mfxU16(MFX_CHROMAFORMAT_YUV420), DXVA2_Intel_Encode_HEVC_Main}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV422), DXVA2_Intel_Encode_HEVC_Main422}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV444), DXVA2_Intel_Encode_HEVC_Main444}
+                    }
+                }
+                , {
+                    mfxU16(10),
+                    {
+                          {mfxU16(MFX_CHROMAFORMAT_YUV420), DXVA2_Intel_Encode_HEVC_Main10}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV422), DXVA2_Intel_Encode_HEVC_Main422_10}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV444), DXVA2_Intel_Encode_HEVC_Main444_10}
+                    }
+                }
+            }
+            //LowPower = ON
+            ,{
+                {
+                    mfxU16(8),
+                    {
+                          {mfxU16(MFX_CHROMAFORMAT_YUV420), DXVA2_Intel_LowpowerEncode_HEVC_Main}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV422), DXVA2_Intel_LowpowerEncode_HEVC_Main422}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV444), DXVA2_Intel_LowpowerEncode_HEVC_Main444}
+                    }
+                }
+                , {
+                    mfxU16(10),
+                    {
+                          {mfxU16(MFX_CHROMAFORMAT_YUV420), DXVA2_Intel_LowpowerEncode_HEVC_Main10}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV422), DXVA2_Intel_LowpowerEncode_HEVC_Main422_10}
+                        , {mfxU16(MFX_CHROMAFORMAT_YUV444), DXVA2_Intel_LowpowerEncode_HEVC_Main444_10}
+                    }
+                }
+            }
+        };
+        const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp);
+
+        bool bBDInvalid = pCO3 && Check<mfxU16, 10, 8, 0>(pCO3->TargetBitDepthLuma);
+        bool bCFInvalid = pCO3 && Check<mfxU16
+            , MFX_CHROMAFORMAT_YUV420 + 1
+            , MFX_CHROMAFORMAT_YUV422 + 1
+            , MFX_CHROMAFORMAT_YUV444 + 1>
+            (pCO3->TargetChromaFormatPlus1);
+
+        bool bLowPower = IsOn(par.mvp.mfx.LowPower);
+        mfxU16 BitDepth = 8 * (par.hw < MFX_HW_KBL || par.base.GetProfile(par) == MFX_PROFILE_HEVC_MAIN);
+        mfxU16 ChromaFormat = MFX_CHROMAFORMAT_YUV420 * (par.hw < MFX_HW_ICL);
+
+        auto mvpCopy = par.mvp;
+        mvpCopy.NumExtParam = 0;
+
+        Defaults::Param parCopy(mvpCopy, par.caps, par.hw, par.base);
+        auto pParForBD = &par;
+        auto pParForCF = &par;
+
+        SetIf(pParForBD, bBDInvalid, &parCopy);
+        SetIf(pParForCF, bCFInvalid, &parCopy);
+
+        SetIf(BitDepth, !BitDepth, [&]() { return pParForBD->base.GetTargetBitDepthLuma(*pParForBD); });
+        SetIf(ChromaFormat, !ChromaFormat, [&]() { return mfxU16(pParForCF->base.GetTargetChromaFormat(*pParForCF) - 1); });
+
+        bool bSupported =
+            GUIDSupported[bLowPower].count(BitDepth)
+            && GUIDSupported[bLowPower].at(BitDepth).count(ChromaFormat);
+
+        SetIf(guid, bSupported, [&]() { return GUIDSupported[bLowPower].at(BitDepth).at(ChromaFormat); });
+
+        return bSupported;
+    }
+
+    static mfxU16 MBBRC(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par.mvp);
+        bool bPassThrough               = pCO2 && pCO2->MBBRC;
+        bool bON                        = bPassThrough && IsOn(pCO2->MBBRC);
+        bool bOFF                       = bPassThrough && IsOff(pCO2->MBBRC);
+
+        bOFF |= !bPassThrough
+            && (   par.base.GetRateControlMethod(par) == MFX_RATECONTROL_CQP
+                || Legacy::IsSWBRC(par.mvp, pCO2)
+                || IsOn(par.mvp.mfx.LowPower));
+
+        return mfxU16(
+            bON * MFX_CODINGOPTION_ON
+            + bOFF * MFX_CODINGOPTION_OFF);
+    }
+
+    static mfxU16 AsyncDepth(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        return par.mvp.AsyncDepth + !par.mvp.AsyncDepth * 5;
+    }
+
+    static mfxU16 NumSlices(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        if (par.mvp.mfx.NumSlice)
+            return par.mvp.mfx.NumSlice;
+
+        std::vector<SliceInfo> slices;
+        return par.base.GetSlices(par, slices);
+    }
+
+    static mfxU16 LCUSize(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par.mvp);
+
+        if (pHEVC && pHEVC->LCUSize)
+        {
+            return pHEVC->LCUSize;
+        }
+
+        bool   bForce64   = par.hw >= MFX_HW_CNL && IsOn(par.mvp.mfx.LowPower);
+        bool   bMaxByCaps = par.hw >= MFX_HW_CNL && !IsOn(par.mvp.mfx.LowPower);
+        bool   bForce32   = !bForce64 && !bMaxByCaps;
+        mfxU16 LCUSize    =
+            bForce64 * 64
+            + bForce32 * 32
+            + bMaxByCaps * (1 << (CeilLog2(par.caps.LCUSizeSupported + 1) + 3));
+
+        assert((LCUSize >> 4) & par.caps.LCUSizeSupported);
+
+        return LCUSize;
+    }
+
+    static bool HRDConformanceON(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption* pCO = ExtBuffer::Get(par.mvp);
+        return (!pCO || !(IsOff(pCO->NalHrdConformance) || IsOff(pCO->VuiNalHrdParameters)))
+            && (   par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+                || par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+                || par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_VCM
+                || par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_QVBR);
+    }
+
+    static mfxU16 PicTimingSEI(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtCodingOption* pCO = ExtBuffer::Get(par.mvp);
+        bool bForceON = pCO && IsOn(pCO->PicTimingSEI);
+        bool bForceOFF = pCO && IsOff(pCO->PicTimingSEI);
+        return Bool2CO(bForceON || (!bForceOFF && par.base.GetHRDConformanceON(par)));
+    }
+
+    static mfxU16 PPyrInterval(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        return mfxU16(
+            !!par.mvp.mfx.NumRefFrame * std::min<mfxU16>(DEFAULT_PPYR_INTERVAL, par.mvp.mfx.NumRefFrame)
+            + !par.mvp.mfx.NumRefFrame * DEFAULT_PPYR_INTERVAL);
+    }
+
+    static mfxU8 PLayer(
+        Defaults::TGetPLayer::TExt
+        , const Defaults::Param& par
+        , mfxU32 fo)
+    {
+        const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par.mvp);
+        auto num = par.base.GetPPyrInterval(par);
+        mfxU32 i = fo % num;
+
+        bool bForce0 = 
+            (pCO3 && pCO3->PRefType != MFX_P_REF_PYRAMID)
+            || i == 0
+            || i >= num;
+
+        if (bForce0)
+            return 0;
+
+        mfxU32 level = 1;
+        mfxU32 begin = 0;
+        mfxU32 end = num;
+        mfxU32 t = (begin + end + 1) / 2;
+
+        while (t != i)
+        {
+            ++level;
+            SetIf(begin, i > t, t);
+            SetIf(end, i <= t, t);
+            t = (begin + end + 1) / 2;
+        }
+
+        return (mfxU8)std::min<mfxU32>(level, 7);
+    }
+
+    static mfxU8 TId(
+        Defaults::TGetTId::TExt
+        , const Defaults::Param& par
+        , mfxU32 fo)
+    {
+        const mfxExtAvcTemporalLayers* pTL = ExtBuffer::Get(par.mvp);
+        if (!pTL)
+            return 0;
+        return TemporalLayers(*pTL).GetTId(fo);
+    }
+
+    static mfxU16 NumTemporalLayers(
+        Defaults::TChain<mfxU16>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtAvcTemporalLayers* pTL = ExtBuffer::Get(par.mvp);
+        if (!pTL)
+            return 1;
+        return TemporalLayers::CountTL(*pTL);
+    }
+
+    static mfxU8 HighestTId(
+        Defaults::TChain<mfxU8>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtAvcTemporalLayers* pTL = ExtBuffer::Get(par.mvp);
+        if (!pTL)
+            return mfxU8(-1);
+        return TemporalLayers(*pTL).HighestTId();
+    }
+
+    static mfxU8 NumReorderFrames(
+        Defaults::TChain<mfxU8>::TExt
+        , const Defaults::Param& par)
+    {
+        mfxU8 BFrameRate = mfxU8(par.base.GetGopRefDist(par) - 1);
+        bool  bBPyramid  = (par.base.GetBRefType(par) == MFX_B_REF_PYRAMID);
+        mfxU8 n          = !!BFrameRate;
+
+        if (bBPyramid && n--)
+        {
+            while (BFrameRate)
+            {
+                BFrameRate >>= 1;
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    static bool NonStdReordering(
+        Defaults::TChain<mfxU8>::TExt
+        , const Defaults::Param& par)
+    {
+        return
+            par.mvp.mfx.EncodedOrder
+            && par.mvp.mfx.NumRefFrame > 2
+            && (par.base.GetBRefType(par) == MFX_B_REF_PYRAMID)
+            && par.base.GetMinRefForBPyramid(par) > par.mvp.mfx.NumRefFrame;
+    }
+
+    static mfxU16 FrameType(
+        Defaults::TGetFrameType::TExt
+        , const Defaults::Param& par
+        , mfxU32 displayOrder
+        , mfxU32 lastIDR)
+    {
+        mfxU32 gopOptFlag = par.mvp.mfx.GopOptFlag;
+        mfxU32 gopPicSize = par.mvp.mfx.GopPicSize;
+        mfxU32 gopRefDist = par.mvp.mfx.GopRefDist;
+        mfxU32 idrPicDist = gopPicSize * (par.mvp.mfx.IdrInterval);
+
+        //infinite GOP
+        SetIf(idrPicDist, gopPicSize == 0xffff, 0xffffffff);
+        SetIf(gopPicSize, gopPicSize == 0xffff, 0xffffffff);
+
+        mfxU32 fo = displayOrder - lastIDR;
+        bool bIdr = fo == 0 || (idrPicDist && (fo % idrPicDist == 0));
+        bool bIRef = !bIdr && (fo % gopPicSize == 0);
+        bool bPRef =
+            !bIdr && !bIRef
+            && (   (fo % gopPicSize % gopRefDist == 0)
+                || ((fo + 1) % gopPicSize == 0 && (gopOptFlag & MFX_GOP_CLOSED))
+                || (idrPicDist && (fo + 1) % idrPicDist == 0));
+        bool bB = !(bPRef || bIdr || bPRef || bIRef);
+
+        mfxU16 ft =
+            bIdr * (MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF | MFX_FRAMETYPE_IDR)
+            + bIRef * (MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF)
+            + bPRef * (MFX_FRAMETYPE_P | MFX_FRAMETYPE_REF)
+            + bB * (MFX_FRAMETYPE_B);
+
+        bool bForceNonRef = IsRef(ft) && par.base.GetTId(par, fo) == par.base.GetHighestTId(par);
+        ft &= ~(bForceNonRef * MFX_FRAMETYPE_REF);
+
+        return ft;
+    }
+
+    static std::tuple<mfxU8, mfxU8> RPLFromExt(
+        Defaults::TGetRPLFromExt::TExt
+        , const Defaults::Param&
+        , const DpbArray &DPB
+        , mfxU16 maxL0
+        , mfxU16 maxL1
+        , const mfxExtAVCRefLists& extRPL
+        , mfxU8(&RPL)[2][MAX_DPB_SIZE])
+    {
+        typedef decltype(*extRPL.RefPicList0) TRExtRPL0Entry;
+        typedef decltype(*extRPL.RefPicList1) TRExtRPL1Entry;
+
+        mfxU8 l0 = 0, l1 = 0;
+
+        std::for_each(extRPL.RefPicList0
+            , extRPL.RefPicList0 + extRPL.NumRefIdxL0Active
+            , [&](TRExtRPL0Entry ref)
+        {
+            mfxU8 idx = Legacy::GetDPBIdxByFO(DPB, (mfxI32)ref.FrameOrder);
+            RPL[0][l0] = idx;
+            l0 += (idx < MAX_DPB_SIZE) && (l0 < maxL0);
+        });
+
+        std::for_each(extRPL.RefPicList1
+            , extRPL.RefPicList1 + extRPL.NumRefIdxL1Active
+            , [&](TRExtRPL1Entry ref)
+        {
+            mfxU8 idx = Legacy::GetDPBIdxByFO(DPB, (mfxI32)ref.FrameOrder);
+            RPL[1][l1] = idx;
+            l1 += (idx < MAX_DPB_SIZE) && (l1 < maxL1);
+        });
+
+        l0 = std::min(l0, mfxU8(maxL0));
+        l1 = std::min(l1, mfxU8(maxL1));
+
+        std::fill(RPL[0] + l0, RPL[0] + Size(RPL[0]), IDX_INVALID);
+        std::fill(RPL[1] + l1, RPL[1] + Size(RPL[1]), IDX_INVALID);
+
+        return std::make_tuple(l0, l1);
+    }
+
+    static std::tuple<mfxU8, mfxU8> RPLMod(
+        Defaults::TGetRPL::TExt
+        , const Defaults::Param& par
+        , const DpbArray &/*DPB*/
+        , mfxU16 /*maxL0*/
+        , mfxU16 maxL1
+        , const FrameBaseInfo& cur
+        , mfxU8(&RPL)[2][MAX_DPB_SIZE])
+    {
+        mfxU8 l0 = mfxU8(Size(RPL[0]) - std::count(RPL[0], RPL[0] + Size(RPL[0]), IDX_INVALID));
+        mfxU8 l1 = mfxU8(Size(RPL[1]) - std::count(RPL[1], RPL[1] + Size(RPL[1]), IDX_INVALID));
+        bool isB = IsB(cur.FrameType) && !cur.isLDB;
+
+        bool bDefaultL1 = isB && !l1 && l0;
+
+        if (bDefaultL1)
+        {
+            RPL[1][l1++] = RPL[0][l0 - 1];
+        }
+
+        // on VDENC for LDB frames L1 must be completely identical to L0
+        mfxU8 maxLdbL1 = (mfxU8)std::max<mfxU32>(maxL1, l0 * IsOn(par.mvp.mfx.LowPower));
+
+        //ignore l1 != l0 in pExtLists for LDB (unsupported by HW)
+        l1 = l1 * isB + std::min<mfxU8>(l0, maxLdbL1) * !isB;
+
+        std::copy_n(RPL[0], l1 * !isB, RPL[1]);
+
+        return std::make_tuple(l0, l1);
+    }
+
+    static bool CmpRef(
+        Defaults::TCmpRef::TExt
+        , const Defaults::Param&
+        , const FrameBaseInfo &cur
+        , const FrameBaseInfo &a
+        , const FrameBaseInfo &b)
+    {
+        return abs(cur.POC - a.POC) < abs(cur.POC - b.POC);
+    }
+
+    static const DpbFrame* WeakRef(
+        Defaults::TGetWeakRef::TExt
+        , const Defaults::Param& par
+        , const FrameBaseInfo  &/*cur*/
+        , const DpbFrame       *begin
+        , const DpbFrame       *end)
+    {
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+
+        if (CO3.PRefType == MFX_P_REF_PYRAMID)
+        {
+            auto CmpLDRefs = [&](const DpbFrame& a, const DpbFrame& b)
+            {
+                return (a.PyramidLevel > b.PyramidLevel
+                    || (a.PyramidLevel == b.PyramidLevel && a.POC < b.POC));
+            };
+
+            return std::min_element(begin, end, CmpLDRefs);
+        }
+
+        auto POCLess = [](const DpbFrame& a, const DpbFrame& b) { return a.POC < b.POC; };
+
+        return std::min_element(begin, end, POCLess);
+    }
+
+    static std::tuple<mfxU8, mfxU8> RPL(
+        Defaults::TGetRPL::TExt
+        , const Defaults::Param& par
+        , const DpbArray &DPB
+        , mfxU16 maxL0
+        , mfxU16 maxL1
+        , const FrameBaseInfo& cur
+        , mfxU8(&RPL)[2][MAX_DPB_SIZE])
+    {
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+        bool bLowDelay = (CO3.PRefType == MFX_P_REF_PYRAMID);
+        mfxU8 l0 = 0, l1 = 0;
+        const DpbFrame* dpbBegin = &DPB[0];
+        std::list<const DpbFrame*> L0(Size(DPB), nullptr);
+        std::list<const DpbFrame*> L1(Size(DPB) * (IsB(cur.FrameType) && !cur.isLDB), nullptr);
+
+        std::iota(L0.begin(), L0.end(), dpbBegin);
+        std::iota(L1.begin(), L1.end(), dpbBegin);
+
+        L0.remove_if([&](const DpbFrame* x)
+        {
+            return
+                !isValid(*x)
+                || x->TemporalID > cur.TemporalID
+                || x->POC > cur.POC;
+        });
+
+        L1.remove_if([&](const DpbFrame* x)
+        {
+            return
+                !isValid(*x)
+                || x->TemporalID > cur.TemporalID
+                || x->POC < cur.POC;
+        });
+
+        bool bL1 = false;
+        auto Closer = [&](const DpbFrame* a, const DpbFrame* b)
+        {
+            return par.base.CmpRefLX[bL1](par, cur, *a, *b);
+        };
+        auto CmpRefs = [&](const DpbFrame* a, const DpbFrame* b) // return (a > b)
+        {
+            bool bEQ = true;
+            bool bGT = false;
+            bGT |= bEQ && (bLowDelay && (a->PyramidLevel < b->PyramidLevel));
+            bEQ &= !bLowDelay || (a->PyramidLevel == b->PyramidLevel);
+            bGT |= bEQ && Closer(a, b);
+            return bGT;
+        };
+
+        if (L0.empty())
+        {
+            assert(!"L0 is empty - reordering issue?");
+            L0 = L1;
+        }
+
+        L0.sort(CmpRefs);
+        L0.splice(L0.begin(), L0, std::min_element(L0.begin(), L0.end(), Closer));
+
+        bL1 = true;
+        L1.sort(CmpRefs);
+
+        l0 = mfxU8(std::min<size_t>(L0.size(), maxL0));
+        l1 = mfxU8(std::min<size_t>(L1.size(), maxL1));
+
+        L0.resize(l0);
+        L1.resize(l1);
+
+        std::transform(L0.begin(), L0.end(), RPL[0]
+            , [&](const DpbFrame* x) { return mfxU8(x - dpbBegin); });
+
+        std::transform(L1.begin(), L1.end(), RPL[1]
+            , [&](const DpbFrame* x) { return mfxU8(x - dpbBegin); });
+
+        return std::make_tuple(l0, l1);
+    }
+
+    static std::tuple<mfxU8, mfxU8> RPLFromCtrl(
+        Defaults::TGetRPLFromCtrl::TExt
+        , const Defaults::Param&
+        , const DpbArray &DPB
+        , mfxU16 maxL0
+        , mfxU16 maxL1
+        , const FrameBaseInfo& cur
+        , const mfxExtAVCRefListCtrl& ctrl
+        , mfxU8(&RPL)[2][MAX_DPB_SIZE])
+    {
+        typedef decltype(*ctrl.RejectedRefList) TRRejected;
+        typedef decltype(*ctrl.PreferredRefList) TRPreferred;
+
+        mfxU8 pref[2] = {};
+        mfxU8 IdxList[16];
+        auto pIdxListEnd = IdxList + Size(IdxList);
+        mfxU8 l0 = mfxU8(Size(RPL[0]) - std::count(RPL[0], RPL[0] + Size(RPL[0]), IDX_INVALID));
+        mfxU8 l1 = mfxU8(Size(RPL[1]) - std::count(RPL[1], RPL[1] + Size(RPL[1]), IDX_INVALID));
+
+        SetIf(maxL0, ctrl.NumRefIdxL0Active, std::min<mfxU16>(ctrl.NumRefIdxL0Active, maxL0));
+        SetIf(maxL1, ctrl.NumRefIdxL1Active, std::min<mfxU16>(ctrl.NumRefIdxL1Active, maxL1));
+
+        std::transform(
+            ctrl.RejectedRefList
+            , ctrl.RejectedRefList + Size(IdxList)
+            , IdxList
+            , [&](TRRejected x) { return Legacy::GetDPBIdxByFO(DPB, x.FrameOrder); });
+
+        l0 = mfxU8(std::remove_if(RPL[0], RPL[0] + l0, [&](mfxU8 ref) {
+            return std::find(IdxList, pIdxListEnd, ref) != pIdxListEnd; }) - RPL[0]);
+        l1 = mfxU8(std::remove_if(RPL[1], RPL[1] + l1, [&](mfxU8 ref) {
+            return std::find(IdxList, pIdxListEnd, ref) != pIdxListEnd; }) - RPL[1]);
+
+        std::transform(
+            ctrl.PreferredRefList
+            , ctrl.PreferredRefList + Size(IdxList)
+            , IdxList
+            , [&](TRPreferred x) { return Legacy::GetDPBIdxByFO(DPB, x.FrameOrder); });
+
+        pIdxListEnd = std::remove_if(IdxList, pIdxListEnd
+            , [&](mfxU8 ref) { return ref >= MAX_DPB_SIZE; });
+
+        mfxU8* pRplEnd[2] = { RPL[0] + l0, RPL[1] + l1 };
+
+        std::for_each(IdxList, pIdxListEnd
+            , [&](mfxU8 ref)
+        {
+            bool lx = DPB[ref].POC > cur.POC;
+            pRplEnd[lx] = std::remove(RPL[lx], pRplEnd[lx], ref);
+            Insert(RPL[lx], pref[lx]++, ref);
+            ++pRplEnd[lx];
+        });
+
+        l0 = std::min<mfxU8>((mfxU8)maxL0, mfxU8(RPL[0] - pRplEnd[0]));
+        l1 = std::min<mfxU8>((mfxU8)maxL1, mfxU8(RPL[1] - pRplEnd[1]));
+
+        Remove(RPL[0], l0, Size(RPL[0]) - l0);
+        Remove(RPL[1], l1, Size(RPL[1]) - l1);
+
+        bool bDefaultL0 = (l0 == 0);
+        RPL[0][l0 += bDefaultL0] *= !bDefaultL0;
+
+        return std::make_tuple(l0, l1);
+    }
+
+    static mfxStatus PreReorderInfo(
+        Defaults::TGetPreReorderInfo::TExt
+        , const Defaults::Param& par
+        , FrameBaseInfo& fi
+        , const mfxFrameSurface1* pSurfIn
+        , const mfxEncodeCtrl*    pCtrl
+        , mfxU32 prevIDROrder
+        , mfxI32 prevIPOC
+        , mfxU32 frameOrder)
+    {
+        mfxU16 ftype = 0;
+        auto SetFrameTypeFromGOP   = [&]() { return          Res2Bool(ftype, par.base.GetFrameType(par, frameOrder, prevIDROrder)); };
+        auto SetFrameTypeFromCTRL  = [&]() { return pCtrl && Res2Bool(ftype, pCtrl->FrameType); };
+        auto ForceIdr              = [&]() { return          Res2Bool(ftype, mfxU16(MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF | MFX_FRAMETYPE_IDR)); };
+        auto SetFrameOrderFromSurf = [&]() { if (!pSurfIn) return false; frameOrder = pSurfIn->Data.FrameOrder;  return true; };
+
+        bool bFrameInfoValid =
+            (par.mvp.mfx.EncodedOrder && SetFrameOrderFromSurf() && SetFrameTypeFromCTRL() )
+            || (pCtrl && IsIdr(pCtrl->FrameType) && ForceIdr())
+            || SetFrameTypeFromGOP();
+        MFX_CHECK(bFrameInfoValid, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        fi.POC        = !IsIdr(ftype) * (frameOrder - prevIDROrder);
+        fi.FrameType  = ftype;
+        fi.TemporalID = !IsI(ftype) * par.base.GetTId(par, fi.POC - prevIPOC);
+
+        if (IsP(ftype))
+        {
+            const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+
+            fi.isLDB        = IsOn(CO3.GPB);
+            fi.PyramidLevel = par.base.GetPLayer(par, fi.POC - prevIPOC);
+        }
+
+        return MFX_ERR_NONE;
+    }
+
+    static std::tuple<mfxU8, mfxU8> FrameNumRefActive(
+        Defaults::TGetFrameNumRefActive::TExt
+        , const Defaults::Param& par
+        , const FrameBaseInfo& fi)
+    {
+        mfxU8 nL0 = 0, nL1 = 0;
+
+        if (IsB(fi.FrameType))
+        {
+            const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+            const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par.mvp);
+            mfxI32 layer = (CO2.BRefType == MFX_B_REF_PYRAMID) * mfx::clamp<mfxI32>(fi.PyramidLevel - 1, 0, 7);
+
+            nL0 = (mfxU8)CO3.NumRefActiveBL0[layer];
+            nL1 = (mfxU8)CO3.NumRefActiveBL1[layer];
+        }
+
+        if (IsP(fi.FrameType))
+        {
+            const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
+            auto layer = mfx::clamp<mfxI32>(fi.PyramidLevel, 0, 7);
+
+            nL0 = (mfxU8)CO3.NumRefActiveP[layer];
+            nL1 = (mfxU8)std::min<mfxU16>(CO3.NumRefActiveP[layer], CO3.NumRefActiveBL1[layer]);
+        }
+
+        return std::make_tuple(nL0, nL1);
+    }
+
+    static mfxU16 LowPower(
+        Defaults::TGetHWDefault<mfxU16>::TExt
+        , const mfxVideoParam& par
+        , eMFXHWType hw)
+    {
+        bool bValid =
+            par.mfx.LowPower
+            && !CheckTriState(par.mfx.LowPower);
+
+        bool bOn =
+            (hw == MFX_HW_CNL
+                && par.mfx.TargetUsage >= 6
+                && par.mfx.GopRefDist < 2
+                && !bValid);
+
+        return mfxU16(
+            bOn * MFX_CODINGOPTION_ON
+            + bValid * par.mfx.LowPower
+            + !(bOn || bValid) * MFX_CODINGOPTION_OFF);
+    }
+
+    static std::tuple<mfxU16, mfxU16> NumTiles(
+        Defaults::TChain<std::tuple<mfxU16, mfxU16>>::TExt
+        , const Defaults::Param& par)
+    {
+        const mfxExtHEVCTiles* pTiles = ExtBuffer::Get(par.mvp);
+
+        mfxU16 nCol = 1;
+        mfxU16 nRow = 1;
+
+        if (pTiles)
+        {
+            nCol = std::max<mfxU16>(nCol, pTiles->NumTileColumns);
+            nRow = std::max<mfxU16>(nRow, pTiles->NumTileRows);
+        }
+
+        return std::make_tuple(nCol, nRow);
+    }
+
+    static mfxU16 TileSlices(
+        Defaults::TGetTileSlices::TExt
+        , const Defaults::Param& dpar
+        , std::vector<SliceInfo>& slices
+        , mfxU32 SliceStructure
+        , mfxU32 nCol
+        , mfxU32 nRow
+        , mfxU32 nSlice)
+    {
+        /*SliceStructure indicates the restrictions set on the slice structure.*/
+        //One slice only to code the whole frame.
+        const mfxU32 OneSlice           = 0;
+        /*Slices are composed of a power of 2 number of rows and each slice
+          must have the same size (width and height) except for the last one,
+          which must be smaller or equal to the previous slices. */
+        const mfxU32 Pow2Rows           = 1;
+        /*Slices are composed of any number of rows, but all must have the same
+        size (width and height) except for the last one, which must be smaller
+        or equal to the previous slices.*/
+        const mfxU32 RowSlice           = 2;
+        //Arbitrary number of rows per slice for all slices.
+        //const mfxU32 ArbitraryRowSlice  = 3;
+        //Arbitrary number of macroblocks per slice for all slices.
+        const mfxU32 ArbitraryMbSlice   = 4;
+
+        mfxU32 nLCU                   = nCol * nRow;
+        mfxU32 nLcuPerSlice           = 0;
+        mfxU32 nSlicePrev             = (mfxU32)slices.size();
+        mfxU32 segAddr                = 0;
+        mfxU32 nLCUMult               = 1;
+        bool   bStrictNumLCUPerSlice  = false;
+
+        if (nSlicePrev)
+        {
+            segAddr = slices.back().SegmentAddress + slices.back().NumLCU;
+        }
+
+        if (SliceStructure == OneSlice)
+        {
+            slices.emplace_back(SliceInfo{ segAddr, nLCU });
+            return 1;
+        }
+
+        if (const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(dpar.mvp))
+        {
+            bStrictNumLCUPerSlice = !!pCO2->NumMbPerSlice;
+            nLcuPerSlice          = pCO2->NumMbPerSlice;
+        }
+
+        SetDefault(nLcuPerSlice, nLCU / nSlice);
+
+        //in case of NumMbPerSlice != 0 need to check alignment
+        //if it's value is not aligned, warning will be generated in CheckVideoParam() after MakeSlices() call
+        bool   bAlignLcuPerSliceByRows = SliceStructure == RowSlice && bStrictNumLCUPerSlice;
+        mfxU32 nLcuPerSliceAlignment   = std::max<mfxU32>(1, bAlignLcuPerSliceByRows * nCol);
+
+        nLcuPerSlice = CeilDiv<mfxU32>(nLcuPerSlice, nLcuPerSliceAlignment) * nLcuPerSliceAlignment;
+
+        //if not aligned already but need to
+        bAlignLcuPerSliceByRows = !bAlignLcuPerSliceByRows && SliceStructure < ArbitraryMbSlice;
+
+        if (bAlignLcuPerSliceByRows)
+        {
+            nSlice = std::min<mfxU32>(nSlice, nRow);
+            mfxU32 nRowsPerSlice = CeilDiv(nRow, nSlice);
+            bool   bAddSlice     = (SliceStructure != Pow2Rows) && (nRowsPerSlice * nSlice) > nRow;
+
+            nSlice        += bAddSlice;
+            nRowsPerSlice -= bAddSlice;
+
+            if (SliceStructure == Pow2Rows)
+            {
+                mfxU32 nRowLog2     = CeilLog2(nRowsPerSlice);
+                mfxU32 nRowsCand[2] = { mfxU32(1 << (nRowLog2 - 1)), mfxU32(1 << nRowLog2) };
+                mfxI32 dC0          = nRowsPerSlice - nRowsCand[0];
+                mfxI32 dC1          = nRowsCand[1] - nRowsPerSlice;
+
+                nRowsPerSlice = nRowsCand[dC0 > dC1];
+                nSlice = CeilDiv(nRow, nRowsPerSlice);
+            }
+
+            nLcuPerSlice           = nRowsPerSlice;
+            nLCUMult               = nCol;
+            nLCU                  /= nCol;
+            bStrictNumLCUPerSlice |= ((SliceStructure == Pow2Rows) || (SliceStructure == RowSlice));
+        }
+
+        slices.resize(nSlicePrev + nSlice);
+
+        mfxU32 nLCULeft = nLCU % nSlice;
+
+        bStrictNumLCUPerSlice |= (nSlice < 2 || (nLCULeft == 0));
+
+        SliceInfo zeroSI  = {};
+        auto      slBegin = std::next(slices.begin(), nSlicePrev);
+        auto      slEnd   = slices.end();
+
+        std::fill(slBegin, slEnd, zeroSI);
+
+        if (!bStrictNumLCUPerSlice)
+        {
+            bool bLessLCUs = (nLCULeft > (nSlice / 2));
+
+            nLcuPerSlice += bLessLCUs;
+            nLCULeft =
+                !bLessLCUs * nLCULeft
+                + bLessLCUs * (nLcuPerSlice * nSlice - nLCU);
+
+            mfxI32 delta       = (1 - 2 * bLessLCUs) * nLCUMult;
+            mfxU32 step        = !!(nSlice % nLCULeft) + nSlice / nLCULeft;
+            auto   slStepBegin = MakeStepIter(slBegin, step);
+            auto   slStepEnd   = MakeStepIter(slEnd, step);
+            auto   ModNumLCU   = [delta](SliceInfo& si) { si.NumLCU += delta; };
+
+            std::for_each(slStepBegin, slStepEnd, ModNumLCU);
+        }
+
+        std::for_each(
+            slBegin
+            , slEnd
+            , [&](SliceInfo& si)
+        {
+            si.NumLCU         += nLcuPerSlice * nLCUMult;
+            si.SegmentAddress = segAddr;
+            segAddr           += si.NumLCU;
+        });
+
+        slices.back().NumLCU = slBegin->SegmentAddress + (nLCU * nLCUMult) - slices.back().SegmentAddress;
+
+        return (mfxU16)nSlice;
+    }
+
+    static void GetTileUniformSpacingParam(
+        std::vector<mfxU32>& colWidth
+        , std::vector<mfxU32>& rowHeight
+        , std::vector<mfxU32>& TsToRs
+        , mfxU32 nCol
+        , mfxU32 nRow
+        , mfxU32 nTCol
+        , mfxU32 nTRow
+        , mfxU32 nLCU)
+    {
+        std::vector<mfxU32> colBd (nTCol + 1, 0);
+        std::vector<mfxU32> rowBd (nTRow + 1, 0);
+
+        colWidth.resize(nTCol, 0);
+        rowHeight.resize(nTRow, 0);
+        TsToRs.resize(nLCU);
+
+        auto pColBd     = colBd.data();
+        auto pRowBd     = rowBd.data();
+        auto pColWidth  = colWidth.data();
+        auto pRowHeight = rowHeight.data();
+
+        mfxI32 i;
+        auto NextCW = [nCol, nTCol, &i]() { ++i; return ((i + 1) * nCol) / nTCol - (i * nCol) / nTCol; };
+        auto NextRH = [nRow, nTRow, &i]() { ++i; return ((i + 1) * nRow) / nTRow - (i * nRow) / nTRow; };
+        auto NextBd  = [&i](mfxU32 wh) { return (i += wh); };
+
+        i = -1;
+        std::generate(pColWidth, pColWidth + nTCol, NextCW);
+        i = -1;
+        std::generate(pRowHeight, pRowHeight + nTRow, NextRH);
+        i = 0;
+        std::transform(pColWidth, pColWidth + nTCol, pColBd + 1, NextBd);
+        i = 0;
+        std::transform(pRowHeight, pRowHeight + nTRow, pRowBd + 1, NextBd);
+
+        for (mfxU32 rso = 0; rso < nLCU; ++rso)
+        {
+            mfxU32 tbX   = rso % nCol;
+            mfxU32 tbY   = rso / nCol;
+            mfxU32 tso   = 0;
+            auto   LTX   = [tbX](mfxU32 x) { return tbX >= x; };
+            auto   LTY   = [tbY](mfxU32 y) { return tbY >= y; };
+            auto   tileX = std::count_if(pColBd + 1, pColBd + nTCol, LTX);
+            auto   tileY = std::count_if(pRowBd + 1, pRowBd + nTRow, LTY);
+            
+            tso += rowHeight[tileY] * std::accumulate(pColWidth, pColWidth + tileX, 0u);
+            tso += nCol             * std::accumulate(pRowHeight, pRowHeight + tileY, 0u);
+            tso += (tbY - rowBd[tileY]) * colWidth[tileX] + tbX - colBd[tileX];
+
+            assert(tso < nLCU);
+
+            TsToRs[tso] = rso;
+        }
+    }
+
+    static mfxU16 Slices(
+        Defaults::TGetSlices::TExt
+        , const Defaults::Param& defPar
+        , std::vector<SliceInfo>& slices)
+    {
+        const mfxExtCodingOption2* pCO2 = ExtBuffer::Get(defPar.mvp);
+        mfxU16 W        = defPar.base.GetCodedPicWidth(defPar);
+        mfxU16 H        = defPar.base.GetCodedPicHeight(defPar);
+        mfxU16 LCUSize  = defPar.base.GetLCUSize(defPar);
+        mfxU32 nCol     = CeilDiv<mfxU32>(W, LCUSize);
+        mfxU32 nRow     = CeilDiv<mfxU32>(H, LCUSize);
+        auto   tiles    = defPar.base.GetNumTiles(defPar);
+        mfxU32 nTCol    = std::get<0>(tiles);
+        mfxU32 nTRow    = std::get<1>(tiles);
+        mfxU32 nTile    = nTCol * nTRow;
+        mfxU32 nLCU     = nCol * nRow;
+        mfxU32 nSlice   = std::min<mfxU32>(std::min<mfxU32>(nLCU, MAX_SLICES), std::max<mfxU32>(defPar.mvp.mfx.NumSlice, 1));
+        mfxU32 SliceStructure = defPar.caps.SliceStructure;
+        mfxU32 minSlice = !defPar.caps.msdk.bSingleSliceMultiTile * nTile;
+        // DDI:0.9972: VDEnc supports multiple static slices in case of single tile frame only.
+        //             But for multi tiles frame, no single tile can contain multiple static slices.
+        // Actually it's no matter for driver whether dynamic or static slices are used
+        // It returns an error in the both cases.
+        mfxU32 maxSlice = (nTile > 1 && IsOn(defPar.mvp.mfx.LowPower)) * nTile;
+
+        SetDefault(maxSlice, nSlice);
+        maxSlice = std::max(maxSlice, minSlice);
+
+        nSlice = mfx::clamp(nSlice, minSlice, maxSlice);
+
+        bool bHardcodeSliceStructure2 =
+            defPar.hw >= MFX_HW_ICL
+            && IsOn(defPar.mvp.mfx.LowPower)
+            && nTile == 1;
+
+        SliceStructure =
+            SliceStructure * !bHardcodeSliceStructure2
+            + 2 * bHardcodeSliceStructure2;
+
+        slices.resize(0);
+
+        bool bNumMbPerSliceSet = pCO2 && pCO2->NumMbPerSlice != 0;
+        if (bNumMbPerSliceSet)
+            nSlice = CeilDiv<mfxU32>(nLCU / nTile, pCO2->NumMbPerSlice) * nTile;
+
+        nSlice = std::max<mfxU32>(nSlice * (SliceStructure != 0), 1);
+        nSlice = std::max<mfxU32>(nSlice, nTile * (nSlice > 1));
+
+        if (nTile == 1)
+        {
+            //TileScan = RasterScan, no SegmentAddress conversion required
+            return defPar.base.GetTileSlices(defPar, slices, SliceStructure, nCol, nRow, nSlice);
+        }
+
+        std::vector<mfxU32> colWidth  (nTCol, 0);
+        std::vector<mfxU32> rowHeight (nTRow, 0);
+        std::vector<mfxU32> TsToRs    (nLCU);
+
+        //assume uniform spacing
+        GetTileUniformSpacingParam(colWidth, rowHeight, TsToRs, nCol, nRow, nTCol, nTRow, nLCU);
+
+        if (nSlice == 1)
+        {
+            defPar.base.GetTileSlices(defPar, slices, SliceStructure, nCol, nRow, nSlice);
+        }
+        else
+        {
+            using TileInfo = struct
+            {
+                mfxU32 id;
+                mfxU32 nCol;
+                mfxU32 nRow;
+                mfxU32 nLCU;
+                mfxU32 nSlice;
+            };
+            auto TileIdLess = [](TileInfo& l, TileInfo& r)
+            {
+                return l.id < r.id;
+            };
+            auto NumSliceCoeff = [](TileInfo const & tile)
+            {
+                assert(tile.nSlice > 0);
+                return (mfxF64(tile.nLCU) / tile.nSlice);
+            };
+            auto CmpTiles = [&](TileInfo& l, TileInfo& r)
+            {
+                return NumSliceCoeff(l) > NumSliceCoeff(r);
+            };
+            auto AddTileSlices = [&](TileInfo& t)
+            {
+                defPar.base.GetTileSlices(defPar, slices, SliceStructure, t.nCol, t.nRow, t.nSlice);
+            };
+            std::vector<TileInfo> tile(nTile);
+            mfxU32 id           = 0;
+            mfxU32 nLcuPerSlice = CeilDiv(nLCU, nSlice);
+            mfxU32 nSliceRest   = nSlice;
+
+            std::for_each(std::begin(rowHeight), std::end(rowHeight), [&](mfxU32 h)
+            {
+                std::for_each(std::begin(colWidth), std::end(colWidth), [&](mfxU32 w)
+                {
+                    auto& curTile = tile[id];
+                    curTile.id     = id;
+                    curTile.nCol   = w;
+                    curTile.nRow   = h;
+                    curTile.nLCU   = curTile.nCol * curTile.nRow;
+                    curTile.nSlice = std::max<mfxU32>(1U, curTile.nLCU / nLcuPerSlice);
+
+                    nSliceRest -= curTile.nSlice;
+                    ++id;
+                });
+            });
+
+            while (nSliceRest)
+            {
+                std::sort(tile.begin(), tile.end(), CmpTiles);
+
+                assert(tile[0].nLCU > tile[0].nSlice);
+
+                tile[0].nSlice++;
+                nSliceRest--;
+            }
+
+            std::sort(tile.begin(), tile.end(), TileIdLess);
+
+            std::for_each(std::begin(tile), std::end(tile), AddTileSlices);
+        }
+
+        std::for_each(std::begin(slices), std::end(slices)
+            , [&](SliceInfo& s)
+        {
+            assert(s.SegmentAddress < nLCU);
+            s.SegmentAddress = TsToRs[s.SegmentAddress];
+        });
+
+        assert(slices.size() <= MAX_SLICES);
+
+        return (mfxU16)slices.size();
+    }
+
+    static mfxStatus SPS(
+        Defaults::TGetSPS::TExt
+        , const Defaults::Param& defPar
+        , const VPS& vps
+        , Gen11::SPS& sps)
+    {
+        const std::map<mfxU32, mfxU32> arIdc =
+        {
+              {(  0 << 16) +  0,  0}
+            , {(  1 << 16) +  1,  1}
+            , {( 12 << 16) + 11,  2}
+            , {( 10 << 16) + 11,  3}
+            , {( 16 << 16) + 11,  4}
+            , {( 40 << 16) + 33,  5}
+            , {( 24 << 16) + 11,  6}
+            , {( 20 << 16) + 11,  7}
+            , {( 32 << 16) + 11,  8}
+            , {( 80 << 16) + 33,  9}
+            , {( 18 << 16) + 11, 10}
+            , {( 15 << 16) + 11, 11}
+            , {( 64 << 16) + 33, 12}
+            , {(160 << 16) + 99, 13}
+            , {(  4 << 16) +  3, 14}
+            , {(  3 << 16) +  2, 15}
+            , {(  2 << 16) +  1, 16}
+        };
+
+        auto GetAspectRatioIdc = [&arIdc](mfxU16 w, mfxU16 h)
+        {
+            mfxU32 key = (w << 16) + h;
+            return arIdc.count(key) ? mfxU8(arIdc.at(key)) : mfxU8(255);
+        };
+        auto& slo = vps.sub_layer[vps.max_sub_layers_minus1];
+        const mfxExtHEVCParam&      HEVCParam = ExtBuffer::Get(defPar.mvp);
+        const mfxExtCodingOption&   CO        = ExtBuffer::Get(defPar.mvp);
+        const mfxExtCodingOption3&  CO3       = ExtBuffer::Get(defPar.mvp);
+        auto  hw  = defPar.hw;
+        auto& mfx = defPar.mvp.mfx;
+
+        sps = Gen11::SPS{};
+        ((LayersInfo&)sps) = ((LayersInfo&)vps);
+        sps.video_parameter_set_id   = vps.video_parameter_set_id;
+        sps.max_sub_layers_minus1    = vps.max_sub_layers_minus1;
+        sps.temporal_id_nesting_flag = vps.temporal_id_nesting_flag;
+
+        sps.seq_parameter_set_id              = 0;
+        sps.chroma_format_idc                 = CO3.TargetChromaFormatPlus1 - 1;
+        sps.separate_colour_plane_flag        = 0;
+        sps.pic_width_in_luma_samples         = HEVCParam.PicWidthInLumaSamples;
+        sps.pic_height_in_luma_samples        = HEVCParam.PicHeightInLumaSamples;
+        sps.conformance_window_flag           = 0;
+        sps.bit_depth_luma_minus8             = (mfxU8)std::max<mfxI32>(0, CO3.TargetBitDepthLuma - 8);
+        sps.bit_depth_chroma_minus8           = (mfxU8)std::max<mfxI32>(0, CO3.TargetBitDepthChroma - 8);
+        sps.log2_max_pic_order_cnt_lsb_minus4 = (mfxU8)mfx::clamp(CeilLog2(mfx.GopRefDist + slo.max_dec_pic_buffering_minus1) - 1, 0u, 12u);
+
+        sps.log2_min_luma_coding_block_size_minus3   = 0;
+        sps.log2_diff_max_min_luma_coding_block_size = CeilLog2(HEVCParam.LCUSize) - 3 - sps.log2_min_luma_coding_block_size_minus3;
+        sps.log2_min_transform_block_size_minus2     = 0;
+        sps.log2_diff_max_min_transform_block_size   = 3;
+        sps.max_transform_hierarchy_depth_inter      = 2;
+        sps.max_transform_hierarchy_depth_intra      = 2;
+        sps.scaling_list_enabled_flag                = 0;
+
+        bool bHwCNLPlus = (hw >= MFX_HW_CNL);
+        sps.amp_enabled_flag                    = bHwCNLPlus;
+        sps.sample_adaptive_offset_enabled_flag = bHwCNLPlus && !(HEVCParam.SampleAdaptiveOffset & MFX_SAO_DISABLE);
+        sps.pcm_enabled_flag                    = 0;
+        sps.long_term_ref_pics_present_flag     = 1;
+        sps.temporal_mvp_enabled_flag           = 1;
+        sps.strong_intra_smoothing_enabled_flag = 0;
+
+        auto&  fi            = mfx.FrameInfo;
+        mfxU16 SubWidthC[4]  = {1,2,2,1};
+        mfxU16 SubHeightC[4] = {1,2,1,1};
+        mfxU16 cropUnitX     = SubWidthC[sps.chroma_format_idc];
+        mfxU16 cropUnitY     = SubHeightC[sps.chroma_format_idc];
+
+        sps.conf_win_left_offset      = (fi.CropX / cropUnitX);
+        sps.conf_win_right_offset     = (sps.pic_width_in_luma_samples - fi.CropW - fi.CropX) / cropUnitX;
+        sps.conf_win_top_offset       = (fi.CropY / cropUnitY);
+        sps.conf_win_bottom_offset    = (sps.pic_height_in_luma_samples - fi.CropH - fi.CropY) / cropUnitY;
+        sps.conformance_window_flag   =    sps.conf_win_left_offset
+                                        || sps.conf_win_right_offset
+                                        || sps.conf_win_top_offset
+                                        || sps.conf_win_bottom_offset;
+
+        sps.vui_parameters_present_flag         = 1;
+        sps.vui.aspect_ratio_info_present_flag  = 1;
+        sps.vui.aspect_ratio_idc                = GetAspectRatioIdc(fi.AspectRatioW, fi.AspectRatioH);
+        sps.vui.sar_width                       = fi.AspectRatioW;
+        sps.vui.sar_height                      = fi.AspectRatioH;
+
+        const mfxExtVideoSignalInfo& VSI = ExtBuffer::Get(defPar.mvp);
+        sps.vui.video_format                    = mfxU8(VSI.VideoFormat);
+        sps.vui.video_full_range_flag           = VSI.VideoFullRange;
+        sps.vui.colour_description_present_flag = VSI.ColourDescriptionPresent;
+        sps.vui.colour_primaries                = mfxU8(VSI.ColourPrimaries);
+        sps.vui.transfer_characteristics        = mfxU8(VSI.TransferCharacteristics);
+        sps.vui.matrix_coeffs                   = mfxU8(VSI.MatrixCoefficients);
+        sps.vui.video_signal_type_present_flag  =
+               (VSI.VideoFormat              != 5)
+            || (VSI.VideoFullRange           != 0)
+            || (VSI.ColourDescriptionPresent != 0);
+
+        sps.vui.timing_info_present_flag      = !!vps.timing_info_present_flag;
+        sps.vui.num_units_in_tick             = vps.num_units_in_tick;
+        sps.vui.time_scale                    = vps.time_scale;
+        sps.vui.field_seq_flag                = 0;
+        sps.vui.frame_field_info_present_flag =
+            IsOn(CO.PicTimingSEI)
+            || sps.vui.field_seq_flag
+            || (vps.general.progressive_source_flag
+                && vps.general.interlaced_source_flag);
+
+        if (IsOn(CO.VuiNalHrdParameters))
+        {
+            HRDInfo&                hrd        = sps.vui.hrd;
+            HRDInfo::SubLayer&      sl0        = hrd.sl[0];
+            HRDInfo::SubLayer::CPB& cpb0       = sl0.cpb[0];
+            mfxU32                  hrdBitrate = HEVCEHW::MaxKbps(mfx) * 1000;
+            mfxU32                  cpbSize    = HEVCEHW::BufferSizeInKB(mfx) * 8000;
+
+            sps.vui.hrd_parameters_present_flag = 1;
+            hrd.nal_hrd_parameters_present_flag = 1;
+            hrd.sub_pic_hrd_params_present_flag = 0;
+
+            hrd.bit_rate_scale = mfxU16(mfx::clamp<mfxI32>(CountTrailingZeroes(hrdBitrate) - 6, 0, 16));
+            hrd.cpb_size_scale = mfxU16(mfx::clamp<mfxI32>(CountTrailingZeroes(cpbSize) - 4, 2, 16));
+
+            hrd.initial_cpb_removal_delay_length_minus1 = 23;
+            hrd.au_cpb_removal_delay_length_minus1      = 23;
+            hrd.dpb_output_delay_length_minus1          = 23;
+
+            sl0.fixed_pic_rate_general_flag = 1;
+            sl0.low_delay_hrd_flag          = 0;
+            sl0.cpb_cnt_minus1              = 0;
+
+            cpb0.bit_rate_value_minus1 = (hrdBitrate >> (6 + hrd.bit_rate_scale)) - 1;
+            cpb0.cpb_size_value_minus1 = (cpbSize >> (4 + hrd.cpb_size_scale)) - 1;
+            cpb0.cbr_flag              = (mfx.RateControlMethod == MFX_RATECONTROL_CBR);
+        }
+
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus PPS(
+        Defaults::TGetPPS::TExt
+        , const Defaults::Param& defPar
+        , const Gen11::SPS& sps
+        , Gen11::PPS& pps)
+    {
+        auto& par = defPar.mvp;
+        auto  hw = defPar.hw;
+        const mfxExtHEVCParam& HEVCParam = ExtBuffer::Get(par);
+        const mfxExtHEVCTiles& HEVCTiles = ExtBuffer::Get(par);
+        const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+        bool bSWBRC = Legacy::IsSWBRC(par, &CO2);
+        bool bCQP = (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP);
+
+        mfxU16 maxRefP   = *std::max_element(CO3.NumRefActiveP, CO3.NumRefActiveP + 8);
+        mfxU16 maxRefBL0 = *std::max_element(CO3.NumRefActiveBL0, CO3.NumRefActiveBL0 + 8);
+        mfxU16 maxRefBL1 = *std::max_element(CO3.NumRefActiveBL1, CO3.NumRefActiveBL1 + 8);
+
+        pps = {};
+
+        pps.seq_parameter_set_id = sps.seq_parameter_set_id;
+
+        pps.pic_parameter_set_id                  = 0;
+        pps.dependent_slice_segments_enabled_flag = 0;
+        pps.output_flag_present_flag              = 0;
+        pps.num_extra_slice_header_bits           = 0;
+        pps.sign_data_hiding_enabled_flag         = 0;
+        pps.cabac_init_present_flag               = 0;
+        pps.num_ref_idx_l0_default_active_minus1  = std::max<mfxU16>(maxRefP, maxRefBL0) - 1;
+        pps.num_ref_idx_l1_default_active_minus1  = maxRefBL1 - 1;
+        pps.init_qp_minus26                       = 0;
+        pps.constrained_intra_pred_flag           = 0;
+        pps.transform_skip_enabled_flag = (hw >= MFX_HW_CNL) && IsOn(CO3.TransformSkip);
+
+        pps.cu_qp_delta_enabled_flag = !(IsOff(CO3.EnableMBQP) && bCQP) && !bSWBRC;
+        pps.cu_qp_delta_enabled_flag |= (IsOn(par.mfx.LowPower) || CO2.MaxSliceSize);
+
+        // according to BSpec only 3 and 0 are supported
+        pps.diff_cu_qp_delta_depth                = (HEVCParam.LCUSize == 64) * 3;
+        pps.cb_qp_offset                          = (bSWBRC * -1);
+        pps.cr_qp_offset                          = (bSWBRC * -1);
+        pps.slice_chroma_qp_offsets_present_flag  = (bSWBRC *  1);
+
+        mfxI32 QP =
+            (par.mfx.GopPicSize == 1) * par.mfx.QPI
+            + (par.mfx.GopPicSize != 1 && par.mfx.GopRefDist == 1) * par.mfx.QPP
+            + (par.mfx.GopPicSize != 1 && par.mfx.GopRefDist != 1) * par.mfx.QPB;
+
+        pps.init_qp_minus26 = bCQP * (QP - 26 - (6 * sps.bit_depth_luma_minus8));
+
+        pps.slice_chroma_qp_offsets_present_flag  = 0;
+        pps.weighted_pred_flag                    = 0;
+        pps.weighted_bipred_flag                  = 0;
+        pps.transquant_bypass_enabled_flag        = 0;
+        pps.tiles_enabled_flag                    = 0;
+        pps.entropy_coding_sync_enabled_flag      = 0;
+
+        if (HEVCTiles.NumTileColumns * HEVCTiles.NumTileRows > 1)
+        {
+            mfxU16 nCol   = (mfxU16)CeilDiv(HEVCParam.PicWidthInLumaSamples,  HEVCParam.LCUSize);
+            mfxU16 nRow   = (mfxU16)CeilDiv(HEVCParam.PicHeightInLumaSamples, HEVCParam.LCUSize);
+            mfxU16 nTCol  = std::max<mfxU16>(HEVCTiles.NumTileColumns, 1);
+            mfxU16 nTRow  = std::max<mfxU16>(HEVCTiles.NumTileRows, 1);
+
+            pps.tiles_enabled_flag        = 1;
+            pps.uniform_spacing_flag      = 1;
+            pps.num_tile_columns_minus1   = nTCol - 1;
+            pps.num_tile_rows_minus1      = nTRow - 1;
+
+            mfxI32 i = -1;
+            std::generate(std::begin(pps.column_width), std::end(pps.column_width)
+                , [nCol, nTCol, &i]() { ++i; return mfxU16(((i + 1) * nCol) / nTCol - (i * nCol) / nTCol); });
+
+            i = -1;
+            std::generate(std::begin(pps.row_height), std::end(pps.row_height)
+                , [nRow, nTRow, &i]() { ++i; return mfxU16(((i + 1) * nRow) / nTRow - (i * nRow) / nTRow); });
+
+            pps.loop_filter_across_tiles_enabled_flag = 1;
+        }
+
+        pps.loop_filter_across_slices_enabled_flag = (hw >= MFX_HW_CNL);
+
+        pps.deblocking_filter_control_present_flag  = 1;
+        pps.deblocking_filter_disabled_flag         = !!CO2.DisableDeblockingIdc;
+        pps.deblocking_filter_override_enabled_flag = 1; // to disable deblocking per frame
+#if MFX_VERSION >= MFX_VERSION_NEXT
+        pps.beta_offset_div2                        = mfxI8(CO3.DeblockingBetaOffset * 0.5 * !pps.deblocking_filter_disabled_flag);
+        pps.tc_offset_div2                          = mfxI8(CO3.DeblockingAlphaTcOffset * 0.5 * !pps.deblocking_filter_disabled_flag);
+#endif
+
+        pps.scaling_list_data_present_flag              = 0;
+        pps.lists_modification_present_flag             = 1;
+        pps.log2_parallel_merge_level_minus2            = 0;
+        pps.slice_segment_header_extension_present_flag = 0;
+
+        return MFX_ERR_NONE;
+    }
+
+    static mfxU8 SHNUT(
+        Defaults::TGetSHNUT::TExt
+        , const Defaults::Param&
+        , const TaskCommonPar& task
+        , bool bRAPIntra)
+    {
+        const DpbArray& DPB = task.DPB.After;
+        const bool isI      = IsI(task.FrameType);
+        const bool isRef    = IsRef(task.FrameType);
+        const bool isIDR    = IsIdr(task.FrameType);
+        auto IsNonCurrLTR = [&](const DpbFrame& ref)
+        {
+            return (isValid(ref) && ref.isLTR && ref.Rec.Idx != task.Rec.Idx);
+        };
+
+        mfxU8 NUT = mfxU8(task.ctrl.MfxNalUnitType);
+        bool bExtNUTValid =
+            task.ctrl.MfxNalUnitType
+            && ((NUT == MFX_HEVC_NALU_TYPE_TRAIL_R && (task.POC > task.PrevRAP && isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_TRAIL_N && (task.POC > task.PrevRAP && !isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_RASL_R && (task.POC < task.PrevRAP && isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_RASL_N && (task.POC < task.PrevRAP && !isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_RADL_R && (task.POC < task.PrevRAP && isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_RADL_N && (task.POC < task.PrevRAP && !isRef))
+                || (NUT == MFX_HEVC_NALU_TYPE_CRA_NUT && isI)
+                || (NUT == MFX_HEVC_NALU_TYPE_IDR_W_RADL && isIDR)
+                || (NUT == MFX_HEVC_NALU_TYPE_IDR_N_LP && isIDR));
+
+        NUT *= bExtNUTValid;
+        NUT += mfxU8((!NUT && isIDR) * (IDR_W_RADL + 1));
+        NUT += mfxU8((!NUT && isI && bRAPIntra
+            && std::end(DPB) != std::find_if(DPB, std::end(DPB), IsNonCurrLTR))
+            * (TRAIL_R + 1)); //following frames may refer to prev. GOP
+        NUT += mfxU8((!NUT && isI && bRAPIntra) * (CRA_NUT + 1));
+        NUT += mfxU8((!NUT && task.TemporalID > 0) * (TSA_N + isRef + 1));
+        NUT += mfxU8((!NUT && task.POC > task.PrevRAP) * (TRAIL_N + isRef + 1));
+        NUT += mfxU8(!NUT * (RASL_N + isRef + 1));
+
+        return mfxU8(NUT - 1);
+    }
+
+    static mfxU32 FrameOrder(
+        Defaults::TGetFrameOrder::TExt
+        , const Defaults::Param& par
+        , const StorageR& s_task
+        , mfxU32 prevFrameOrder)
+    {
+        if (par.mvp.mfx.EncodedOrder)
+        {
+            auto& task = Task::Common::Get(s_task);
+            if (task.pSurfIn)
+            {
+                return task.pSurfIn->Data.FrameOrder;
+            }
+        }
+
+        return (prevFrameOrder + 1);
+    }
+
+    static void Push(Defaults& df)
+    {
+#define PUSH_DEFAULT(X) df.Get##X.Push(X);
+
+        PUSH_DEFAULT(CodedPicAlignment);
+        PUSH_DEFAULT(CodedPicWidth);
+        PUSH_DEFAULT(CodedPicHeight);
+        PUSH_DEFAULT(MaxDPB);
+        PUSH_DEFAULT(GopPicSize);
+        PUSH_DEFAULT(GopRefDist);
+        PUSH_DEFAULT(NumBPyramidLayers);
+        PUSH_DEFAULT(NumRefBPyramid);
+        PUSH_DEFAULT(NumRefPPyramid);
+        PUSH_DEFAULT(NumRefNoPyramid);
+        PUSH_DEFAULT(NumRefFrames);
+        PUSH_DEFAULT(MinRefForBPyramid);
+        PUSH_DEFAULT(MinRefForBNoPyramid);
+        PUSH_DEFAULT(NumRefActive);
+        PUSH_DEFAULT(BRefType);
+        PUSH_DEFAULT(PRefType);
+        PUSH_DEFAULT(FrameRate);
+        PUSH_DEFAULT(MaxBitDepthByFourCC);
+        PUSH_DEFAULT(MaxBitDepth);
+        PUSH_DEFAULT(MaxChroma);
+        PUSH_DEFAULT(MaxChromaByFourCC);
+        PUSH_DEFAULT(TargetBitDepthLuma);
+        PUSH_DEFAULT(TargetChromaFormat);
+        PUSH_DEFAULT(TargetKbps);
+        PUSH_DEFAULT(MaxKbps);
+        PUSH_DEFAULT(BufferSizeInKB);
+        PUSH_DEFAULT(MaxNumRef);
+        PUSH_DEFAULT(RateControlMethod);
+        PUSH_DEFAULT(MinQPMFX);
+        PUSH_DEFAULT(MaxQPMFX);
+        PUSH_DEFAULT(QPMFX);
+        PUSH_DEFAULT(QPOffset);
+        PUSH_DEFAULT(Profile);
+        PUSH_DEFAULT(GUID);
+        PUSH_DEFAULT(MBBRC);
+        PUSH_DEFAULT(AsyncDepth);
+        PUSH_DEFAULT(NumSlices);
+        PUSH_DEFAULT(LCUSize);
+        PUSH_DEFAULT(HRDConformanceON);
+        PUSH_DEFAULT(PicTimingSEI);
+        PUSH_DEFAULT(FrameType);
+        PUSH_DEFAULT(PPyrInterval);
+        PUSH_DEFAULT(PLayer);
+        PUSH_DEFAULT(NumTemporalLayers);
+        PUSH_DEFAULT(TId);
+        PUSH_DEFAULT(HighestTId);
+        PUSH_DEFAULT(RPLFromExt);
+        PUSH_DEFAULT(RPL);
+        PUSH_DEFAULT(RPLMod);
+        PUSH_DEFAULT(RPLFromCtrl);
+        PUSH_DEFAULT(PreReorderInfo);
+        PUSH_DEFAULT(LowPower);
+        PUSH_DEFAULT(NumReorderFrames);
+        PUSH_DEFAULT(NonStdReordering);
+        PUSH_DEFAULT(NumTiles);
+        PUSH_DEFAULT(TileSlices);
+        PUSH_DEFAULT(Slices);
+        PUSH_DEFAULT(SPS);
+        PUSH_DEFAULT(PPS);
+        PUSH_DEFAULT(FrameNumRefActive);
+        PUSH_DEFAULT(SHNUT);
+        PUSH_DEFAULT(WeakRef);
+        PUSH_DEFAULT(FrameOrder);
+
+#undef PUSH_DEFAULT
+
+        df.CmpRefLX[0].Push(CmpRef);
+        df.CmpRefLX[1].Push(CmpRef);
+    }
+};
+
+class PreCheck
+{
+public:
+    static mfxStatus CodecId(
+        Defaults::TPreCheck::TExt
+        , const mfxVideoParam& in)
+    {
+        MFX_CHECK(in.mfx.CodecId == MFX_CODEC_HEVC, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus ChromaFormat(
+        Defaults::TPreCheck::TExt
+        , const mfxVideoParam& in)
+    {
+        bool bUnsupported = Check<mfxU16
+            , MFX_CHROMAFORMAT_YUV420
+            , MFX_CHROMAFORMAT_YUV422
+            , MFX_CHROMAFORMAT_YUV444>
+            (in.mfx.FrameInfo.ChromaFormat);
+
+        MFX_CHECK(!bUnsupported, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static void Push(Defaults& df)
+    {
+#define PUSH_DEFAULT(X) df.PreCheck##X.Push(X);
+
+        PUSH_DEFAULT(CodecId);
+        PUSH_DEFAULT(ChromaFormat);
+
+#undef PUSH_DEFAULT
+    }
+};
+
+class CheckAndFix
+{
+public:
+    static mfxStatus LCUSize(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
+        MFX_CHECK(pHEVC, MFX_ERR_NONE);
+
+        auto& lcuSize = pHEVC->LCUSize;
+        MFX_CHECK(lcuSize != 0, MFX_ERR_NONE);// zero is allowed
+
+        /*
+            LCUSizeSupported - Supported LCU sizes, bit fields
+            0b001 : 16x16
+            0b010 : 32x32
+            0b100 : 64x64
+        */
+        assert(dpar.caps.LCUSizeSupported > 0);
+
+        bool bValid =
+            !Check<mfxU16, 16, 32, 64>(lcuSize)
+            && ((lcuSize >> 4) & dpar.caps.LCUSizeSupported);
+
+        lcuSize *= bValid;
+        MFX_CHECK(bValid, MFX_ERR_UNSUPPORTED);
+
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus LowDelayBRC(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        mfxU32 changed = 0;
+        bool bAllowed =
+            (dpar.hw >= MFX_HW_ICL)
+            && !Check<mfxU16
+            , MFX_RATECONTROL_VBR
+            , MFX_RATECONTROL_QVBR
+            , MFX_RATECONTROL_VCM>
+            (par.mfx.RateControlMethod);
+
+        changed += CheckOrZero<mfxU16>(
+            pCO3->LowDelayBRC
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(MFX_CODINGOPTION_ON * bAllowed));
+
+        bool bOn = IsOn(pCO3->LowDelayBRC);
+
+        changed += bOn && CheckOrZero<mfxU16, 0>(pCO3->WinBRCMaxAvgKbps);
+        changed += bOn && CheckOrZero<mfxU16, 0>(pCO3->WinBRCSize);
+        changed += bOn && CheckOrZero<mfxU16, 1, 0>(par.mfx.GopRefDist);
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus Level(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& /*dpar*/
+        , mfxVideoParam& par)
+    {
+        bool bInalid = CheckOrZero<mfxU16
+            , MFX_LEVEL_HEVC_1
+            , MFX_LEVEL_HEVC_2
+            , MFX_LEVEL_HEVC_21
+            , MFX_LEVEL_HEVC_3
+            , MFX_LEVEL_HEVC_31
+            , MFX_LEVEL_HEVC_4
+            , MFX_LEVEL_HEVC_41
+            , MFX_LEVEL_HEVC_5
+            , MFX_LEVEL_HEVC_51
+            , MFX_LEVEL_HEVC_52
+            , MFX_LEVEL_HEVC_6
+            , MFX_LEVEL_HEVC_61
+            , MFX_LEVEL_HEVC_62
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_1
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_2
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_21
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_3
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_31
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_4
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_41
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_5
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_51
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_52
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_6
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_61
+            , MFX_TIER_HEVC_HIGH | MFX_LEVEL_HEVC_62
+            , 0>
+            (par.mfx.CodecLevel);
+
+        MFX_CHECK(!bInalid, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus SurfSize(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        auto      pCO2     = (const mfxExtCodingOption2*)ExtBuffer::Get(par);
+        auto&     W        = par.mfx.FrameInfo.Width;
+        auto&     H        = par.mfx.FrameInfo.Height;
+        auto&     CRPX     = par.mfx.FrameInfo.CropX;
+        auto&     CRPY     = par.mfx.FrameInfo.CropY;
+        auto      CRPX_c   = CRPX;
+        auto      CRPY_c   = CRPY;
+        auto&     CRPW     = par.mfx.FrameInfo.CropW;
+        auto&     CRPH     = par.mfx.FrameInfo.CropH;
+        auto      AW       = mfx::align2_value(W, HW_SURF_ALIGN_W);
+        auto      AH       = mfx::align2_value(H, HW_SURF_ALIGN_H);
+        mfxU32    changed  = 0;
+        mfxStatus UnsSts   = MFX_ERR_NONE;
+        bool      bVDEnc64 = IsOn(par.mfx.LowPower) && (64 == dpar.base.GetLCUSize(dpar));
+        mfxU16    MaxW     = mfxU16(dpar.caps.MaxPicWidth);
+        mfxU16    MaxH     = mfxU16(dpar.caps.MaxPicHeight);
+        mfxU16    MinW     = mfxU16(128 * (bVDEnc64 && !dpar.caps.SliceByteSizeCtrl));
+        mfxU16    MinH     = mfxU16(128 * (bVDEnc64));
+
+        MinW = std::max(MinW, mfxU16(192 * (bVDEnc64 && pCO2 && pCO2->MaxSliceSize)));
+
+        MFX_CHECK(W, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(H, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        changed += (W != AW) + (H != AH);
+        W = AW;
+        H = AH;
+
+        MFX_CHECK_NO_RET(!CheckRangeOrSetDefault<mfxU16>(W, MinW, MaxW, 0), UnsSts, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK_NO_RET(!CheckRangeOrSetDefault<mfxU16>(H, MinH, MaxH, 0), UnsSts, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK_NO_RET(!CheckMaxOrZero        <mfxU16>(CRPX, W),          UnsSts, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK_NO_RET(!CheckMaxOrZero        <mfxU16>(CRPY, H),          UnsSts, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK_NO_RET(!CheckMaxOrZero        <mfxU16>(CRPW, W - CRPX_c), UnsSts, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK_NO_RET(!CheckMaxOrZero        <mfxU16>(CRPH, H - CRPY_c), UnsSts, MFX_ERR_UNSUPPORTED);
+
+        MFX_CHECK_STS(UnsSts);
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus Profile(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& defPar
+        , mfxVideoParam& par)
+    {
+        mfxU32 changed = 0;
+        mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
+
+        changed += (pHEVC && defPar.hw < MFX_HW_ICL)
+            && CheckOrZero<mfxU64, 0>(pHEVC->GeneralConstraintFlags);
+
+        mfxU16 ChromaFormat = defPar.base.GetTargetChromaFormat(defPar) - 1;
+        mfxU16 BitDepth     = defPar.base.GetTargetBitDepthLuma(defPar);
+        mfxU64 REXTConstr   = 0;
+
+        if (pHEVC)
+            REXTConstr = pHEVC->GeneralConstraintFlags;
+
+        bool bValid =
+            !par.mfx.CodecProfile
+            || (par.mfx.CodecProfile == MFX_PROFILE_HEVC_REXT
+                && !((defPar.hw < MFX_HW_ICL)
+                    || ((REXTConstr & MFX_HEVC_CONSTR_REXT_MAX_8BIT) && BitDepth > 8)
+                    || ((REXTConstr & MFX_HEVC_CONSTR_REXT_MAX_10BIT) && BitDepth > 10)
+                    || ((REXTConstr & MFX_HEVC_CONSTR_REXT_MAX_12BIT) && BitDepth > 12)
+                    || ((REXTConstr & MFX_HEVC_CONSTR_REXT_MAX_420CHROMA) && ChromaFormat > MFX_CHROMAFORMAT_YUV420)
+                    || ((REXTConstr & MFX_HEVC_CONSTR_REXT_MAX_422CHROMA) && ChromaFormat > MFX_CHROMAFORMAT_YUV422)))
+            || (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAIN10 && !(BitDepth != 10 && BitDepth != 0))
+            || (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAINSP)
+            || (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAIN && !(BitDepth != 8 && BitDepth != 0));
+
+        changed += (par.mfx.CodecProfile == MFX_PROFILE_HEVC_MAINSP)
+            && CheckOrZero<mfxU16>(par.mfx.GopPicSize, 0, 1);
+
+        par.mfx.CodecProfile *= bValid;
+
+        MFX_CHECK(bValid, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    }
+
+    static const std::map<mfxU32, std::array<mfxU16, 2>> FourCCPar;
+
+    static mfxStatus FourCC(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        const mfxU16 BdMap[] = {8, 10, 12, 16};
+        auto& FourCC    = par.mfx.FrameInfo.FourCC;
+        auto  it        = FourCCPar.find(FourCC);
+        bool  bInvalid  = (it == FourCCPar.end());
+        bool  bRGB      = (FourCC == MFX_FOURCC_A2RGB10 || FourCC == MFX_FOURCC_RGB4);
+
+        bInvalid = bInvalid || (it->second[0] == MFX_CHROMAFORMAT_YUV422 && !dpar.caps.YUV422ReconSupport);
+        bInvalid = bInvalid || (it->second[0] == MFX_CHROMAFORMAT_YUV444 && !(bRGB || dpar.caps.YUV444ReconSupport));
+        bInvalid = bInvalid || (it->second[1] > BdMap[dpar.caps.MaxEncodedBitDepth & 3]);
+
+        FourCC *= !bInvalid;
+
+        MFX_CHECK(!bInvalid, MFX_ERR_UNSUPPORTED);
+
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus InputFormatByFourCC(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& /*dpar*/
+        , mfxVideoParam& par)
+    {
+        mfxU32 invalid = 0;
+
+        auto itFourCCPar = FourCCPar.find(par.mfx.FrameInfo.FourCC);
+        invalid += (itFourCCPar == FourCCPar.end() && Res2Bool(par.mfx.FrameInfo.FourCC, mfxU32(MFX_FOURCC_NV12)));
+
+        itFourCCPar = FourCCPar.find(par.mfx.FrameInfo.FourCC);
+        assert(itFourCCPar != FourCCPar.end());
+
+        invalid += CheckOrZero(par.mfx.FrameInfo.ChromaFormat, itFourCCPar->second[0]);
+        invalid += CheckOrZero(par.mfx.FrameInfo.BitDepthLuma, itFourCCPar->second[1], 0);
+        invalid += CheckOrZero(par.mfx.FrameInfo.BitDepthChroma, itFourCCPar->second[1], 0);
+
+        MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus TargetChromaFormat(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        mfxU32 invalid = 0;
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        // 422 target is not supported on VDENC
+        invalid +=
+            IsOn(par.mfx.LowPower)
+            && pCO3->TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV422);
+
+        // 444 target is not POR on VME
+        invalid +=
+            !IsOn(par.mfx.LowPower)
+            && pCO3->TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444);
+
+        static const mfxU16 cfTbl[] =
+        {
+            0
+            , 1 + MFX_CHROMAFORMAT_YUV420
+            , 1 + MFX_CHROMAFORMAT_YUV422
+            , 1 + MFX_CHROMAFORMAT_YUV444
+        };
+
+        mfxU16 maxChroma = dpar.base.GetMaxChroma(dpar) + 1;
+        maxChroma *= (maxChroma <= Size(cfTbl));
+        SetDefault(maxChroma, mfxU16(MFX_CHROMAFORMAT_YUV420 + 1));
+
+        invalid += !std::count(cfTbl, cfTbl + maxChroma, pCO3->TargetChromaFormatPlus1);
+        invalid += (pCO3->TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && !dpar.caps.YUV444ReconSupport);
+        invalid += (pCO3->TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV422) && !dpar.caps.YUV422ReconSupport);
+
+        pCO3->TargetChromaFormatPlus1 *= !invalid;
+
+        MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus TargetBitDepth(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        mfxU32 invalid = 0;
+        auto CheckBD   = [&](bool bMax10)
+        {
+            invalid += bMax10 && CheckOrZero<mfxU16, 10, 8, 0>(pCO3->TargetBitDepthLuma);
+            invalid += bMax10 && CheckOrZero<mfxU16, 10, 8, 0>(pCO3->TargetBitDepthChroma);
+            invalid += !bMax10 && CheckOrZero<mfxU16, 8, 0>(pCO3->TargetBitDepthLuma);
+            invalid += !bMax10 && CheckOrZero<mfxU16, 8, 0>(pCO3->TargetBitDepthChroma);
+        };
+
+        CheckBD(dpar.base.GetMaxBitDepth(dpar) == 10);
+        CheckBD(pCO3->TargetBitDepthLuma == 10);
+
+        MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus FourCCByTargetFormat(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& dpar
+        , mfxVideoParam& par)
+    {
+        auto tbdl = dpar.base.GetTargetBitDepthLuma(dpar);
+        auto tcf = dpar.base.GetTargetChromaFormat(dpar);
+
+        static const std::map<mfxU16, std::set<mfxU32>> Compatible[2] =
+        {
+            //8
+            {
+                {
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV444)
+                    , {MFX_FOURCC_AYUV, MFX_FOURCC_Y410, MFX_FOURCC_RGB4, MFX_FOURCC_A2RGB10}
+                }
+                ,{
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV422)
+                    , {MFX_FOURCC_YUY2, MFX_FOURCC_Y210, MFX_FOURCC_P210
+                    , MFX_FOURCC_AYUV, MFX_FOURCC_Y410
+                    , MFX_FOURCC_RGB4, MFX_FOURCC_A2RGB10}
+                }
+                ,{
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV420)
+                    , {MFX_FOURCC_NV12, MFX_FOURCC_P010, MFX_FOURCC_RGB4
+                    , MFX_FOURCC_YUY2, MFX_FOURCC_P210, MFX_FOURCC_Y210
+                    , MFX_FOURCC_AYUV, MFX_FOURCC_Y410, MFX_FOURCC_A2RGB10}
+                }
+            },
+            //10
+            {
+                {
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV444)
+                    , {MFX_FOURCC_Y410, MFX_FOURCC_A2RGB10}
+                }
+                ,{
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV422)
+                    , {MFX_FOURCC_P210, MFX_FOURCC_Y210, MFX_FOURCC_Y410, MFX_FOURCC_A2RGB10}
+                }
+                ,{
+                    mfxU16(1 + MFX_CHROMAFORMAT_YUV420)
+                    , {MFX_FOURCC_P010, MFX_FOURCC_P210, MFX_FOURCC_Y210, MFX_FOURCC_Y410, MFX_FOURCC_A2RGB10}
+                }
+            },
+        };
+
+        bool bUndefinedTargetFormat =
+            (tbdl != 8 && tbdl != 10)
+            || !Compatible[tbdl == 10].count(tcf)
+            || !Compatible[tbdl == 10].at(tcf).count(par.mfx.FrameInfo.FourCC);
+
+        assert(!bUndefinedTargetFormat);
+
+        par.mfx.FrameInfo.FourCC *= !bUndefinedTargetFormat;
+
+        MFX_CHECK(!bUndefinedTargetFormat, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus WinBRC(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param&
+        , mfxVideoParam& par)
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        mfxU32 changed = 0;
+        bool   bSWBRC  = Legacy::IsSWBRC(par, ExtBuffer::Get(par));
+        
+        changed +=
+            (par.mfx.RateControlMethod != MFX_RATECONTROL_VBR || !bSWBRC)
+            && (   CheckOrZero<mfxU16, 0>(pCO3->WinBRCSize)
+                || CheckOrZero<mfxU16, 0>(pCO3->WinBRCMaxAvgKbps));
+
+        changed +=
+            (pCO3->WinBRCSize > 0 || pCO3->WinBRCMaxAvgKbps > 0)
+            && CheckMinOrClip(pCO3->WinBRCMaxAvgKbps, par.mfx.TargetKbps);
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus SAO(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& defPar
+        , mfxVideoParam& par)
+    {
+        mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
+        MFX_CHECK(pHEVC, MFX_ERR_NONE);
+
+        mfxU32 changed = 0;
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        /* On Gen10 VDEnc, this flag should be set to 0 when SliceSizeControl flag is on.
+        On Gen10/CNL both VDEnc and VME, this flag should be set to 0 for 10-bit encoding.
+        On CNL+, this flag should be set to 0 for max LCU size is 16x16 */
+        bool bSAOSupported =
+            !(     defPar.hw < MFX_HW_CNL
+                || (par.mfx.TargetUsage == MFX_TARGETUSAGE_BEST_SPEED && defPar.hw == MFX_HW_CNL)
+                || (pCO3 && pCO3->WeightedPred == MFX_WEIGHTED_PRED_EXPLICIT)
+                || (pCO3 && pCO3->WeightedBiPred == MFX_WEIGHTED_PRED_EXPLICIT)
+                || defPar.base.GetLCUSize(defPar) == 16
+                || (defPar.hw == MFX_HW_CNL
+                    && (   (defPar.base.GetTargetBitDepthLuma(defPar) == 10)
+                        || (IsOn(par.mfx.LowPower) && pCO2 && pCO2->MaxSliceSize)
+                       )
+                   )
+            );
+
+        //On Gen10 VDEnc SAO for only Luma/Chroma in CQP mode isn't supported by driver until real customer usage
+        //For TU 1 and TU 4 SAO isn't supported due to HuC restrictions, for TU 7 SAO isn't supported at all
+        bSAOSupported &= !(
+            defPar.hw == MFX_HW_CNL
+            && par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+            && IsOn(par.mfx.LowPower));
+
+        changed += CheckOrZero<mfxU16>
+            (pHEVC->SampleAdaptiveOffset
+            , mfxU16(MFX_SAO_UNKNOWN)
+            , mfxU16(MFX_SAO_DISABLE)
+            , mfxU16(bSAOSupported * MFX_SAO_ENABLE_LUMA)
+            , mfxU16(bSAOSupported * MFX_SAO_ENABLE_CHROMA)
+            , mfxU16(bSAOSupported * (MFX_SAO_ENABLE_LUMA | MFX_SAO_ENABLE_CHROMA)));
+
+        MFX_CHECK(!changed, MFX_ERR_UNSUPPORTED);
+        return MFX_ERR_NONE;
+    }
+
+    static mfxStatus NumRefActive(
+        Defaults::TCheckAndFix::TExt
+        , const Defaults::Param& defPar
+        , mfxVideoParam& par)
+    {
+        mfxU32 changed = 0;
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        mfxU16 maxDPB = par.mfx.NumRefFrame + 1;
+        SetIf(maxDPB, !maxDPB, defPar.base.GetMaxDPB, defPar);
+
+        mfxU16 maxForward = std::min<mfxU16>(defPar.caps.MaxNum_Reference0, maxDPB - 1);
+        mfxU16 maxBackward = std::min<mfxU16>(defPar.caps.MaxNum_Reference1, maxDPB - 1);
+
+        if (defPar.hw >= MFX_HW_CNL)
+        {
+            auto maxRefByTu = defPar.base.GetMaxNumRef(defPar);
+            maxForward = std::min<mfxU16>(maxForward, std::get<0>(maxRefByTu));
+            maxBackward = std::min<mfxU16>(maxBackward, std::get<1>(maxRefByTu));
+        }
+
+        for (mfxU16 i = 0; i < 8; i++)
+        {
+            changed += CheckMaxOrClip(pCO3->NumRefActiveP[i], maxForward);
+            changed += CheckMaxOrClip(pCO3->NumRefActiveBL0[i], maxForward);
+            changed += CheckMaxOrClip(pCO3->NumRefActiveBL1[i], maxBackward);
+        }
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+        return MFX_ERR_NONE;
+    }
+
+    static void Push(Defaults& df)
+    {
+#define PUSH_DEFAULT(X) df.Check##X.Push(X);
+
+        PUSH_DEFAULT(LCUSize);
+        PUSH_DEFAULT(LowDelayBRC);
+        PUSH_DEFAULT(Level);
+        PUSH_DEFAULT(SurfSize);
+        PUSH_DEFAULT(Profile);
+        PUSH_DEFAULT(FourCC);
+        PUSH_DEFAULT(InputFormatByFourCC);
+        PUSH_DEFAULT(TargetChromaFormat);
+        PUSH_DEFAULT(TargetBitDepth);
+        PUSH_DEFAULT(FourCCByTargetFormat);
+        PUSH_DEFAULT(WinBRC);
+        PUSH_DEFAULT(SAO);
+        PUSH_DEFAULT(NumRefActive);
+
+#undef PUSH_DEFAULT
+    }
+
+};
+
+const std::map<mfxU32, std::array<mfxU16, 2>> CheckAndFix::FourCCPar =
+{
+    {mfxU32(MFX_FOURCC_AYUV),       {mfxU16(MFX_CHROMAFORMAT_YUV444), 8}}
+    , {mfxU32(MFX_FOURCC_RGB4),     {mfxU16(MFX_CHROMAFORMAT_YUV444), 8}}
+    , {mfxU32(MFX_FOURCC_A2RGB10),  {mfxU16(MFX_CHROMAFORMAT_YUV444), 10}}
+    , {mfxU32(MFX_FOURCC_Y410),     {mfxU16(MFX_CHROMAFORMAT_YUV444), 10}}
+    , {mfxU32(MFX_FOURCC_P210),     {mfxU16(MFX_CHROMAFORMAT_YUV422), 10}}
+    , {mfxU32(MFX_FOURCC_Y210),     {mfxU16(MFX_CHROMAFORMAT_YUV422), 10}}
+    , {mfxU32(MFX_FOURCC_YUY2),     {mfxU16(MFX_CHROMAFORMAT_YUV422), 8}}
+    , {mfxU32(MFX_FOURCC_P010),     {mfxU16(MFX_CHROMAFORMAT_YUV420), 10}}
+    , {mfxU32(MFX_FOURCC_NV12),     {mfxU16(MFX_CHROMAFORMAT_YUV420), 8}}
+};
+
+void Legacy::PushDefaults(Defaults& df)
+{
+    GetDefault::Push(df);
+    PreCheck::Push(df);
+    CheckAndFix::Push(df);
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_max_frame_size.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_max_frame_size.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_max_frame_size.h"
+#include "hevcehw_g11_legacy.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void MaxFrameSize::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtCodingOption2*)pSrc;
+        auto& dst = *(mfxExtCodingOption2*)pDst;
+
+        dst.MaxFrameSize = src.MaxFrameSize;
+    });
+}
+
+void MaxFrameSize::SetInherited(ParamInheritance& par)
+{
+    par.m_ebInheritDefault[MFX_EXTBUFF_CODING_OPTION2].emplace_back(
+        [](const mfxVideoParam& /*parInit*/
+            , const mfxExtBuffer* pSrc
+            , const mfxVideoParam& /*parReset*/
+            , mfxExtBuffer* pDst)
+    {
+        auto& src = *(const mfxExtCodingOption2*)pSrc;
+        auto& dst = *(mfxExtCodingOption2*)pDst;
+
+        InheritOption(src.MaxFrameSize, dst.MaxFrameSize);
+    });
+}
+
+void MaxFrameSize::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFix
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& global) -> mfxStatus
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        MFX_CHECK(pCO2 && pCO2->MaxFrameSize, MFX_ERR_NONE);
+
+        auto& caps = Glob::EncodeCaps::Get(global);
+        auto& MaxFrameSize = pCO2->MaxFrameSize;
+
+        mfxU32 changed = 0;
+        bool   bSupported = (Legacy::IsSWBRC(par, pCO2) || caps.UserMaxFrameSizeSupport)
+            && !Check(par.mfx.RateControlMethod, mfxU16(MFX_RATECONTROL_VBR), mfxU16(MFX_RATECONTROL_QVBR));
+
+        mfxU32 MinValid = 0;
+        mfxU32 MaxValid = MaxFrameSize * bSupported;
+
+        if (par.mfx.FrameInfo.FrameRateExtN && par.mfx.FrameInfo.FrameRateExtD)
+        {
+            MinValid = mfxU32(TargetKbps(par.mfx) * 1000 * par.mfx.FrameInfo.FrameRateExtD / par.mfx.FrameInfo.FrameRateExtN / 8);
+            MaxValid = std::max<mfxU32>(MaxValid, MinValid) * bSupported;
+        }
+
+        changed += CheckMinOrClip(MaxFrameSize, MinValid);
+        changed += CheckMaxOrZero(MaxFrameSize, MaxValid);
+
+        return changed ? MFX_WRN_INCOMPATIBLE_VIDEO_PARAM : MFX_ERR_NONE;
+    });
+}
+
+void MaxFrameSize::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaults
+        , [](mfxVideoParam& par, StorageW& /*strg*/, StorageRW&)
+    {
+        mfxExtCodingOption2* pCO2 = ExtBuffer::Get(par);
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3 && pCO2 && IsOn(pCO3->LowDelayBRC), MFX_ERR_NONE);
+
+        mfxF64 frameRate = mfxF64(par.mfx.FrameInfo.FrameRateExtN) / par.mfx.FrameInfo.FrameRateExtD;
+        mfxU32 avgFrameSizeInBytes = mfxU32(MaxKbps(par.mfx) * 1000 / frameRate / 8);
+
+        SetDefault<mfxU32>(pCO2->MaxFrameSize, 2 * avgFrameSizeInBytes);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void MaxFrameSize::Reset(const FeatureBlocks& /*blocks*/, TPushR Push)
+{
+    Push(BLK_Reset
+        , [](
+            const mfxVideoParam& /*par*/
+            , StorageRW& global
+            , StorageRW& /*local*/) -> mfxStatus
+    {
+        auto& parOld = Glob::VideoParam::Get(Glob::RealState::Get(global));
+        auto& parNew = Glob::VideoParam::Get(global);
+        mfxExtCodingOption2& CO2Old = ExtBuffer::Get(parOld);
+        mfxExtCodingOption2& CO2New = ExtBuffer::Get(parNew);
+        auto& hint = Glob::ResetHint::Get(global);
+
+        hint.Flags |= RF_BRC_RESET *
+            ((     parOld.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+                || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+                || parOld.mfx.RateControlMethod == MFX_RATECONTROL_VCM)
+            && (CO2Old.MaxFrameSize != CO2New.MaxFrameSize));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_max_frame_size.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_max_frame_size.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+    namespace Gen11
+    {
+        class MaxFrameSize
+            : public FeatureBase
+        {
+        public:
+#define DECL_BLOCK_LIST\
+        DECL_BLOCK(CheckAndFix)\
+        DECL_BLOCK(SetDefaults)\
+        DECL_BLOCK(Init)\
+        DECL_BLOCK(Reset)\
+        DECL_BLOCK(PatchDDITask)
+#define DECL_FEATURE_NAME "G11_MaxFrameSize"
+#include "hevcehw_decl_blocks.h"
+
+            MaxFrameSize(mfxU32 FeatureId)
+                : FeatureBase(FeatureId)
+            {}
+
+        protected:
+            virtual void SetSupported(ParamSupport& par) override;
+            virtual void SetInherited(ParamInheritance& par) override;
+            virtual void InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push) override {};
+            virtual void Reset(const FeatureBlocks& blocks, TPushR Push) override;
+            virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+            virtual void SetDefaults(const FeatureBlocks& blocks, TPushSD Push) override;
+            virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override {};
+
+            bool m_bPatchNextDDITask = false;
+        };
+
+    } //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_packer.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_packer.cpp
@@ -1,0 +1,2179 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_packer.h"
+#include <numeric>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+const mfxU8 tab_cabacRangeTabLps[128][4] =
+{
+    { 128, 176, 208, 240 }, { 128, 167, 197, 227 }, { 128, 158, 187, 216 }, { 123, 150, 178, 205 },
+    { 116, 142, 169, 195 }, { 111, 135, 160, 185 }, { 105, 128, 152, 175 }, { 100, 122, 144, 166 },
+    {  95, 116, 137, 158 }, {  90, 110, 130, 150 }, {  85, 104, 123, 142 }, {  81,  99, 117, 135 },
+    {  77,  94, 111, 128 }, {  73,  89, 105, 122 }, {  69,  85, 100, 116 }, {  66,  80,  95, 110 },
+    {  62,  76,  90, 104 }, {  59,  72,  86,  99 }, {  56,  69,  81,  94 }, {  53,  65,  77,  89 },
+    {  51,  62,  73,  85 }, {  48,  59,  69,  80 }, {  46,  56,  66,  76 }, {  43,  53,  63,  72 },
+    {  41,  50,  59,  69 }, {  39,  48,  56,  65 }, {  37,  45,  54,  62 }, {  35,  43,  51,  59 },
+    {  33,  41,  48,  56 }, {  32,  39,  46,  53 }, {  30,  37,  43,  50 }, {  29,  35,  41,  48 },
+    {  27,  33,  39,  45 }, {  26,  31,  37,  43 }, {  24,  30,  35,  41 }, {  23,  28,  33,  39 },
+    {  22,  27,  32,  37 }, {  21,  26,  30,  35 }, {  20,  24,  29,  33 }, {  19,  23,  27,  31 },
+    {  18,  22,  26,  30 }, {  17,  21,  25,  28 }, {  16,  20,  23,  27 }, {  15,  19,  22,  25 },
+    {  14,  18,  21,  24 }, {  14,  17,  20,  23 }, {  13,  16,  19,  22 }, {  12,  15,  18,  21 },
+    {  12,  14,  17,  20 }, {  11,  14,  16,  19 }, {  11,  13,  15,  18 }, {  10,  12,  15,  17 },
+    {  10,  12,  14,  16 }, {   9,  11,  13,  15 }, {   9,  11,  12,  14 }, {   8,  10,  12,  14 },
+    {   8,   9,  11,  13 }, {   7,   9,  11,  12 }, {   7,   9,  10,  12 }, {   7,   8,  10,  11 },
+    {   6,   8,   9,  11 }, {   6,   7,   9,  10 }, {   6,   7,   8,   9 }, {   2,   2,   2,   2 },
+    //The same for valMPS=1
+    { 128, 176, 208, 240 }, { 128, 167, 197, 227 }, { 128, 158, 187, 216 }, { 123, 150, 178, 205 },
+    { 116, 142, 169, 195 }, { 111, 135, 160, 185 }, { 105, 128, 152, 175 }, { 100, 122, 144, 166 },
+    {  95, 116, 137, 158 }, {  90, 110, 130, 150 }, {  85, 104, 123, 142 }, {  81,  99, 117, 135 },
+    {  77,  94, 111, 128 }, {  73,  89, 105, 122 }, {  69,  85, 100, 116 }, {  66,  80,  95, 110 },
+    {  62,  76,  90, 104 }, {  59,  72,  86,  99 }, {  56,  69,  81,  94 }, {  53,  65,  77,  89 },
+    {  51,  62,  73,  85 }, {  48,  59,  69,  80 }, {  46,  56,  66,  76 }, {  43,  53,  63,  72 },
+    {  41,  50,  59,  69 }, {  39,  48,  56,  65 }, {  37,  45,  54,  62 }, {  35,  43,  51,  59 },
+    {  33,  41,  48,  56 }, {  32,  39,  46,  53 }, {  30,  37,  43,  50 }, {  29,  35,  41,  48 },
+    {  27,  33,  39,  45 }, {  26,  31,  37,  43 }, {  24,  30,  35,  41 }, {  23,  28,  33,  39 },
+    {  22,  27,  32,  37 }, {  21,  26,  30,  35 }, {  20,  24,  29,  33 }, {  19,  23,  27,  31 },
+    {  18,  22,  26,  30 }, {  17,  21,  25,  28 }, {  16,  20,  23,  27 }, {  15,  19,  22,  25 },
+    {  14,  18,  21,  24 }, {  14,  17,  20,  23 }, {  13,  16,  19,  22 }, {  12,  15,  18,  21 },
+    {  12,  14,  17,  20 }, {  11,  14,  16,  19 }, {  11,  13,  15,  18 }, {  10,  12,  15,  17 },
+    {  10,  12,  14,  16 }, {   9,  11,  13,  15 }, {   9,  11,  12,  14 }, {   8,  10,  12,  14 },
+    {   8,   9,  11,  13 }, {   7,   9,  11,  12 }, {   7,   9,  10,  12 }, {   7,   8,  10,  11 },
+    {   6,   8,   9,  11 }, {   6,   7,   9,  10 }, {   6,   7,   8,   9 }, {   2,   2,   2,   2 }
+};
+
+/* CABAC trans tables: state (MPS and LPS ) + valMPS in 6th bit */
+const mfxU8 tab_cabacTransTbl[2][128] =
+{
+    {
+          1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,
+         17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,
+         33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,
+         49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  62,  63,
+          0,  64,  65,  66,  66,  68,  68,  69,  70,  71,  72,  73,  73,  75,  75,  76,
+         77,  77,  79,  79,  80,  80,  82,  82,  83,  83,  85,  85,  86,  86,  87,  88,
+         88,  89,  90,  90,  91,  91,  92,  93,  93,  94,  94,  94,  95,  96,  96,  97,
+         97,  97,  98,  98,  99,  99,  99, 100, 100, 100, 101, 101, 101, 102, 102, 127
+    },
+    {
+           0,   0,   1,   2,   2,   4,   4,   5,   6,   7,   8,   9,   9,  11,  11,  12,
+          13,  13,  15,  15,  16,  16,  18,  18,  19,  19,  21,  21,  22,  22,  23,  24,
+          24,  25,  26,  26,  27,  27,  28,  29,  29,  30,  30,  30,  31,  32,  32,  33,
+          33,  33,  34,  34,  35,  35,  35,  36,  36,  36,  37,  37,  37,  38,  38,  63,
+          65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  80,
+          81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,
+          97,  98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
+         113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 126, 127
+    }
+};
+
+const CABACContextTable CABACContext::InitVal[3] =
+{
+    {
+        { 154 },            /*CU_TRANSQUANT_BYPASS_FLAG*/
+        { 139, 141, 157 },  /*SPLIT_CODING_UNIT_FLAG*/
+        { 154, 154, 154 },  /*SKIP_FLAG*/
+        { 154 },            /*MERGE_IDX*/
+        { 63 }              /*END_OF_SLICE_FLAG*/
+    },
+    {
+        { 154 },            /*CU_TRANSQUANT_BYPASS_FLAG*/
+        { 107, 139, 126 },  /*SPLIT_CODING_UNIT_FLAG*/
+        { 197, 185, 201 },  /*SKIP_FLAG*/
+        { 122 },            /*MERGE_IDX*/
+        { 63 }              /*END_OF_SLICE_FLAG*/
+    },
+    {
+        { 154 },            /*CU_TRANSQUANT_BYPASS_FLAG*/
+        { 107, 139, 126 },  /*SPLIT_CODING_UNIT_FLAG*/
+        { 197, 185, 201 },  /*SKIP_FLAG*/
+        { 137 },            /*MERGE_IDX*/
+        { 63 }              /*END_OF_SLICE_FLAG*/
+    }
+};
+
+void CABACContext::Init(const PPS& pps, const Slice& sh)
+{
+    mfxU8* pState    = (mfxU8*)&((CABACContextTable&)*this);
+    mfxU8* pStateEnd = pState + sizeof(CABACContextTable);
+    mfxI32 SliceQpY = mfx::clamp(26 + pps.init_qp_minus26 + sh.slice_qp_delta, 0, 51);
+    mfxU32 initType =
+          (sh.type == 1)                 * (sh.cabac_init_flag + 1)
+        + (sh.type != 2 && sh.type != 1) * (2 - sh.cabac_init_flag);
+
+    const mfxU8* pInitVal = (const mfxU8*)&InitVal[initType];
+
+    while (pState != pStateEnd)
+    {
+        mfxI32 preCtxState = mfx::clamp(((((pInitVal[0] >> 4) * 5 - 45) * SliceQpY) >> 4) + ((pInitVal[0] & 15) << 3) - 16, 1, 126);
+
+        *pState = mfxU8(
+              (preCtxState <= 63) * ((63 - preCtxState) << 1)
+            + (preCtxState > 63)  * (((preCtxState - 64) << 1) | 1));
+
+        ++pState;
+        ++pInitVal;
+    }
+
+    END_OF_SLICE_FLAG[0] = (63 << 1);
+}
+
+BitstreamWriter::BitstreamWriter(mfxU8* bs, mfxU32 size, mfxU8 bitOffset)
+    : m_bsStart(bs)
+    , m_bsEnd(bs + size)
+    , m_bs(bs)
+    , m_bitStart(bitOffset & 7)
+    , m_bitOffset(bitOffset & 7)
+    , m_codILow(0)// cabac variables
+    , m_codIRange(510)
+    , m_bitsOutstanding(0)
+    , m_BinCountsInNALunits(0)
+    , m_firstBitFlag(true)
+{
+    assert(bitOffset < 8);
+    *m_bs &= 0xFF << (8 - m_bitOffset);
+}
+
+BitstreamWriter::~BitstreamWriter()
+{
+}
+
+void BitstreamWriter::Reset(mfxU8* bs, mfxU32 size, mfxU8 bitOffset)
+{
+    if (bs)
+    {
+        m_bsStart   = bs;
+        m_bsEnd     = bs + size;
+        m_bs        = bs;
+        m_bitOffset = (bitOffset & 7);
+        m_bitStart  = (bitOffset & 7);
+    }
+    else
+    {
+        m_bs        = m_bsStart;
+        m_bitOffset = m_bitStart;
+    }
+}
+
+void BitstreamWriter::PutBitsBuffer(mfxU32 n, void* bb, mfxU32 o)
+{
+    mfxU8* b = (mfxU8*)bb;
+    mfxU32 N, B;
+
+    assert(bb);
+
+    auto SkipOffsetBytes = [&]()
+    {
+        N = o / 8;
+        b += N;
+        o &= 7;
+        return o;
+    };
+    auto PutBitsAfterOffsetOnes = [&]()
+    {
+        N = (n < (8 - o)) * n;
+        PutBits(8 - o, ((b[0] & (0xff >> o)) >> N));
+        n -= (N + !N * (8 - o));
+        ++b;
+        return n;
+    };
+    auto PutBytesAligned = [&]()
+    {
+        N = n / 8;
+        n &= 7;
+
+        assert(N + !!n < (m_bsEnd - m_bs));
+        std::copy(b, b + N, m_bs);
+
+        m_bs += N;
+
+        return !n;
+    };
+    auto PutLastByteBitsAligned = [&]()
+    {
+        m_bs[0] = b[N];
+        m_bs[0] &= (0xff << (8 - n));
+        m_bitOffset = (mfxU8)n;
+        return true;
+    };
+    auto CopyAlignedToUnaligned = [&]()
+    {
+        assert((n + 7 - m_bitOffset) / 8 < (m_bsEnd - m_bs));
+
+        while (n >= 24)
+        {
+            B = ((((mfxU32)b[0] << 24) | ((mfxU32)b[1] << 16) | ((mfxU32)b[2] << 8)) >> m_bitOffset);
+
+            m_bs[0] |= (mfxU8)(B >> 24);
+            m_bs[1] = (mfxU8)(B >> 16);
+            m_bs[2] = (mfxU8)(B >> 8);
+            m_bs[3] = (mfxU8)B;
+
+            m_bs += 3;
+            b += 3;
+            n -= 24;
+        }
+
+        while (n >= 8)
+        {
+            B = ((mfxU32)b[0] << 8) >> m_bitOffset;
+
+            m_bs[0] |= (mfxU8)(B >> 8);
+            m_bs[1] = (mfxU8)B;
+
+            m_bs++;
+            b++;
+            n -= 8;
+        }
+
+        if (n)
+            PutBits(n, (b[0] >> (8 - n)));
+
+        return true;
+    };
+    auto CopyUnalignedPartToAny = [&]()
+    {
+        return o && SkipOffsetBytes() && PutBitsAfterOffsetOnes();
+    };
+    auto CopyAlignedToAligned = [&]()
+    {
+        return !m_bitOffset && (PutBytesAligned() || PutLastByteBitsAligned());
+    };
+
+    bool bDone =
+           CopyUnalignedPartToAny()
+        || CopyAlignedToAligned()
+        || CopyAlignedToUnaligned();
+
+    ThrowAssert(!bDone, "BitstreamWriter::PutBitsBuffer failed");
+}
+
+void BitstreamWriter::PutBits(mfxU32 n, mfxU32 b)
+{
+    assert(n <= sizeof(b) * 8);
+    while (n > 24)
+    {
+        n -= 16;
+        PutBits(16, (b >> n));
+    }
+
+    b <<= (32 - n);
+
+    if (!m_bitOffset)
+    {
+        m_bs[0] = (mfxU8)(b >> 24);
+        m_bs[1] = (mfxU8)(b >> 16);
+    }
+    else
+    {
+        b >>= m_bitOffset;
+        n  += m_bitOffset;
+
+        m_bs[0] |= (mfxU8)(b >> 24);
+        m_bs[1]  = (mfxU8)(b >> 16);
+    }
+
+    if (n > 16)
+    {
+        m_bs[2] = (mfxU8)(b >> 8);
+        m_bs[3] = (mfxU8)b;
+    }
+
+    m_bs += (n >> 3);
+    m_bitOffset = (n & 7);
+}
+
+void BitstreamWriter::PutBit(mfxU32 b)
+{
+    switch(m_bitOffset)
+    {
+    case 0:
+        m_bs[0] = (mfxU8)(b << 7);
+        m_bitOffset = 1;
+        break;
+    case 7:
+        m_bs[0] |= (mfxU8)(b & 1);
+        m_bs ++;
+        m_bitOffset = 0;
+        break;
+    default:
+        if (b & 1)
+            m_bs[0] |= (mfxU8)(1 << (7 - m_bitOffset));
+        m_bitOffset ++;
+        break;
+    }
+}
+
+void BitstreamWriter::PutGolomb(mfxU32 b)
+{
+    if (!b)
+    {
+        PutBit(1);
+    }
+    else
+    {
+        mfxU32 n = 1;
+
+        b ++;
+
+        while (b >> n)
+            n ++;
+
+        PutBits(n - 1, 0);
+        PutBits(n, b);
+    }
+}
+
+void BitstreamWriter::PutTrailingBits(bool bCheckAligened)
+{
+    if ((!bCheckAligened) || m_bitOffset)
+        PutBit(1);
+
+    if (m_bitOffset)
+    {
+        *(++m_bs)   = 0;
+        m_bitOffset = 0;
+    }
+}
+
+void BitstreamWriter::PutBitC(mfxU32 B)
+{
+    if (m_firstBitFlag)
+        m_firstBitFlag = false;
+    else
+        PutBit(B);
+
+    while (m_bitsOutstanding > 0)
+    {
+        PutBit(1 - B);
+        m_bitsOutstanding--;
+    }
+}
+void BitstreamWriter::RenormE()
+{
+    while (m_codIRange < 256)
+    {
+        if (m_codILow < 256)
+        {
+            PutBitC(0);
+        }
+        else if (m_codILow >= 512)
+        {
+            m_codILow -= 512;
+            PutBitC(1);
+        }
+        else
+        {
+            m_codILow -= 256;
+            m_bitsOutstanding++;
+        }
+        m_codIRange <<= 1;
+        m_codILow <<= 1;
+    }
+}
+
+void BitstreamWriter::EncodeBin(mfxU8& ctx, mfxU8 binVal)
+{
+    mfxU8  pStateIdx = (ctx >> 1);
+    mfxU8  valMPS = (ctx & 1);
+    mfxU32 qCodIRangeIdx = (m_codIRange >> 6) & 3;
+    mfxU32 codIRangeLPS = tab_cabacRangeTabLps[pStateIdx][qCodIRangeIdx];
+
+    m_codIRange -= codIRangeLPS;
+
+    if (binVal != valMPS)
+    {
+        m_codILow += m_codIRange;
+        m_codIRange = codIRangeLPS;
+
+        if (pStateIdx == 0)
+            valMPS = 1 - valMPS;
+
+        pStateIdx = tab_cabacTransTbl[1][pStateIdx];//transIdxLPS[pStateIdx];
+    }
+    else
+    {
+        pStateIdx = tab_cabacTransTbl[0][pStateIdx];//transIdxMPS[pStateIdx];
+    }
+
+    ctx = (pStateIdx << 1) | valMPS;
+
+    RenormE();
+    m_BinCountsInNALunits++;
+}
+
+void BitstreamWriter::EncodeBinEP(mfxU8 binVal)
+{
+    m_codILow += m_codILow + m_codIRange * (binVal == 1);
+    RenormE();
+    m_BinCountsInNALunits++;
+}
+
+void BitstreamWriter::SliceFinish()
+{
+    m_codIRange -= 2;
+    m_codILow += m_codIRange;
+    m_codIRange = 2;
+
+    RenormE();
+    PutBitC((m_codILow >> 9) & 1);
+    PutBit(m_codILow >> 8);
+    PutTrailingBits();
+
+    m_BinCountsInNALunits++;
+}
+
+void BitstreamWriter::cabacInit()
+{
+    m_codILow = 0;
+    m_codIRange = 510;
+    m_bitsOutstanding = 0;
+    m_BinCountsInNALunits = 0;
+    m_firstBitFlag = true;
+}
+
+
+void Packer::PackNALU(BitstreamWriter& bs, NALU const & h)
+{
+    bool bLongSC =
+        h.nal_unit_type == VPS_NUT
+        || h.nal_unit_type == SPS_NUT
+        || h.nal_unit_type == PPS_NUT
+        || h.nal_unit_type == AUD_NUT
+        || h.nal_unit_type == PREFIX_SEI_NUT
+        || h.long_start_code;
+
+    if (bLongSC)
+        bs.PutBits(8, 0); //zero_byte
+
+    bs.PutBits( 24, 0x000001);//start_code
+
+    bs.PutBit(0);
+    bs.PutBits(6, h.nal_unit_type);
+    bs.PutBits(6, h.nuh_layer_id);
+    bs.PutBits(3, h.nuh_temporal_id_plus1);
+}
+
+void Packer::PackPTL(BitstreamWriter& bs, LayersInfo const & ptl, mfxU16 max_sub_layers_minus1)
+{
+    bs.PutBits(2, ptl.general.profile_space);
+    bs.PutBit(ptl.general.tier_flag);
+    bs.PutBits(5, ptl.general.profile_idc);
+    bs.PutBits(24,(ptl.general.profile_compatibility_flags >> 8));
+    bs.PutBits(8 ,(ptl.general.profile_compatibility_flags & 0xFF));
+    bs.PutBit(ptl.general.progressive_source_flag);
+    bs.PutBit(ptl.general.interlaced_source_flag);
+    bs.PutBit(ptl.general.non_packed_constraint_flag);
+    bs.PutBit(ptl.general.frame_only_constraint_flag);
+    bs.PutBit(ptl.general.constraint.max_12bit       );
+    bs.PutBit(ptl.general.constraint.max_10bit       );
+    bs.PutBit(ptl.general.constraint.max_8bit        );
+    bs.PutBit(ptl.general.constraint.max_422chroma   );
+    bs.PutBit(ptl.general.constraint.max_420chroma   );
+    bs.PutBit(ptl.general.constraint.max_monochrome  );
+    bs.PutBit(ptl.general.constraint.intra           );
+    bs.PutBit(ptl.general.constraint.one_picture_only);
+    bs.PutBit(ptl.general.constraint.lower_bit_rate  );
+    bs.PutBits(23, 0);
+    bs.PutBits(11, 0);
+    bs.PutBit(ptl.general.inbld_flag);
+    bs.PutBits(8, ptl.general.level_idc);
+
+    std::for_each(ptl.sub_layer, ptl.sub_layer + max_sub_layers_minus1
+        , [&](const LayersInfo::SubLayer& sl)
+    {
+        bs.PutBit(sl.profile_present_flag);
+        bs.PutBit(sl.level_present_flag);
+    });
+
+    if (max_sub_layers_minus1 > 0)
+        bs.PutBits(2 * (8 - max_sub_layers_minus1), 0); // reserved_zero_2bits[ i ]
+
+    std::for_each(ptl.sub_layer, ptl.sub_layer + max_sub_layers_minus1
+        , [&](const LayersInfo::SubLayer& sl)
+    {
+        if (sl.profile_present_flag)
+        {
+            bs.PutBits(2, sl.profile_space);
+            bs.PutBit(sl.tier_flag);
+            bs.PutBits(5, sl.profile_idc);
+            bs.PutBits(24, (sl.profile_compatibility_flags >> 8));
+            bs.PutBits(8, (sl.profile_compatibility_flags & 0xFF));
+            bs.PutBit(sl.progressive_source_flag);
+            bs.PutBit(sl.interlaced_source_flag);
+            bs.PutBit(sl.non_packed_constraint_flag);
+            bs.PutBit(sl.frame_only_constraint_flag);
+            bs.PutBit(ptl.general.constraint.max_12bit);
+            bs.PutBit(ptl.general.constraint.max_10bit);
+            bs.PutBit(ptl.general.constraint.max_8bit);
+            bs.PutBit(ptl.general.constraint.max_422chroma);
+            bs.PutBit(ptl.general.constraint.max_420chroma);
+            bs.PutBit(ptl.general.constraint.max_monochrome);
+            bs.PutBit(ptl.general.constraint.intra);
+            bs.PutBit(ptl.general.constraint.one_picture_only);
+            bs.PutBit(ptl.general.constraint.lower_bit_rate);
+            bs.PutBits(23, 0);
+            bs.PutBits(11, 0);
+            bs.PutBit(sl.inbld_flag);
+        }
+
+        if (sl.level_present_flag)
+            bs.PutBits(8, sl.level_idc);
+
+    });
+}
+
+void Packer::PackSLO(BitstreamWriter& bs, LayersInfo const & slo, mfxU16 max_sub_layers_minus1)
+{
+    bs.PutBit(slo.sub_layer_ordering_info_present_flag);
+
+    std::for_each(
+        slo.sub_layer + (max_sub_layers_minus1 * !slo.sub_layer_ordering_info_present_flag)
+        , slo.sub_layer + max_sub_layers_minus1 + 1
+        , [&](const LayersInfo::SubLayer& sl)
+    {
+        bs.PutUE(sl.max_dec_pic_buffering_minus1);
+        bs.PutUE(sl.max_num_reorder_pics);
+        bs.PutUE(sl.max_latency_increase_plus1);
+    });
+}
+
+void Packer::PackAUD(BitstreamWriter& bs, mfxU8 pic_type)
+{
+    NALU nalu = {0, AUD_NUT, 0, 1};
+    PackNALU(bs, nalu);
+    bs.PutBits(3, pic_type);
+    bs.PutTrailingBits();
+}
+
+void Packer::PackVPS(BitstreamWriter& bs, VPS const &  vps)
+{
+    NALU nalu = {0, VPS_NUT, 0, 1};
+
+    PackNALU(bs, nalu);
+
+    bs.PutBits(4, vps.video_parameter_set_id);
+    bs.PutBits(2, 3);
+    bs.PutBits(6, vps.max_layers_minus1);
+    bs.PutBits(3, vps.max_sub_layers_minus1);
+    bs.PutBit(vps.temporal_id_nesting_flag);
+    bs.PutBits(16, 0xFFFF);
+
+    PackPTL(bs, vps, vps.max_sub_layers_minus1);
+    PackSLO(bs, vps, vps.max_sub_layers_minus1);
+
+    bs.PutBits(6, vps.max_layer_id);
+    bs.PutUE(vps.num_layer_sets_minus1);
+
+    assert(0 == vps.num_layer_sets_minus1);
+
+    bs.PutBit(vps.timing_info_present_flag);
+
+    if (vps.timing_info_present_flag)
+    {
+        bs.PutBits(32, vps.num_units_in_tick);
+        bs.PutBits(32, vps.time_scale);
+
+        bs.PutBit(vps.poc_proportional_to_timing_flag);
+
+        if (vps.poc_proportional_to_timing_flag)
+            bs.PutUE(vps.num_ticks_poc_diff_one_minus1);
+
+        bs.PutUE(vps.num_hrd_parameters);
+
+        assert(0 == vps.num_hrd_parameters);
+    }
+
+    bs.PutBit(0); //vps.extension_flag
+    bs.PutTrailingBits();
+}
+
+void Packer::PackHRD(
+    BitstreamWriter& bs,
+    HRDInfo const & hrd,
+    bool commonInfPresentFlag,
+    mfxU16 maxNumSubLayersMinus1)
+{
+    mfxU32 nSE = 0;
+
+    auto PackSubLayer = [&](const HRDInfo::SubLayer& sl)
+    {
+        nSE += PutBit(bs, sl.fixed_pic_rate_general_flag);
+        nSE += !sl.fixed_pic_rate_general_flag && PutBit(bs, sl.fixed_pic_rate_within_cvs_flag);
+
+        bool bFixedPicRate =
+            sl.fixed_pic_rate_within_cvs_flag
+            || sl.fixed_pic_rate_general_flag;
+
+        nSE += bFixedPicRate && PutUE(bs, sl.elemental_duration_in_tc_minus1);
+        nSE += !bFixedPicRate && PutBit(bs, sl.low_delay_hrd_flag);
+        nSE += !sl.low_delay_hrd_flag && PutUE(bs, sl.cpb_cnt_minus1);
+
+        std::for_each(
+            sl.cpb
+            , sl.cpb + ((sl.cpb_cnt_minus1 + 1) * hrd.nal_hrd_parameters_present_flag)
+            , [&](const HRDInfo::SubLayer::CPB& cpb)
+        {
+            nSE += PutUE(bs, cpb.bit_rate_value_minus1);
+            nSE += PutUE(bs, cpb.cpb_size_value_minus1);
+            nSE += hrd.sub_pic_hrd_params_present_flag && PutUE(bs, cpb.cpb_size_du_value_minus1);
+            nSE += hrd.sub_pic_hrd_params_present_flag && PutUE(bs, cpb.bit_rate_du_value_minus1);
+            nSE += PutBit(bs, cpb.cbr_flag);
+        });
+
+        assert(hrd.vcl_hrd_parameters_present_flag == 0);
+    };
+
+    if (commonInfPresentFlag)
+    {
+        nSE += PutBit(bs, hrd.nal_hrd_parameters_present_flag);
+        nSE += PutBit(bs, hrd.vcl_hrd_parameters_present_flag);
+
+        bool bNalVclHrdPresent =
+            hrd.nal_hrd_parameters_present_flag
+            || hrd.vcl_hrd_parameters_present_flag;
+
+        if (bNalVclHrdPresent)
+        {
+            nSE += PutBit(bs, hrd.sub_pic_hrd_params_present_flag);
+
+            if (hrd.sub_pic_hrd_params_present_flag)
+            {
+                nSE += PutBits(bs, 8, hrd.tick_divisor_minus2);
+                nSE += PutBits(bs, 5, hrd.du_cpb_removal_delay_increment_length_minus1);
+                nSE += PutBit(bs, hrd.sub_pic_cpb_params_in_pic_timing_sei_flag);
+                nSE += PutBits(bs, 5, hrd.dpb_output_delay_du_length_minus1);
+            }
+
+            nSE += PutBits(bs, 4, hrd.bit_rate_scale);
+            nSE += PutBits(bs, 4, hrd.cpb_size_scale);
+            nSE += hrd.sub_pic_hrd_params_present_flag && PutBits(bs, 4, hrd.cpb_size_du_scale);
+            nSE += PutBits(bs, 5, hrd.initial_cpb_removal_delay_length_minus1);
+            nSE += PutBits(bs, 5, hrd.au_cpb_removal_delay_length_minus1);
+            nSE += PutBits(bs, 5, hrd.dpb_output_delay_length_minus1);
+        }
+    }
+
+    std::for_each(hrd.sl, hrd.sl + maxNumSubLayersMinus1 + 1, PackSubLayer);
+}
+
+void Packer::PackVUI(BitstreamWriter& bs, VUI const & vui, mfxU16 max_sub_layers_minus1)
+{
+    mfxU32 nSE = 0;
+    bool bPackSARWH = vui.aspect_ratio_info_present_flag && vui.aspect_ratio_idc == 255;
+
+    nSE += PutBit(bs, vui.aspect_ratio_info_present_flag);
+    nSE += vui.aspect_ratio_info_present_flag && PutBits(bs, 8, vui.aspect_ratio_idc);
+    nSE += bPackSARWH && PutBits(bs, 16, vui.sar_width);
+    nSE += bPackSARWH && PutBits(bs, 16, vui.sar_height);
+    nSE += PutBit(bs, vui.overscan_info_present_flag);
+    nSE += vui.overscan_info_present_flag && PutBit(bs, vui.overscan_appropriate_flag);
+    nSE += PutBit(bs, vui.video_signal_type_present_flag);
+
+    if (vui.video_signal_type_present_flag)
+    {
+        nSE += PutBits(bs, 3, vui.video_format);
+        nSE += PutBit(bs, vui.video_full_range_flag);
+        nSE += PutBit(bs, vui.colour_description_present_flag);
+
+        if (vui.colour_description_present_flag)
+        {
+            nSE += PutBits(bs, 8, vui.colour_primaries);
+            nSE += PutBits(bs, 8, vui.transfer_characteristics);
+            nSE += PutBits(bs, 8, vui.matrix_coeffs);
+        }
+    }
+
+    nSE += PutBit(bs, vui.chroma_loc_info_present_flag);
+    nSE += vui.chroma_loc_info_present_flag && PutUE(bs, vui.chroma_sample_loc_type_top_field);
+    nSE += vui.chroma_loc_info_present_flag && PutUE(bs, vui.chroma_sample_loc_type_bottom_field);
+    nSE += PutBit(bs, vui.neutral_chroma_indication_flag );
+    nSE += PutBit(bs, vui.field_seq_flag                 );
+    nSE += PutBit(bs, vui.frame_field_info_present_flag  );
+    nSE += PutBit(bs, vui.default_display_window_flag    );
+
+    if (vui.default_display_window_flag)
+    {
+        nSE += PutUE(bs, vui.def_disp_win_left_offset   );
+        nSE += PutUE(bs, vui.def_disp_win_right_offset  );
+        nSE += PutUE(bs, vui.def_disp_win_top_offset    );
+        nSE += PutUE(bs, vui.def_disp_win_bottom_offset );
+    }
+
+    nSE += PutBit(bs, vui.timing_info_present_flag);
+
+    if (vui.timing_info_present_flag)
+    {
+        nSE += PutBits(bs, 32, vui.num_units_in_tick );
+        nSE += PutBits(bs, 32, vui.time_scale        );
+        nSE += PutBit(bs, vui.poc_proportional_to_timing_flag);
+        nSE += vui.poc_proportional_to_timing_flag && PutUE(bs, vui.num_ticks_poc_diff_one_minus1);
+        nSE += PutBit(bs, vui.hrd_parameters_present_flag);
+
+        if (vui.hrd_parameters_present_flag)
+            PackHRD(bs, vui.hrd, 1, max_sub_layers_minus1);
+    }
+
+    nSE += PutBit(bs, vui.bitstream_restriction_flag);
+
+    if (vui.bitstream_restriction_flag)
+    {
+        nSE += PutBit(bs, vui.tiles_fixed_structure_flag              );
+        nSE += PutBit(bs, vui.motion_vectors_over_pic_boundaries_flag );
+        nSE += PutBit(bs, vui.restricted_ref_pic_lists_flag           );
+        nSE += PutUE(bs, vui.min_spatial_segmentation_idc  );
+        nSE += PutUE(bs, vui.max_bytes_per_pic_denom       );
+        nSE += PutUE(bs, vui.max_bits_per_min_cu_denom     );
+        nSE += PutUE(bs, vui.log2_max_mv_length_horizontal );
+        nSE += PutUE(bs, vui.log2_max_mv_length_vertical   );
+    }
+
+    assert(nSE >= 10);
+}
+
+void PackSTRPS(BitstreamWriter& bs, const STRPS* sets, mfxU32 num, mfxU32 idx);
+
+void PackExtension(mfxU8 extFlags, std::function<bool(mfxU8)> Pack)
+{
+    mfxU8 extId = 0;
+
+    while (extFlags)
+    {
+        if (extFlags & 0x80)
+            ThrowAssert(!Pack(extId), "extension is not supported");
+
+        ++extId;
+        extFlags <<= 1;
+    }
+}
+
+mfxU32 Packer::PackSLD(BitstreamWriter& bs, ScalingList const & scl)
+{
+    mfxU32 nSE = 0;
+    const mfxU32 matrixIds[] = { 0, 1, 2, 3, 4, 5 };
+    auto PackDeltaCoef = [&](mfxU32 sizeId, mfxU32 nextCoef, const mfxU8* scalingList)
+    {
+        mfxU32 coefNum = std::min(64, (1 << (4 + (sizeId << 1))));
+        nSE += PutSE(bs, int8_t(scalingList[0] - nextCoef));
+
+        for (mfxU32 i = 1; i < coefNum; i++)
+        {
+            nSE += PutSE(bs, int8_t(scalingList[i] - scalingList[i - 1]));
+            //here casting to int8_t will perform as x -= 256 if x > 127 and x += 256 if x < -128
+        }
+    };
+    auto Pack4x4 = [&](mfxU32 matrixId)
+    {
+        nSE += PutBit(bs, 0); //scaling_list_pred_mode_flag
+        PackDeltaCoef(0, 8, &scl.scalingLists0[matrixId][0]);
+    };
+    auto Pack8x8 = [&](mfxU32 matrixId)
+    {
+        nSE += PutBit(bs, 0); //scaling_list_pred_mode_flag
+        PackDeltaCoef(1, 8, &scl.scalingLists1[matrixId][0]);
+    };
+    auto Pack16x16 = [&](mfxU32 matrixId)
+    {
+        nSE += PutBit(bs, 0); //scaling_list_pred_mode_flag
+        auto next = scl.scalingLists2[matrixId][0];
+        nSE += PutSE(bs, next - 8);
+        PackDeltaCoef(2, next, &scl.scalingLists2[matrixId][0]);
+    };
+    auto Pack32x32 = [&](mfxU32 matrixId)
+    {
+        nSE += PutBit(bs, 0); //scaling_list_pred_mode_flag
+        auto next = scl.scalingLists3[!!matrixId][0];
+        nSE += PutSE(bs, next - 8);
+        PackDeltaCoef(3, next, &scl.scalingLists3[!!matrixId][0]);
+    };
+
+    std::for_each(std::begin(matrixIds), std::end(matrixIds), Pack4x4);
+    std::for_each(std::begin(matrixIds), std::end(matrixIds), Pack8x8);
+    std::for_each(std::begin(matrixIds), std::end(matrixIds), Pack16x16);
+    Pack32x32(0);
+    Pack32x32(3);
+
+    assert(nSE ==
+          (1 + sizeof(scl.scalingLists0)
+        + (1 + sizeof(scl.scalingLists1))
+        + (2 + sizeof(scl.scalingLists2))
+        + (2 + sizeof(scl.scalingLists3))));
+
+    return nSE;
+}
+
+void Packer::PackSPS(BitstreamWriter& bs, SPS const & sps)
+{
+    NALU   nalu = {0, SPS_NUT, 0, 1};
+    mfxU32 nSE  = 0;
+    mfxU32 nLTR = !!sps.long_term_ref_pics_present_flag * sps.num_long_term_ref_pics_sps;
+
+    PackNALU(bs, nalu);
+
+    nSE += PutBits(bs, 4, sps.video_parameter_set_id);
+    nSE += PutBits(bs, 3, sps.max_sub_layers_minus1);
+    nSE += PutBit(bs, sps.temporal_id_nesting_flag);
+
+    PackPTL(bs, sps, sps.max_sub_layers_minus1);
+
+    nSE += PutUE(bs, sps.seq_parameter_set_id);
+    nSE += PutUE(bs, sps.chroma_format_idc);
+    nSE += (sps.chroma_format_idc == 3) && PutBit(bs, sps.separate_colour_plane_flag);
+    nSE += PutUE(bs, sps.pic_width_in_luma_samples);
+    nSE += PutUE(bs, sps.pic_height_in_luma_samples);
+    nSE += PutBit(bs, sps.conformance_window_flag);
+
+    if (sps.conformance_window_flag)
+    {
+        nSE += PutUE(bs, sps.conf_win_left_offset);
+        nSE += PutUE(bs, sps.conf_win_right_offset);
+        nSE += PutUE(bs, sps.conf_win_top_offset);
+        nSE += PutUE(bs, sps.conf_win_bottom_offset);
+    }
+
+    nSE += PutUE(bs, sps.bit_depth_luma_minus8);
+    nSE += PutUE(bs, sps.bit_depth_chroma_minus8);
+    nSE += PutUE(bs, sps.log2_max_pic_order_cnt_lsb_minus4);
+
+    PackSLO(bs, sps, sps.max_sub_layers_minus1);
+
+    nSE += PutUE(bs, sps.log2_min_luma_coding_block_size_minus3);
+    nSE += PutUE(bs, sps.log2_diff_max_min_luma_coding_block_size);
+    nSE += PutUE(bs, sps.log2_min_transform_block_size_minus2);
+    nSE += PutUE(bs, sps.log2_diff_max_min_transform_block_size);
+    nSE += PutUE(bs, sps.max_transform_hierarchy_depth_inter);
+    nSE += PutUE(bs, sps.max_transform_hierarchy_depth_intra);
+    nSE += PutBit(bs, sps.scaling_list_enabled_flag);
+
+    nSE += sps.scaling_list_enabled_flag && PackSLD(bs, sps.scl);
+
+    nSE += PutBit(bs, sps.amp_enabled_flag);
+    nSE += PutBit(bs, sps.sample_adaptive_offset_enabled_flag);
+    nSE += PutBit(bs, sps.pcm_enabled_flag);
+
+    if (sps.pcm_enabled_flag)
+    {
+        nSE += PutBits(bs, 4, sps.pcm_sample_bit_depth_luma_minus1);
+        nSE += PutBits(bs, 4, sps.pcm_sample_bit_depth_chroma_minus1);
+        nSE += PutUE(bs, sps.log2_min_pcm_luma_coding_block_size_minus3);
+        nSE += PutUE(bs, sps.log2_diff_max_min_pcm_luma_coding_block_size);
+        nSE += PutBit(bs, sps.pcm_loop_filter_disabled_flag);
+    }
+
+    nSE += PutUE(bs, sps.num_short_term_ref_pic_sets);
+
+    for (mfxU32 i = 0; i < sps.num_short_term_ref_pic_sets; i++)
+        PackSTRPS(bs, sps.strps, sps.num_short_term_ref_pic_sets, i);
+
+    nSE += PutBit(bs, sps.long_term_ref_pics_present_flag);
+    nSE += sps.long_term_ref_pics_present_flag && PutUE(bs, sps.num_long_term_ref_pics_sps);
+
+    for (mfxU32 i = 0; i < nLTR; ++i)
+    {
+        nSE += PutBits(bs, sps.log2_max_pic_order_cnt_lsb_minus4 + 4, sps.lt_ref_pic_poc_lsb_sps[i] );
+        nSE += PutBit(bs, sps.used_by_curr_pic_lt_sps_flag[i] );
+    }
+
+    nSE += PutBit(bs, sps.temporal_mvp_enabled_flag);
+    nSE += PutBit(bs, sps.strong_intra_smoothing_enabled_flag);
+    nSE += PutBit(bs, sps.vui_parameters_present_flag);
+
+    if (sps.vui_parameters_present_flag)
+        PackVUI(bs, sps.vui, sps.max_sub_layers_minus1);
+
+    nSE += PutBit(bs, sps.extension_flag);
+    nSE += sps.extension_flag && PutBit(bs, sps.range_extension_flag);
+    nSE += sps.extension_flag && PutBits(bs, 7, sps.ExtensionFlags);
+
+    if (sps.range_extension_flag)
+    {
+        nSE += PutBit(bs, sps.transform_skip_rotation_enabled_flag);
+        nSE += PutBit(bs, sps.transform_skip_context_enabled_flag);
+        nSE += PutBit(bs, sps.implicit_rdpcm_enabled_flag);
+        nSE += PutBit(bs, sps.explicit_rdpcm_enabled_flag);
+        nSE += PutBit(bs, sps.extended_precision_processing_flag);
+        nSE += PutBit(bs, sps.intra_smoothing_disabled_flag);
+        nSE += PutBit(bs, sps.high_precision_offsets_enabled_flag);
+        nSE += PutBit(bs, sps.persistent_rice_adaptation_enabled_flag);
+        nSE += PutBit(bs, sps.cabac_bypass_alignment_enabled_flag);
+    }
+
+    assert(nSE >= 27);
+
+    PackExtension(sps.ExtensionFlags & 0x7f
+        , [&](mfxU8 id)
+    {
+        auto& PackSpsExt = Glob::PackSpsExt::Get(*m_pGlob);
+        return PackSpsExt && PackSpsExt(sps, id, bs);
+    });
+
+    bs.PutTrailingBits();
+}
+
+void Packer::PackPPS(BitstreamWriter& bs, PPS const &  pps)
+{
+    NALU   nalu             = {0, PPS_NUT, 0, 1};
+    mfxU32 nSE              = 0;
+    bool   bNeedDblk        = pps.deblocking_filter_control_present_flag;
+    bool   bNeedDblkOffsets = bNeedDblk && !pps.deblocking_filter_disabled_flag;
+
+    PackNALU(bs, nalu);
+
+    nSE += PutUE(bs, pps.pic_parameter_set_id);
+    nSE += PutUE(bs, pps.seq_parameter_set_id);
+    nSE += PutBit(bs, pps.dependent_slice_segments_enabled_flag);
+    nSE += PutBit(bs, pps.output_flag_present_flag);
+    nSE += PutBits(bs, 3, pps.num_extra_slice_header_bits);
+    nSE += PutBit(bs, pps.sign_data_hiding_enabled_flag);
+    nSE += PutBit(bs, pps.cabac_init_present_flag);
+    nSE += PutUE(bs, pps.num_ref_idx_l0_default_active_minus1);
+    nSE += PutUE(bs, pps.num_ref_idx_l1_default_active_minus1);
+    nSE += PutSE(bs, pps.init_qp_minus26);
+    nSE += PutBit(bs, pps.constrained_intra_pred_flag);
+    nSE += PutBit(bs, pps.transform_skip_enabled_flag);
+    nSE += PutBit(bs, pps.cu_qp_delta_enabled_flag);
+
+    nSE += pps.cu_qp_delta_enabled_flag && PutUE(bs, pps.diff_cu_qp_delta_depth);
+
+    nSE += PutSE(bs, pps.cb_qp_offset);
+    nSE += PutSE(bs, pps.cr_qp_offset);
+    nSE += PutBit(bs, pps.slice_chroma_qp_offsets_present_flag);
+    nSE += PutBit(bs, pps.weighted_pred_flag);
+    nSE += PutBit(bs, pps.weighted_bipred_flag);
+    nSE += PutBit(bs, pps.transquant_bypass_enabled_flag);
+    nSE += PutBit(bs, pps.tiles_enabled_flag);
+    nSE += PutBit(bs, pps.entropy_coding_sync_enabled_flag);
+
+    if (pps.tiles_enabled_flag)
+    {
+        auto cwEnd      = pps.column_width + pps.num_tile_columns_minus1 * !pps.uniform_spacing_flag;
+        auto rhEnd      = pps.row_height + pps.num_tile_rows_minus1 * !pps.uniform_spacing_flag;
+        auto PutTileDim = [&](mfxU16 x) { return PutUE(bs, std::max<mfxU16>(x, 1) - 1); };
+
+        nSE += PutUE(bs, pps.num_tile_columns_minus1);
+        nSE += PutUE(bs, pps.num_tile_rows_minus1);
+        nSE += PutBit(bs, pps.uniform_spacing_flag);
+        nSE += mfxU32(std::count_if(pps.column_width, cwEnd, PutTileDim));
+        nSE += mfxU32(std::count_if(pps.row_height, rhEnd, PutTileDim));
+        nSE += PutBit(bs, pps.loop_filter_across_tiles_enabled_flag);
+    }
+
+    nSE += PutBit(bs, pps.loop_filter_across_slices_enabled_flag);
+    nSE += PutBit(bs, pps.deblocking_filter_control_present_flag);
+    nSE += bNeedDblk && PutBit(bs, pps.deblocking_filter_override_enabled_flag);
+    nSE += bNeedDblk && PutBit(bs, pps.deblocking_filter_disabled_flag);
+    nSE += bNeedDblkOffsets && PutSE(bs, pps.beta_offset_div2);
+    nSE += bNeedDblkOffsets && PutSE(bs, pps.tc_offset_div2);
+
+    nSE += PutBit(bs, pps.scaling_list_data_present_flag);
+    assert(0 == pps.scaling_list_data_present_flag);
+
+    nSE += PutBit(bs, pps.lists_modification_present_flag);
+    nSE += PutUE(bs, pps.log2_parallel_merge_level_minus2);
+    nSE += PutBit(bs, pps.slice_segment_header_extension_present_flag);
+    nSE += PutBit(bs, pps.extension_flag);
+    nSE += pps.extension_flag && PutBit(bs, pps.range_extension_flag);
+    nSE += pps.extension_flag && PutBits(bs, 7, pps.ExtensionFlags);
+
+    if (pps.range_extension_flag)
+    {
+        mfxU32 nQpOffsets = pps.chroma_qp_offset_list_enabled_flag * (pps.chroma_qp_offset_list_len_minus1 + 1);
+
+        nSE += pps.transform_skip_enabled_flag && PutUE(bs, pps.log2_max_transform_skip_block_size_minus2);
+        nSE += PutBit(bs, pps.cross_component_prediction_enabled_flag);
+        nSE += PutBit(bs, pps.chroma_qp_offset_list_enabled_flag);
+        nSE += pps.chroma_qp_offset_list_enabled_flag && PutUE(bs, pps.diff_cu_chroma_qp_offset_depth);
+        nSE += pps.chroma_qp_offset_list_enabled_flag && PutUE(bs, pps.chroma_qp_offset_list_len_minus1);
+
+        for (mfxU32 i = 0; i < nQpOffsets; i++)
+        {
+            nSE += PutSE(bs, pps.cb_qp_offset_list[i]);
+            nSE += PutSE(bs, pps.cr_qp_offset_list[i]);
+        }
+
+        nSE += PutUE(bs, pps.log2_sao_offset_scale_luma);
+        nSE += PutUE(bs, pps.log2_sao_offset_scale_chroma);
+    }
+
+    PackExtension(pps.ExtensionFlags & 0x7f
+        , [&](mfxU8 id)
+    {
+        auto& PackPpsExt = Glob::PackPpsExt::Get(*m_pGlob);
+        return PackPpsExt && PackPpsExt(pps, id, bs);
+    });
+
+    bs.PutTrailingBits();
+
+    assert(nSE >= 28);
+}
+
+void Packer::PackSSHPartIdAddr(
+    BitstreamWriter& bs,
+    NALU  const &    nalu,
+    SPS   const &    sps,
+    PPS   const &    pps,
+    Slice const &    slice)
+{
+    mfxU32 MaxCU = (1<<(sps.log2_min_luma_coding_block_size_minus3 + 3 + sps.log2_diff_max_min_luma_coding_block_size));
+    mfxU32 PicSizeInCtbsY = CeilDiv(sps.pic_width_in_luma_samples, MaxCU) * CeilDiv(sps.pic_height_in_luma_samples, MaxCU);
+
+    bs.PutBit(slice.first_slice_segment_in_pic_flag);
+
+    bool bIRAP = nalu.nal_unit_type >= BLA_W_LP && nalu.nal_unit_type <= RSV_IRAP_VCL23;
+
+    if (bIRAP)
+        bs.PutBit(slice.no_output_of_prior_pics_flag);
+
+    bs.PutUE(slice.pic_parameter_set_id);
+
+    if (!slice.first_slice_segment_in_pic_flag)
+    {
+        if (pps.dependent_slice_segments_enabled_flag)
+            bs.PutBit(slice.dependent_slice_segment_flag);
+
+        bs.PutBits(CeilLog2(PicSizeInCtbsY), slice.segment_address);
+    }
+}
+
+void Packer::PackSSHPartNonIDR(
+    BitstreamWriter& bs,
+    SPS   const &    sps,
+    Slice const &    slice)
+{
+    mfxU32 nSE          = 0;
+    bool   bNeedStIdx   = slice.short_term_ref_pic_set_sps_flag && (sps.num_short_term_ref_pic_sets > 1);
+    auto   PutSpsLT     = [&](const Slice::LongTerm& lt)
+    {
+        nSE += (sps.num_long_term_ref_pics_sps > 1) && PutBits(bs, CeilLog2(sps.num_long_term_ref_pics_sps), lt.lt_idx_sps);
+        nSE += PutBit(bs, lt.delta_poc_msb_present_flag);
+        nSE += lt.delta_poc_msb_present_flag && PutUE(bs, lt.delta_poc_msb_cycle_lt);
+    };
+    auto   PutSliceLT   = [&](const Slice::LongTerm& lt)
+    {
+        nSE += PutBits(bs, sps.log2_max_pic_order_cnt_lsb_minus4 + 4, lt.poc_lsb_lt);
+        nSE += PutBit(bs, lt.used_by_curr_pic_lt_flag);
+        nSE += PutBit(bs, lt.delta_poc_msb_present_flag);
+        nSE += lt.delta_poc_msb_present_flag && PutUE(bs, lt.delta_poc_msb_cycle_lt);
+    };
+
+    nSE += PutBits(bs, sps.log2_max_pic_order_cnt_lsb_minus4 + 4, slice.pic_order_cnt_lsb);
+    nSE += PutBit(bs, slice.short_term_ref_pic_set_sps_flag);
+
+    if (!slice.short_term_ref_pic_set_sps_flag)
+    {
+        std::vector<STRPS> strps(sps.strps, sps.strps + sps.num_short_term_ref_pic_sets);
+        strps.push_back(slice.strps);
+        PackSTRPS(bs, strps.data(), sps.num_short_term_ref_pic_sets, sps.num_short_term_ref_pic_sets);
+    }
+
+    nSE += bNeedStIdx && PutBits(bs, CeilLog2(sps.num_short_term_ref_pic_sets), slice.short_term_ref_pic_set_idx);
+
+    if (sps.long_term_ref_pics_present_flag)
+    {
+        nSE += (sps.num_long_term_ref_pics_sps > 0) && PutUE(bs, slice.num_long_term_sps);
+        nSE += PutUE(bs, slice.num_long_term_pics);
+
+        std::for_each(slice.lt, slice.lt + slice.num_long_term_sps, PutSpsLT);
+        std::for_each(slice.lt, slice.lt + slice.num_long_term_pics, PutSliceLT);
+    }
+
+    nSE += sps.temporal_mvp_enabled_flag && PutBit(bs, slice.temporal_mvp_enabled_flag);
+
+    assert(nSE >= 2);
+}
+
+bool Packer::PackSSHPWT(
+    BitstreamWriter& bs
+    , const SPS&     sps
+    , const PPS&     pps
+    , const Slice&   slice)
+{
+    constexpr mfxU16 Y = 0, Cb = 1, Cr = 2, W = 0, O = 1, P = 1, B = 0;
+
+    struct AccWFlag : std::pair<mfxU16, mfxI16>
+    {
+        AccWFlag(mfxU16 idx, mfxI16 w) : std::pair<mfxU16, mfxI16>(idx, w){}
+        mfxU16 operator()(mfxU16 wf, const mfxI16(&pwt)[3][2])
+        {
+            return (wf << 1) + !(pwt[first][O] == 0 && pwt[first][W] == second);
+        };
+    };
+
+    bool     bNeedY       = (pps.weighted_pred_flag && slice.type == P) || (pps.weighted_bipred_flag && slice.type == B);
+    bool     bNeedC       = bNeedY && (sps.chroma_format_idc != 0);
+    mfxI16   BdOffsetC    =
+        sps.high_precision_offsets_enabled_flag * (sps.bit_depth_chroma_minus8 + 8 - 1)
+        + !sps.high_precision_offsets_enabled_flag * 7;
+    mfxU32   nSE          = 0;
+    mfxI16   WpOffC       = (1 << BdOffsetC);
+    mfxI16   wY           = (1 << slice.luma_log2_weight_denom);
+    mfxI16   wC           = (1 << slice.chroma_log2_weight_denom);
+    mfxI16   l2WDc        = slice.chroma_log2_weight_denom;
+    auto     startOffset  = bs.GetOffset();
+    auto     PutPwtLX     = [&](const mfxI16(&pwtLX)[16][3][2], mfxU32 sz)
+    {
+        mfxU32 szY      = sz * bNeedY;
+        mfxU32 szC      = sz * bNeedC;
+        mfxU16 wfmap    = (1 << (szY - 1));
+        mfxU16 lumaw    = 0;
+        mfxU16 chromaw  = 0;
+        auto   PutWOVal = [&](const mfxI16(&pwt)[3][2])
+        {
+            bool bPutY = !!(lumaw & wfmap);
+            bool bPutC = !!(chromaw & wfmap);
+
+            nSE += bPutY && PutSE(bs, pwt[Y][W] - wY);
+            nSE += bPutY && PutSE(bs, pwt[Y][0]);
+
+            nSE += bPutC && PutSE(bs, pwt[Cb][W] - wC);
+            nSE += bPutC && PutSE(bs, mfx::clamp(((WpOffC * pwt[Cb][W]) >> l2WDc) + pwt[Cb][O] - WpOffC, -4 * WpOffC, 4 * WpOffC - 1));
+
+            nSE += bPutC && PutSE(bs, pwt[Cb][W] - wC);
+            nSE += bPutC && PutSE(bs, mfx::clamp(((WpOffC * pwt[Cr][W]) >> l2WDc) + pwt[Cr][O] - WpOffC, -4 * WpOffC, 4 * WpOffC - 1));
+
+            wfmap >>= 1;
+        };
+
+        lumaw    = std::accumulate(pwtLX, pwtLX + szY, mfxU16(0), AccWFlag(Y, wY));
+        chromaw  = std::accumulate(pwtLX, pwtLX + szC, mfxU16(0), AccWFlag(Cb, wC));
+        chromaw |= std::accumulate(pwtLX, pwtLX + szC, mfxU16(0), AccWFlag(Cr, wC));
+
+        nSE += szY && PutBits(bs, szY, lumaw);
+        nSE += szC && PutBits(bs, szC, chromaw);
+
+        std::for_each(pwtLX, pwtLX + szY, PutWOVal);
+    };
+
+    bs.AddInfo(PACK_PWTOffset, startOffset);
+
+    nSE += bNeedY && PutUE(bs, slice.luma_log2_weight_denom);
+    nSE += bNeedC && PutSE(bs, mfxI32(slice.chroma_log2_weight_denom) - slice.luma_log2_weight_denom);
+
+    PutPwtLX(slice.pwt[0], slice.num_ref_idx_l0_active_minus1 + 1);
+    PutPwtLX(slice.pwt[1], (slice.num_ref_idx_l0_active_minus1 + 1) * (slice.type == B));
+
+    bs.AddInfo(PACK_PWTLength, bs.GetOffset() - startOffset);
+
+    return !!nSE;
+}
+
+void Packer::PackSSHPartPB(
+    BitstreamWriter& bs,
+    SPS   const &    sps,
+    PPS   const &    pps,
+    Slice const &    slice)
+{
+    auto   IsSTUsed        = [](const STRPSPic& pic) { return !!pic.used_by_curr_pic_sx_flag; };
+    auto   IsLTUsed        = [](const Slice::LongTerm& lt) { return !!lt.used_by_curr_pic_lt_flag; };
+    bool   bB              = (slice.type == 0);
+    mfxU32 nSE             = 0;
+    auto   stEnd           = slice.strps.pic + slice.strps.num_negative_pics + slice.strps.num_positive_pics;
+    auto   ltEnd           = slice.lt + slice.num_long_term_sps + slice.num_long_term_pics;
+    mfxU16 NumPocTotalCurr = mfxU16(std::count_if(slice.strps.pic, stEnd, IsSTUsed) + std::count_if(slice.lt, ltEnd, IsLTUsed));
+    bool   bNeedRPLM0      = pps.lists_modification_present_flag && NumPocTotalCurr > 1;
+    bool   bNeedRPLM1      = bNeedRPLM0 && bB;
+    bool   bNeedCRefIdx0   = (slice.collocated_from_l0_flag && slice.num_ref_idx_l0_active_minus1 > 0);
+    bool   bNeedCRefIdx1   = (!slice.collocated_from_l0_flag && slice.num_ref_idx_l1_active_minus1 > 0);
+    bool   bNeedCRefIdx    = slice.temporal_mvp_enabled_flag && (bNeedCRefIdx0 || bNeedCRefIdx1);
+    auto   PackRPLM        = [&](mfxU8 lx, mfxU8 num)
+    {
+        nSE += PutBit(bs, !!slice.ref_pic_list_modification_flag_lx[lx]);
+
+        num *= !!slice.ref_pic_list_modification_flag_lx[lx];
+
+        std::for_each(slice.list_entry_lx[lx], slice.list_entry_lx[lx] + num
+            , [&](mfxU8 entry)
+        {
+            nSE += PutBits(bs, CeilLog2(NumPocTotalCurr), entry);
+        });
+    };
+
+    nSE += PutBit(bs, slice.num_ref_idx_active_override_flag);
+    nSE += slice.num_ref_idx_active_override_flag && PutUE(bs, slice.num_ref_idx_l0_active_minus1);
+    nSE += slice.num_ref_idx_active_override_flag && bB && PutUE(bs, slice.num_ref_idx_l1_active_minus1);
+
+    if (bNeedRPLM0)
+    {
+        PackRPLM(0, slice.num_ref_idx_l0_active_minus1 + 1);
+    }
+
+    if (bNeedRPLM1)
+    {
+        PackRPLM(1, slice.num_ref_idx_l1_active_minus1 + 1);
+    }
+
+    nSE += bB && PutBit(bs, slice.mvd_l1_zero_flag);
+    nSE += pps.cabac_init_present_flag && PutBit(bs, slice.cabac_init_flag);
+    nSE += slice.temporal_mvp_enabled_flag && bB && PutBit(bs, slice.collocated_from_l0_flag);
+    nSE += bNeedCRefIdx && PutUE(bs, slice.collocated_ref_idx);
+
+    PackSSHPWT(bs, sps, pps, slice);
+
+    nSE += PutUE(bs, slice.five_minus_max_num_merge_cand);
+
+    assert(nSE >= 2);
+}
+
+void Packer::PackSSHPartIndependent(
+    BitstreamWriter& bs,
+    NALU  const &    nalu,
+    SPS   const &    sps,
+    PPS   const &    pps,
+    Slice const &    slice)
+{
+    const mfxU8 I = 2;
+    mfxU32 nSE = 0;
+
+    nSE += PutBits(bs, pps.num_extra_slice_header_bits, slice.reserved_flags);
+    nSE += PutUE(bs, slice.type);
+    nSE += pps.output_flag_present_flag && PutBit(bs, slice.pic_output_flag);
+    nSE += (sps.separate_colour_plane_flag == 1) && PutBits(bs, 2, slice.colour_plane_id);
+
+    bool bNonIDR = nalu.nal_unit_type != IDR_W_RADL && nalu.nal_unit_type != IDR_N_LP;
+
+    if (bNonIDR)
+        PackSSHPartNonIDR(bs, sps, slice);
+
+    if (sps.sample_adaptive_offset_enabled_flag)
+    {
+        bs.AddInfo(PACK_SAOOffset, bs.GetOffset());
+
+        nSE += PutBit(bs, slice.sao_luma_flag);
+        nSE += PutBit(bs, slice.sao_chroma_flag);
+    }
+
+    if (slice.type != I)
+        PackSSHPartPB(bs, sps, pps, slice);
+
+    bs.AddInfo(PACK_QPDOffset, bs.GetOffset());
+
+    nSE += PutSE(bs, slice.slice_qp_delta);
+    nSE += pps.slice_chroma_qp_offsets_present_flag && PutSE(bs, slice.slice_cb_qp_offset);
+    nSE += pps.slice_chroma_qp_offsets_present_flag && PutSE(bs, slice.slice_cr_qp_offset);
+    nSE += pps.deblocking_filter_override_enabled_flag && PutBit(bs, slice.deblocking_filter_override_flag);
+    nSE += slice.deblocking_filter_override_flag && PutBit(bs, slice.deblocking_filter_disabled_flag);
+
+    bool bPackDblkOffsets = slice.deblocking_filter_override_flag && !slice.deblocking_filter_disabled_flag;
+    nSE += bPackDblkOffsets && PutSE(bs, slice.beta_offset_div2);
+    nSE += bPackDblkOffsets && PutSE(bs, slice.tc_offset_div2);
+
+    bool bPackSliceLF =
+        (pps.loop_filter_across_slices_enabled_flag
+            && (slice.sao_luma_flag
+                || slice.sao_chroma_flag
+                || !slice.deblocking_filter_disabled_flag));
+
+    nSE += bPackSliceLF && PutBit(bs, slice.loop_filter_across_slices_enabled_flag);
+
+    assert(nSE >= 2);
+}
+
+void Packer::PackSSH(
+    BitstreamWriter& bs,
+    NALU  const &    nalu,
+    SPS   const &    sps,
+    PPS   const &    pps,
+    Slice const &    slice,
+    bool             dyn_slice_size)
+{
+    PackNALU(bs, nalu);
+
+    if (!dyn_slice_size)
+        PackSSHPartIdAddr(bs, nalu, sps, pps, slice);
+
+    if (!slice.dependent_slice_segment_flag)
+        PackSSHPartIndependent(bs, nalu, sps, pps, slice);
+
+    if (pps.tiles_enabled_flag || pps.entropy_coding_sync_enabled_flag)
+    {
+        assert(slice.num_entry_point_offsets == 0);
+
+        bs.PutUE(slice.num_entry_point_offsets);
+    }
+
+    assert(0 == pps.slice_segment_header_extension_present_flag);
+
+    if (!dyn_slice_size)   // no trailing bits for dynamic slice size
+        bs.PutTrailingBits();
+}
+
+void PackSTRPS(BitstreamWriter& bs, const STRPS* sets, mfxU32 num, mfxU32 idx)
+{
+    STRPS const & strps = sets[idx];
+
+    if (idx != 0)
+        bs.PutBit(strps.inter_ref_pic_set_prediction_flag);
+
+    if (strps.inter_ref_pic_set_prediction_flag)
+    {
+        if(idx == num)
+            bs.PutUE(strps.delta_idx_minus1);
+
+        bs.PutBit(strps.delta_rps_sign);
+        bs.PutUE(strps.abs_delta_rps_minus1);
+
+        mfxU32 RefRpsIdx = idx - ( strps.delta_idx_minus1 + 1 );
+        mfxU32 NumDeltaPocs = sets[RefRpsIdx].num_negative_pics + sets[RefRpsIdx].num_positive_pics;
+
+        std::for_each(
+            strps.pic
+            , strps.pic + NumDeltaPocs + 1
+            , [&](const STRPS::Pic& pic)
+        {
+            bs.PutBit(pic.used_by_curr_pic_flag);
+
+            if (!pic.used_by_curr_pic_flag)
+                bs.PutBit(pic.use_delta_flag);
+        });
+    }
+    else
+    {
+        bs.PutUE(strps.num_negative_pics);
+        bs.PutUE(strps.num_positive_pics);
+
+        std::for_each(
+            strps.pic
+            , strps.pic + strps.num_positive_pics + strps.num_negative_pics
+            , [&](const STRPS::Pic& pic)
+        {
+            bs.PutUE(pic.delta_poc_sx_minus1);
+            bs.PutBit(pic.used_by_curr_pic_sx_flag);
+        });
+    }
+}
+
+void Packer::PackSEIPayload(
+    BitstreamWriter& bs,
+    VUI const & vui,
+    BufferingPeriodSEI const & bp)
+{
+    HRDInfo const & hrd = vui.hrd;
+
+    bs.PutUE(bp.seq_parameter_set_id);
+
+    if (!bp.irap_cpb_params_present_flag)
+        bs.PutBit(bp.irap_cpb_params_present_flag);
+
+    if (bp.irap_cpb_params_present_flag)
+    {
+        bs.PutBits(hrd.au_cpb_removal_delay_length_minus1+1, bp.cpb_delay_offset);
+        bs.PutBits(hrd.dpb_output_delay_length_minus1+1, bp.dpb_delay_offset);
+    }
+
+    bs.PutBit(bp.concatenation_flag);
+    bs.PutBits(hrd.au_cpb_removal_delay_length_minus1+1, bp.au_cpb_removal_delay_delta_minus1);
+
+    mfxU16 CpbCnt = hrd.sl[0].cpb_cnt_minus1;
+    bool bAltCpb = hrd.sub_pic_hrd_params_present_flag || bp.irap_cpb_params_present_flag;
+
+    auto PackCPB = [&](const BufferingPeriodSEI::CPB& cpb)
+    {
+        bs.PutBits(hrd.initial_cpb_removal_delay_length_minus1 + 1, cpb.initial_cpb_removal_delay);
+        bs.PutBits(hrd.initial_cpb_removal_delay_length_minus1 + 1, cpb.initial_cpb_removal_offset);
+
+        if (bAltCpb)
+        {
+            bs.PutBits(hrd.initial_cpb_removal_delay_length_minus1 + 1, cpb.initial_alt_cpb_removal_delay);
+            bs.PutBits(hrd.initial_cpb_removal_delay_length_minus1 + 1, cpb.initial_alt_cpb_removal_offset);
+        }
+    };
+
+    std::for_each(
+        bp.nal
+        , bp.nal + (CpbCnt + 1) * hrd.nal_hrd_parameters_present_flag
+        , PackCPB);
+
+    std::for_each(
+        bp.vcl
+        , bp.vcl + (CpbCnt + 1) * hrd.vcl_hrd_parameters_present_flag
+        , PackCPB);
+
+    bs.PutTrailingBits(true);
+}
+
+void Packer::PackSEIPayload(
+    BitstreamWriter& bs,
+    VUI const & vui,
+    PicTimingSEI const & pt)
+{
+    HRDInfo const & hrd = vui.hrd;
+
+    if (vui.frame_field_info_present_flag)
+    {
+        bs.PutBits(4, pt.pic_struct);
+        bs.PutBits(2, pt.source_scan_type);
+        bs.PutBit(pt.duplicate_flag);
+    }
+
+    bool bHRD = hrd.nal_hrd_parameters_present_flag || hrd.vcl_hrd_parameters_present_flag;
+    if (bHRD)
+    {
+       bs.PutBits(hrd.au_cpb_removal_delay_length_minus1+1, pt.au_cpb_removal_delay_minus1);
+       bs.PutBits(hrd.dpb_output_delay_length_minus1+1, pt.pic_dpb_output_delay);
+
+       assert(hrd.sub_pic_hrd_params_present_flag == 0);
+    }
+
+    bs.PutTrailingBits(true);
+}
+
+mfxU32 Packer::PackRBSP(mfxU8* dst, mfxU8* rbsp, mfxU32 dst_size, mfxU32 rbsp_size)
+{
+    mfxU32 rest_bytes = dst_size - rbsp_size;
+    mfxU8* rbsp_end = rbsp + rbsp_size;
+
+    if(dst_size < rbsp_size)
+        return 0;
+
+    //skip start-code
+    if (rbsp_size > 3)
+    {
+        dst[0] = rbsp[0];
+        dst[1] = rbsp[1];
+        dst[2] = rbsp[2];
+        dst  += 3;
+        rbsp += 3;
+    }
+
+    while (rbsp_end - rbsp > 2)
+    {
+        *dst++ = *rbsp++;
+
+        bool bNeedEPB = !(rbsp[-1] || rbsp[0] || (rbsp[1] & 0xFC));
+        if (bNeedEPB)
+        {
+            if (!--rest_bytes)
+                return 0;
+
+            *dst++ = *rbsp++;
+            *dst++ = 0x03;
+        }
+    }
+
+    while (rbsp_end > rbsp)
+        *dst++ = *rbsp++;
+
+    dst_size -= rest_bytes;
+
+    return dst_size;
+}
+
+void Packer::PackBPPayload(
+    BitstreamWriter& rbsp
+    , const TaskCommonPar & task
+    , const SPS& sps)
+{
+    BufferingPeriodSEI bp = {};
+
+    bp.seq_parameter_set_id = sps.seq_parameter_set_id;
+    bp.nal[0].initial_cpb_removal_delay = bp.vcl[0].initial_cpb_removal_delay = task.initial_cpb_removal_delay;
+    bp.nal[0].initial_cpb_removal_offset = bp.vcl[0].initial_cpb_removal_offset = task.initial_cpb_removal_offset;
+
+    mfxU32 size = CeilDiv(rbsp.GetOffset(), 8u);
+    mfxU8* pl = rbsp.GetStart() + size; // payload start
+
+    rbsp.PutBits(8, 0);    //payload type
+    rbsp.PutBits(8, 0xff); //place for payload  size
+    size += 2;
+
+    Packer::PackSEIPayload(rbsp, sps.vui, bp);
+
+    size = CeilDiv(rbsp.GetOffset(), 8u) - size;
+
+    assert(size < 256);
+    pl[1] = (mfxU8)size; //payload size
+}
+
+void Packer::PackPTPayload(
+    BitstreamWriter& rbsp
+    , const ExtBuffer::Param<mfxVideoParam> & par
+    , const TaskCommonPar & task
+    , const SPS& sps)
+{
+    PicTimingSEI pt = {};
+
+    static const std::map<mfxU16, std::array<mfxU8,2>> PicStructMFX2STD[2] =
+    {
+        {
+              {mfxU16(MFX_PICSTRUCT_FIELD_TFF), {mfxU8(3), mfxU8(0)}}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_BFF), {mfxU8(4), mfxU8(0)}}
+            , {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_TFF), {mfxU8(3), mfxU8(1)}}
+            , {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_BFF), {mfxU8(4), mfxU8(1)}}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_TFF | MFX_PICSTRUCT_FIELD_REPEATED), {mfxU8(5), mfxU8(0)}}
+            , {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_TFF | MFX_PICSTRUCT_FIELD_REPEATED), {mfxU8(5), mfxU8(1)}}
+            , {mfxU16(MFX_PICSTRUCT_FIELD_BFF | MFX_PICSTRUCT_FIELD_REPEATED), {mfxU8(6), mfxU8(0)}}
+            , {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FIELD_BFF | MFX_PICSTRUCT_FIELD_REPEATED), {mfxU8(6), mfxU8(1)}}
+            , {mfxU16(0), {mfxU8(0), mfxU8(2)}}
+        }
+        , {//progressive only
+              {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FRAME_DOUBLING), {mfxU8(7), mfxU8(1)}}
+            , {mfxU16(MFX_PICSTRUCT_PROGRESSIVE | MFX_PICSTRUCT_FRAME_TRIPLING), {mfxU8(8), mfxU8(1)}}
+            , {mfxU16(0), {mfxU8(0), mfxU8(1)}}
+        }
+    };
+
+    bool bProg = !!(par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
+    mfxU16 key = task.pSurfIn->Info.PicStruct;
+    key *= mfxU16(!!PicStructMFX2STD[bProg].count(key));
+    auto ps = PicStructMFX2STD[bProg].at(key);
+
+    pt.pic_struct = ps[0];
+    pt.source_scan_type = ps[1];
+    pt.duplicate_flag = 0;
+
+    pt.au_cpb_removal_delay_minus1 = std::max<mfxU32>(task.cpb_removal_delay, 1) - 1;
+    pt.pic_dpb_output_delay =
+        task.DisplayOrder
+        + sps.sub_layer[sps.max_sub_layers_minus1].max_num_reorder_pics
+        - task.EncodedOrder;
+
+    mfxU32 size = CeilDiv(rbsp.GetOffset(), 8u);
+    mfxU8* pl = rbsp.GetStart() + size; // payload start
+
+    rbsp.PutBits(8, 1);    //payload type
+    rbsp.PutBits(8, 0xFF); //place for payload  size
+    size += 2;
+
+    Packer::PackSEIPayload(rbsp, sps.vui, pt);
+
+    size = CeilDiv(rbsp.GetOffset(), 8u) - size;
+
+    assert(size < 256);
+    pl[1] = (mfxU8)size; //payload size
+}
+
+template<mfxU16 PT>
+bool PLTypeEq(const mfxPayload* pl)
+{
+    return (pl && pl->Type == PT);
+}
+
+mfxU32 Packer::GetPrefixSEI(
+    const ExtBuffer::Param<mfxVideoParam> & par
+    , const TaskCommonPar & task
+    , const SPS& sps
+    , mfxU8* buf
+    , mfxU32 sizeInBytes)
+{
+    NALU nalu = {1, PREFIX_SEI_NUT, 0, 1};
+    BitstreamWriter rbsp(m_rbsp.data(), (mfxU32)m_rbsp.size());
+    std::list<const mfxPayload*> prefixPL, tmpPL;
+    mfxPayload BPSEI = {}, PTSEI = {};
+    auto pBegin = buf;
+
+    auto PutPLIntoRBSP = [&rbsp](const mfxPayload* pPL)
+    {
+        rbsp.PutBitsBuffer(pPL->NumBit, pPL->Data);
+        rbsp.PutTrailingBits(true);
+    };
+    auto PackSeiNalu = [&](std::list<const mfxPayload*>& pls)
+    {
+        PackNALU(rbsp, nalu);
+
+        std::for_each(pls.begin(), pls.end(), PutPLIntoRBSP);
+
+        rbsp.PutTrailingBits();
+
+        auto bytesPacked = PackRBSP(buf, rbsp.GetStart(), sizeInBytes, CeilDiv(rbsp.GetOffset(), 8u));
+
+        buf += bytesPacked;
+        sizeInBytes -= bytesPacked;
+
+        rbsp.Reset();
+
+        return bytesPacked;
+    };
+
+    //external payloads
+    prefixPL.assign(task.ctrl.Payload, task.ctrl.Payload + (task.ctrl.NumPayload * !!task.ctrl.Payload));
+
+    if (par.mfx.RateControlMethod != MFX_RATECONTROL_CQP)
+    {
+        prefixPL.remove_if(PLTypeEq<0>); //buffering_period
+        prefixPL.remove_if(PLTypeEq<1>); //pic_timing
+    }
+
+    //internal payloads
+    std::transform(task.PLInternal.begin(), task.PLInternal.end(), std::back_inserter(prefixPL)
+        , [](const mfxPayload& pl) { return &pl; });
+
+    prefixPL.remove_if([](const mfxPayload* pPL) { return !pPL || (pPL->CtrlFlags & MFX_PAYLOAD_CTRL_SUFFIX); });
+
+    bool bNeedSEI = !prefixPL.empty() || (task.InsertHeaders & INSERT_SEI);
+
+    if (!bNeedSEI)
+        return 0;
+
+    /* An SEI NAL unit containing an active parameter sets SEI message shall contain only
+    one active parameter sets SEI message and shall not contain any other SEI messages. */
+    /* When an SEI NAL unit containing an active parameter sets SEI message is present
+    in an access unit, it shall be the first SEI NAL unit that follows the prevVclNalUnitInAu
+    of the SEI NAL unit and precedes the nextVclNalUnitInAu of the SEI NAL unit. */
+    MoveIf(prefixPL, tmpPL, PLTypeEq<129>);
+
+    bool bPackError = !tmpPL.empty() && !PackSeiNalu(tmpPL);
+
+    if (bPackError)
+        return 0;
+    
+    bool bNeedOwnPT = (task.InsertHeaders & INSERT_PTSEI)
+        && !std::any_of(prefixPL.begin(), prefixPL.end(), PLTypeEq<1>);
+    if (bNeedOwnPT)
+    {
+        PTSEI.Type   = 1;
+        PTSEI.NumBit = rbsp.GetOffset();
+        PTSEI.Data   = rbsp.GetStart() + PTSEI.NumBit / 8;
+
+        PackPTPayload(rbsp, par, task, sps);
+
+        PTSEI.NumBit  = rbsp.GetOffset() - PTSEI.NumBit;
+        PTSEI.BufSize = (mfxU16)CeilDiv<mfxU32>(PTSEI.NumBit, 8);
+
+        prefixPL.push_front(&PTSEI);
+        rbsp.PutTrailingBits(true);
+
+        auto pNewRBSPStart = rbsp.GetStart() + CeilDiv(rbsp.GetOffset(), 8u);
+        rbsp.Reset(pNewRBSPStart, mfxU32(rbsp.GetEnd() - pNewRBSPStart));
+    }
+
+    bool bNeedOwnBP = (task.InsertHeaders & INSERT_BPSEI)
+        && !std::any_of(prefixPL.begin(), prefixPL.end(), PLTypeEq<0>);
+    if (bNeedOwnBP)
+    {
+        BPSEI.Type   = 0;
+        BPSEI.NumBit = rbsp.GetOffset();
+        BPSEI.Data   = rbsp.GetStart() + BPSEI.NumBit / 8;
+
+        PackBPPayload(rbsp, task, sps);
+
+        BPSEI.NumBit  = rbsp.GetOffset() - BPSEI.NumBit;
+        BPSEI.BufSize = (mfxU16)CeilDiv<mfxU32>(BPSEI.NumBit, 8);
+
+        prefixPL.push_front(&BPSEI);
+        rbsp.PutTrailingBits(true);
+
+        auto pNewRBSPStart = rbsp.GetStart() + CeilDiv(rbsp.GetOffset(), 8u);
+        rbsp.Reset(pNewRBSPStart, mfxU32(rbsp.GetEnd() - pNewRBSPStart));
+    }
+
+    /* When an SEI NAL unit contains a non-nested buffering period SEI message,
+    a non-nested picture timing SEI message, or a non-nested decoding unit information
+    SEI message, the SEI NAL unit shall not contain any other SEI message with payloadType
+    not equal to 0 (buffering period), 1 (picture timing) or 130 (decoding unit information). */
+    tmpPL.clear();
+    MoveIf(prefixPL, tmpPL, PLTypeEq<0>);
+    MoveIf(prefixPL, tmpPL, PLTypeEq<1>);
+    MoveIf(prefixPL, tmpPL, PLTypeEq<130>);
+
+    bPackError =
+           (!tmpPL.empty() && !PackSeiNalu(tmpPL))
+        || (!prefixPL.empty() && !PackSeiNalu(prefixPL));
+
+    return mfxU32(!bPackError * (buf - pBegin));
+}
+
+mfxU32 Packer::GetSuffixSEI(
+    const TaskCommonPar & task
+    , mfxU8* buf
+    , mfxU32 sizeInBytes)
+{
+    NALU nalu = {0, SUFFIX_SEI_NUT, 0, 1};
+    BitstreamWriter rbsp(m_rbsp.data(), (mfxU32)m_rbsp.size());
+    std::list<const mfxPayload*> suffixPL, prefixPL;
+    std::list<const mfxPayload*>::iterator plIt;
+
+    suffixPL.assign(task.ctrl.Payload, task.ctrl.Payload + (task.ctrl.NumPayload * !!task.ctrl.Payload));
+    suffixPL.remove_if([](const mfxPayload* pPL) { return !pPL || !(pPL->CtrlFlags & MFX_PAYLOAD_CTRL_SUFFIX); });
+    prefixPL.assign(task.ctrl.Payload, task.ctrl.Payload + (task.ctrl.NumPayload * !!task.ctrl.Payload));
+    prefixPL.remove_if([](const mfxPayload* pPL) { return !pPL || (pPL->CtrlFlags & MFX_PAYLOAD_CTRL_SUFFIX); });
+
+     /* It is a requirement of bitstream conformance that when a prefix SEI message with payloadType
+     equal to 17 (progressive refinement segment end) or 22 (post-filter hint) is present in an access unit,
+     a suffix SEI message with the same value of payloadType shall not be present in the same access unit.*/
+    if (prefixPL.end() != std::find_if(prefixPL.begin(), prefixPL.end(), PLTypeEq<17>))
+        suffixPL.remove_if(PLTypeEq<17>);
+    if (prefixPL.end() != std::find_if(prefixPL.begin(), prefixPL.end(), PLTypeEq<22>))
+        suffixPL.remove_if(PLTypeEq<22>);
+
+    if (suffixPL.empty())
+        return 0;
+
+    PackNALU(rbsp, nalu);
+
+    std::for_each(suffixPL.begin(), suffixPL.end()
+        , [&](const mfxPayload* pPL)
+    {
+        rbsp.PutBitsBuffer(pPL->NumBit, pPL->Data);
+        rbsp.PutTrailingBits(true);
+    });
+
+    rbsp.PutTrailingBits();
+
+    return PackRBSP(buf, rbsp.GetStart(), sizeInBytes, CeilDiv(rbsp.GetOffset(), 8u));
+}
+
+static void PackSkipCTU(
+    mfxU32 xCtu
+    , mfxU32 yCtu
+    , mfxU32 log2CtuSize
+    , BitstreamWriter& bs
+    , const SPS& sps
+    , const PPS& pps
+    , const Slice& slice
+    , mfxU32 x0
+    , mfxU32 y0
+    , CABACContext& ctx)
+{
+    bool mbA = //is left MB available
+        ((yCtu == y0) && xCtu > x0)
+        || ((yCtu != y0) && xCtu > 0);
+    bool mbB = //is above MB available
+        (yCtu != y0)
+        && ((xCtu >= x0 && yCtu > y0)
+            || (xCtu < x0 && yCtu > (y0 + (1 << log2CtuSize))));
+    bool boundary =
+        ((xCtu + (1 << log2CtuSize) > sps.pic_width_in_luma_samples)
+            || (yCtu + (1 << log2CtuSize) > sps.pic_height_in_luma_samples))
+        && (log2CtuSize > (sps.log2_min_luma_coding_block_size_minus3 + 3));
+    mfxU8 split_flag = boundary && (log2CtuSize > (sps.log2_min_luma_coding_block_size_minus3 + 3));
+
+    if (!boundary)
+        bs.EncodeBin(ctx.SPLIT_CODING_UNIT_FLAG[0], split_flag);
+
+    if (split_flag)
+    {
+        mfxU32 x1 = xCtu + (1 << (log2CtuSize - 1));
+        mfxU32 y1 = yCtu + (1 << (log2CtuSize - 1));
+        struct SplitMap
+        {
+            mfxU32 x;
+            mfxU32 y;
+            bool   bPackCTU;
+        };
+        auto PackSplitCTU = [&](const SplitMap& s)
+        {
+            PackSkipCTU(s.x, s.y, log2CtuSize - 1, bs, sps, pps, slice, x0, y0, ctx);
+        };
+        std::list<SplitMap> splitMap({
+            {xCtu, yCtu, true},
+            {x1  , yCtu, x1 < sps.pic_width_in_luma_samples},
+            {xCtu, y1  , y1 < sps.pic_height_in_luma_samples},
+            {x1  , y1  , x1 < sps.pic_width_in_luma_samples && y1 < sps.pic_height_in_luma_samples}
+        });
+
+        splitMap.remove_if([](const SplitMap& s) { return !s.bPackCTU; });
+
+        std::for_each(std::begin(splitMap), std::end(splitMap), PackSplitCTU);
+    }
+    else
+    {
+        if (pps.transquant_bypass_enabled_flag)
+            bs.EncodeBin(ctx.CU_TRANSQUANT_BYPASS_FLAG[0], 0);
+
+        bs.EncodeBin(ctx.SKIP_FLAG[mbA + mbB], 1);
+
+        if (slice.five_minus_max_num_merge_cand < 4)
+            bs.EncodeBin(ctx.MERGE_IDX[0], 0);
+    }
+}
+
+void Packer::PackSkipSSD(
+    BitstreamWriter& bs
+    , SPS   const &     sps
+    , PPS   const &     pps
+    , Slice const &     sh
+    , mfxU32 NumLCU)
+{
+    CABACContext ctx;
+    const mfxU32 CtbLog2SizeY = sps.log2_min_luma_coding_block_size_minus3 + 3 + sps.log2_diff_max_min_luma_coding_block_size;
+    const mfxU32 CtbSizeY = (1 << CtbLog2SizeY);
+    const mfxU32 PicWidthInCtbsY = CeilDiv(sps.pic_width_in_luma_samples, CtbSizeY);
+
+    ctx.Init(pps, sh);
+
+    mfxU32 xCtu0 = (sh.segment_address % PicWidthInCtbsY) << CtbLog2SizeY;
+    mfxU32 yCtu0 = (sh.segment_address / PicWidthInCtbsY) << CtbLog2SizeY;
+    mfxU32 ctuAdrrEnd = sh.segment_address + NumLCU - 1;
+
+    for (mfxU32 ctuAdrr = sh.segment_address; ctuAdrr < ctuAdrrEnd; ctuAdrr++)
+    {
+        mfxU32 xCtu = (ctuAdrr % PicWidthInCtbsY) << CtbLog2SizeY;
+        mfxU32 yCtu = (ctuAdrr / PicWidthInCtbsY) << CtbLog2SizeY;
+
+        PackSkipCTU(xCtu, yCtu, CtbLog2SizeY, bs, sps, pps, sh, xCtu0, yCtu0, ctx);
+
+        bs.EncodeBin(ctx.END_OF_SLICE_FLAG[0], 0);
+    }
+
+    mfxU32 ctu = ctuAdrrEnd;//PicSizeInCtbsY - 1;
+    mfxU32 xCtu = (ctu % PicWidthInCtbsY) << CtbLog2SizeY;
+    mfxU32 yCtu = (ctu / PicWidthInCtbsY) << CtbLog2SizeY;
+
+    PackSkipCTU(xCtu, yCtu, CtbLog2SizeY, bs, sps, pps, sh, xCtu0, yCtu0, ctx);
+
+    bs.SliceFinish();
+}
+
+void Packer::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_Init
+        , [this](
+            StorageRW& global
+            , StorageRW&) -> mfxStatus
+    {
+        auto ph = make_unique<MakeStorable<PackedHeaders>>(PackedHeaders{});
+
+        mfxStatus sts = Reset(
+            Glob::VPS::Get(global)
+            , Glob::SPS::Get(global)
+            , Glob::PPS::Get(global)
+            , Glob::SliceInfo::Get(global)
+            , *ph);
+        MFX_CHECK_STS(sts);
+
+        auto&                     vpar   = Glob::VideoParam::Get(global);
+        mfxExtCodingOptionVPS&    vps    = ExtBuffer::Get(vpar);
+        mfxExtCodingOptionSPSPPS& spspps = ExtBuffer::Get(vpar);
+
+        vps.VPSBuffer     = ph->VPS.pData;
+        vps.VPSBufSize    = mfxU16(CeilDiv(ph->VPS.BitLen, 8u));
+        spspps.SPSBuffer  = ph->SPS.pData;
+        spspps.SPSBufSize = mfxU16(CeilDiv(ph->SPS.BitLen, 8u));
+        spspps.PPSBuffer  = ph->PPS.pData;
+        spspps.PPSBufSize = mfxU16(CeilDiv(ph->PPS.BitLen, 8u));
+
+        global.Insert(Glob::PackedHeaders::Key, std::move(ph));
+        m_pGlob = &global;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Packer::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this](
+            StorageRW& global
+            , StorageRW&) -> mfxStatus
+    {
+        auto& initState = Glob::RealState::Get(global);
+        auto& ph = Glob::PackedHeaders::Get(initState);
+
+        mfxStatus sts = Reset(
+            Glob::VPS::Get(global)
+            , Glob::SPS::Get(global)
+            , Glob::PPS::Get(global)
+            , Glob::SliceInfo::Get(global)
+            , ph);
+        MFX_CHECK_STS(sts);
+        
+        auto&                     vpar   = Glob::VideoParam::Get(global);
+        mfxExtCodingOptionVPS&    vps    = ExtBuffer::Get(vpar);
+        mfxExtCodingOptionSPSPPS& spspps = ExtBuffer::Get(vpar);
+
+        vps.VPSBuffer     = ph.VPS.pData;
+        vps.VPSBufSize    = mfxU16(CeilDiv(ph.VPS.BitLen, 8u));
+        spspps.SPSBuffer  = ph.SPS.pData;
+        spspps.SPSBufSize = mfxU16(CeilDiv(ph.SPS.BitLen, 8u));
+        spspps.PPSBuffer  = ph.PPS.pData;
+        spspps.PPSBufSize = mfxU16(CeilDiv(ph.PPS.BitLen, 8u));
+
+        auto& vparInit = Glob::VideoParam::Get(initState);
+        ((mfxExtCodingOptionVPS&)ExtBuffer::Get(vparInit)) = vps;
+        ((mfxExtCodingOptionSPSPPS&)ExtBuffer::Get(vparInit)) = spspps;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+mfxStatus Packer::PackHeader(BitstreamWriter& rbsp, mfxU8* pESBegin, mfxU8* pESEnd, PackedData& d)
+{
+    d.BitLen = PackRBSP(pESBegin, rbsp.GetStart(), mfxU32(pESEnd - pESBegin), CeilDiv(rbsp.GetOffset(), 8u));
+    MFX_CHECK(d.BitLen, MFX_ERR_NOT_ENOUGH_BUFFER);
+
+    d.pData   = pESBegin;
+    d.bLongSC = true;
+    d.bHasEP  = true;
+    d.BitLen  *= 8;
+
+    rbsp.Reset();
+
+    return MFX_ERR_NONE;
+};
+
+mfxStatus Packer::Reset(
+    const VPS& vps
+    , const SPS& sps
+    , const PPS& pps
+    , const std::vector<SliceInfo>& si
+    , PackedHeaders& ph)
+{
+    mfxStatus sts = MFX_ERR_NONE;
+    auto pESBegin = m_es.data();
+    auto pESEnd = pESBegin + m_es.size();
+    BitstreamWriter rbsp(m_rbsp.data(), (mfxU32)m_rbsp.size());
+
+    for (mfxU8 i = 0; i < 3; i++)
+    {
+        BitstreamWriter es(pESBegin, mfxU32(pESEnd - pESBegin));
+        PackAUD(es, i);
+
+        auto& d = ph.AUD[i];
+        d.pData = es.GetStart();
+        d.BitLen = es.GetOffset();
+        d.bLongSC = true;
+        d.bHasEP = true;
+        pESBegin += CeilDiv(d.BitLen, 8u);
+    }
+
+    PackVPS(rbsp, vps);
+    sts = PackHeader(rbsp, pESBegin, pESEnd, ph.VPS);
+    MFX_CHECK_STS(sts);
+    pESBegin += ph.VPS.BitLen / 8;
+
+    PackSPS(rbsp, sps);
+    sts = PackHeader(rbsp, pESBegin, pESEnd, ph.SPS);
+    MFX_CHECK_STS(sts);
+    pESBegin += ph.SPS.BitLen / 8;
+
+    PackPPS(rbsp, pps);
+    sts = PackHeader(rbsp, pESBegin, pESEnd, ph.PPS);
+    MFX_CHECK_STS(sts);
+    pESBegin += ph.PPS.BitLen / 8;
+
+    ph.SSH.resize(si.size());
+
+    m_pRTBufBegin = pESBegin;
+    m_pRTBufEnd   = pESEnd;
+
+    return MFX_ERR_NONE;
+}
+
+mfxU32 Packer::GetPSEIAndSSH(
+    const ExtBuffer::Param<mfxVideoParam>& par
+    , const TaskCommonPar& task
+    , const SPS& sps
+    , const PPS& pps
+    , Slice sh
+    , const std::vector<SliceInfo>& si
+    , PackedHeaders& ph
+    , mfxU8* buf
+    , mfxU32 sizeInBytes)
+{
+    BitstreamWriter rbsp(m_rbsp.data(), (mfxU32)m_rbsp.size());
+    mfxU8*          pBegin   = buf;
+    mfxU8*          pEnd     = pBegin + sizeInBytes;
+    bool            bSkip    = !!(task.SkipCMD & SKIPCMD_NeedSkipSliceGen);
+    bool            bDSS     = !bSkip && !!((const mfxExtCodingOption2&)ExtBuffer::Get(par)).MaxSliceSize;
+    bool            bNeedSEI = (task.InsertHeaders & INSERT_SEI)
+                                || std::any_of(task.ctrl.Payload, task.ctrl.Payload + task.ctrl.NumPayload,
+                                    [](const mfxPayload* pPL) { return pPL && !(pPL->CtrlFlags & MFX_PAYLOAD_CTRL_SUFFIX); });
+    auto            PutSSH   = [&](PackedData& d, NALU& nalu)
+    {
+        rbsp.Reset(pBegin, mfxU32(pEnd - pBegin));
+        rbsp.SetInfo(&d.PackInfo);
+
+        PackSSH(rbsp, nalu, sps, pps, sh, bDSS);
+
+        d.BitLen = rbsp.GetOffset();
+        pBegin += CeilDiv(d.BitLen, 8u);
+
+        return d.BitLen;
+    };
+    auto            PutSkip  = [&](PackedData& d, NALU& nalu, mfxU32 nLCU)
+    {
+        rbsp.Reset();
+
+        PackSSH(rbsp, nalu, sps, pps, sh, bDSS);
+        PackSkipSSD(rbsp, sps, pps, sh, nLCU);
+
+        d.BitLen = PackRBSP(pBegin, rbsp.GetStart(), mfxU32(pEnd - pBegin), CeilDiv(rbsp.GetOffset(), 8u));
+        pBegin   += d.BitLen;
+        d.BitLen *= 8;
+
+        return d.BitLen;
+    };
+
+    ph.PrefixSEI.BitLen = 0;
+
+    if (bNeedSEI)
+    {
+        ph.PrefixSEI.BitLen  = GetPrefixSEI(par, task, sps, pBegin, mfxU32(pEnd - pBegin));
+        ph.PrefixSEI.pData   = pBegin;
+        pBegin              += ph.PrefixSEI.BitLen;
+        ph.PrefixSEI.BitLen *= 8;
+        ph.PrefixSEI.bHasEP  = true;
+        ph.PrefixSEI.bLongSC = true;
+
+        if (!ph.PrefixSEI.BitLen)
+        {
+            return 0;
+        }
+    }
+
+    for (mfxU32 i = 0; i < si.size(); i++)
+    {
+        auto&   d               = ph.SSH.at(i);
+        bool    bLongStartCode  = (!i && !task.InsertHeaders) || task.bForceLongStartCode;
+        NALU    nalu            = { mfxU16(bLongStartCode), task.SliceNUT, 0, mfxU16(task.TemporalID + 1) };
+
+        d.pData   = pBegin;
+        d.bLongSC = bLongStartCode;
+        d.bHasEP  = bSkip;
+
+        sh.first_slice_segment_in_pic_flag  = !i;
+        sh.segment_address                  = si.at(i).SegmentAddress;
+
+        bool bFailed =
+            !(     (bSkip && PutSkip(d, nalu, si.at(i).NumLCU))
+                || (!bSkip && PutSSH(d, nalu)));
+
+        if (bFailed)
+        {
+            return 0;
+        }
+    }
+
+    return mfxU32(pBegin - buf);
+}
+
+void Packer::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SubmitTask
+        , [this](
+            StorageW& global
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+        OnExit cleanup([&]() { task.PLInternal.clear(); });
+
+        if (task.SkipCMD & SKIPCMD_NeedDriverCall)
+        {
+            auto& ph  = Glob::PackedHeaders::Get(global);
+            auto& pps = Glob::PPS::Get(global);
+
+            if (task.RepackHeaders & INSERT_PPS)
+            {
+                BitstreamWriter rbsp(m_rbsp.data(), (mfxU32)m_rbsp.size());
+                auto pPpsEsBegin = ph.SPS.pData + ph.SPS.BitLen / 8;
+
+                PackPPS(rbsp, pps);
+
+                ThrowAssert(pPpsEsBegin < m_es.data() || pPpsEsBegin > (m_es.data() + m_es.size())
+                    , "pPpsEsBegin is out of Packer ES buffer (m_es)");
+
+                auto sts = PackHeader(rbsp, pPpsEsBegin, m_pRTBufEnd, ph.PPS);
+                MFX_CHECK_STS(sts);
+
+                m_pRTBufBegin = ph.PPS.pData + ph.PPS.BitLen / 8;
+            }
+
+            mfxU32 sz = GetPSEIAndSSH(
+                Glob::VideoParam::Get(global)
+                , task
+                , Glob::SPS::Get(global)
+                , pps
+                , Task::SSH::Get(s_task)
+                , Glob::SliceInfo::Get(global)
+                , ph
+                , m_pRTBufBegin
+                , mfxU32(m_pRTBufEnd - m_pRTBufBegin));
+            MFX_CHECK(sz, MFX_ERR_NOT_ENOUGH_BUFFER);
+        }
+        else if (task.SkipCMD & SKIPCMD_NeedSkipSliceGen)
+        {
+            FrameLocker bsData(Glob::VideoCore::Get(global), task.BS.Mid);
+            auto& ph                = Glob::PackedHeaders::Get(global);
+            auto& bsInfo            = Glob::AllocBS::Get(global).Info();
+            auto& ssh               = Task::SSH::Get(s_task);
+            mfxU32 BsBytesAvailable = bsInfo.Width * bsInfo.Height;
+            mfxStatus sts           = MFX_ERR_NONE;
+
+            MFX_CHECK(bsData.Y, MFX_ERR_LOCK_MEMORY);
+
+            auto BSInsert = [&](const PackedData& d) -> mfxStatus
+            {
+                mfxU32 sz = CeilDiv(d.BitLen, 8u);
+                MFX_CHECK(sz <= BsBytesAvailable, MFX_ERR_NOT_ENOUGH_BUFFER);
+                MFX_CHECK(d.bHasEP, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+                std::copy(d.pData, d.pData + sz, bsData.Y + task.BsDataLength);
+
+                task.BsDataLength += sz;
+                BsBytesAvailable  -= sz;
+
+                return MFX_ERR_NONE;
+            };
+
+            bool bErr =
+                   ((task.InsertHeaders & INSERT_AUD) && Res2Bool(sts, BSInsert(ph.AUD[mfx::clamp(2 - ssh.type, 0, 2)])))
+                || ((task.InsertHeaders & INSERT_VPS) && Res2Bool(sts, BSInsert(ph.VPS)))
+                || ((task.InsertHeaders & INSERT_SPS) && Res2Bool(sts, BSInsert(ph.SPS)))
+                || ((task.InsertHeaders & INSERT_PPS) && Res2Bool(sts, BSInsert(ph.PPS)));
+            MFX_CHECK(!bErr, sts);
+
+            mfxU32 sz = GetPSEIAndSSH(
+                Glob::VideoParam::Get(global)
+                , task
+                , Glob::SPS::Get(global)
+                , Glob::PPS::Get(global)
+                , ssh
+                , Glob::SliceInfo::Get(global)
+                , ph
+                , bsData.Y + task.BsDataLength
+                , BsBytesAvailable);
+            MFX_CHECK(sz, MFX_ERR_NOT_ENOUGH_BUFFER);
+
+            task.BsDataLength += sz;
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Packer::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_InsertSuffixSEI
+        , [this](
+            StorageW& /*global*/
+            , StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        if (task.ctrl.NumPayload)
+        {
+            mfxU32 sz = GetSuffixSEI(task, task.pBsData + task.BsDataLength, task.BsBytesAvailable);
+            MFX_CHECK(!sz || !task.bDontPatchBS, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+            task.BsDataLength     += sz;
+            task.BsBytesAvailable -= sz;
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_packer.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_packer.h
@@ -1,0 +1,257 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+#include <array>
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class BitstreamWriter
+        : public IBsWriter
+    {
+    public:
+        BitstreamWriter(mfxU8* bs, mfxU32 size, mfxU8 bitOffset = 0);
+        ~BitstreamWriter();
+
+        virtual void PutBits(mfxU32 n, mfxU32 b) override;
+        void PutBitsBuffer(mfxU32 n, void* b, mfxU32 offset = 0);
+        virtual void PutBit(mfxU32 b) override;
+        void PutGolomb(mfxU32 b);
+        void PutTrailingBits(bool bCheckAligned = false);
+
+        virtual void PutUE(mfxU32 b)  override { PutGolomb(b); }
+        virtual void PutSE(mfxI32 b)  override { (b > 0) ? PutGolomb((b << 1) - 1) : PutGolomb((-b) << 1); }
+
+        mfxU32 GetOffset() { return mfxU32(m_bs - m_bsStart) * 8 + m_bitOffset - m_bitStart; }
+        mfxU8* GetStart() { return m_bsStart; }
+        mfxU8* GetEnd() { return m_bsEnd; }
+
+        void Reset(mfxU8* bs = 0, mfxU32 size = 0, mfxU8 bitOffset = 0);
+        void cabacInit();
+        void EncodeBin(mfxU8& ctx, mfxU8 binVal);
+        void EncodeBinEP(mfxU8 binVal);
+        void SliceFinish();
+        void PutBitC(mfxU32 B);
+
+        void AddInfo(mfxU32 key, mfxU32 value)
+        {
+            if (m_pInfo)
+                m_pInfo[0][key] = value;
+        }
+        void SetInfo(std::map<mfxU32, mfxU32> *pInfo)
+        {
+            m_pInfo = pInfo;
+        }
+
+    private:
+        void RenormE();
+        mfxU8* m_bsStart;
+        mfxU8* m_bsEnd;
+        mfxU8* m_bs;
+        mfxU8  m_bitStart;
+        mfxU8  m_bitOffset;
+
+        mfxU32 m_codILow;
+        mfxU32 m_codIRange;
+        mfxU32 m_bitsOutstanding;
+        mfxU32 m_BinCountsInNALunits;
+        bool   m_firstBitFlag;
+        std::map<mfxU32, mfxU32> *m_pInfo = nullptr;
+    };
+
+    
+    struct CABACContextTable
+    {
+        mfxU8 CU_TRANSQUANT_BYPASS_FLAG[1];
+        mfxU8 SPLIT_CODING_UNIT_FLAG[3];
+        mfxU8 SKIP_FLAG[3];
+        mfxU8 MERGE_IDX[1];
+        mfxU8 END_OF_SLICE_FLAG[1];
+    };
+
+    struct CABACContext
+        : CABACContextTable
+    {
+        static const CABACContextTable InitVal[3];
+        void Init(const PPS& pps, const Slice& sh);
+    };
+
+    class Packer
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Init) \
+    DECL_BLOCK(Reset) \
+    DECL_BLOCK(SubmitTask) \
+    DECL_BLOCK(InsertSuffixSEI)
+#define DECL_FEATURE_NAME "G11_Packer"
+#include "hevcehw_decl_blocks.h"
+
+        Packer(mfxU32 id)
+            : FeatureBase(id)
+        {}
+
+    //protected:
+        static const mfxU32 RBSP_SIZE = 1024;
+        static const mfxU32 AUD_ES_SIZE = 8;
+        static const mfxU32 VPS_ES_SIZE = 256;
+        static const mfxU32 SPS_ES_SIZE = 1024;
+        static const mfxU32 PPS_ES_SIZE = 128;
+        static const mfxU32 SSH_ES_SIZE = MAX_SLICES * 16;
+        static const mfxU32 ES_SIZE =
+            AUD_ES_SIZE * 3
+            + VPS_ES_SIZE
+            + SPS_ES_SIZE
+            + PPS_ES_SIZE
+            + SSH_ES_SIZE;
+        std::array<mfxU8, RBSP_SIZE> m_rbsp;
+        std::array<mfxU8, ES_SIZE> m_es;
+        mfxU8 *m_pRTBufBegin = nullptr
+            , *m_pRTBufEnd = nullptr;
+        NotNull<StorageW*> m_pGlob;
+
+
+        virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+        virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+        virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+        virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+
+        using FeatureBase::Reset;
+        mfxStatus Reset(
+            const VPS& vps
+            , const SPS& sps
+            , const PPS& pps
+            , const std::vector<SliceInfo>& si
+            , PackedHeaders& ph);
+
+        mfxU32 GetPrefixSEI(
+            const ExtBuffer::Param<mfxVideoParam> & par
+            , const TaskCommonPar & task
+            , const SPS& sps
+            , mfxU8* buf
+            , mfxU32 sizeInBytes);
+
+        mfxU32 GetSuffixSEI(
+            const TaskCommonPar & task
+            , mfxU8* buf
+            , mfxU32 sizeInBytes);
+
+        mfxU32 GetPSEIAndSSH(
+            const ExtBuffer::Param<mfxVideoParam>& par
+            , const TaskCommonPar& task
+            , const SPS& sps
+            , const PPS& pps
+            , Slice sh
+            , const std::vector<SliceInfo>& si
+            , PackedHeaders& ph
+            , mfxU8* buf
+            , mfxU32 sizeInBytes);
+
+        void PackBPPayload(
+            BitstreamWriter& rbsp
+            , const TaskCommonPar & task
+            , const SPS& sps);
+        void PackPTPayload(
+            BitstreamWriter& rbsp
+            , const ExtBuffer::Param<mfxVideoParam> & par
+            , const TaskCommonPar & task
+            , const SPS& sps);
+
+        void PackNALU (BitstreamWriter& bs, NALU  const &  nalu);
+        void PackAUD  (BitstreamWriter& bs, mfxU8 pic_type);
+        void PackVPS  (BitstreamWriter& bs, VPS const & vps);
+        void PackSPS  (BitstreamWriter& bs, SPS const & sps);
+        void PackPPS  (BitstreamWriter& bs, PPS const & pps);
+        void PackVUI  (BitstreamWriter& bs, VUI        const & vui, mfxU16 max_sub_layers_minus1);
+        void PackHRD  (BitstreamWriter& bs, HRDInfo    const & hrd, bool commonInfPresentFlag, mfxU16 maxNumSubLayersMinus1);
+        void PackPTL  (BitstreamWriter& bs, LayersInfo const & ptl, mfxU16 max_sub_layers_minus1);
+        void PackSLO  (BitstreamWriter& bs, LayersInfo const & slo, mfxU16 max_sub_layers_minus1);
+        mfxU32 PackSLD(BitstreamWriter& bs, ScalingList const & scl);
+
+        void PackSSH(
+            BitstreamWriter& bs
+            , NALU  const & nalu
+            , SPS   const & sps
+            , PPS   const & pps
+            , Slice const & slice
+            , bool dyn_slice_size = false);
+
+        void PackSkipSSD(
+            BitstreamWriter& bs
+            , SPS   const & sps
+            , PPS   const & pps
+            , Slice const & slice
+            , mfxU32 NumLCU);
+
+        void PackSEIPayload(BitstreamWriter& bs, VUI const & vui, BufferingPeriodSEI const & bp);
+        static void PackSEIPayload(BitstreamWriter& bs, VUI const & vui, PicTimingSEI const & pt);
+        static mfxU32 PackRBSP(mfxU8* dst, mfxU8* src, mfxU32 dst_size, mfxU32 src_size);
+        static mfxStatus PackHeader(BitstreamWriter& rbsp, mfxU8* pESBegin, mfxU8* pESEnd, PackedData& d);
+
+        static bool PutUE   (BitstreamWriter& bs, mfxU32 b) { bs.PutUE(b); return true; };
+        static bool PutSE   (BitstreamWriter& bs, mfxI32 b) { bs.PutSE(b); return true; };
+        static bool PutBit  (BitstreamWriter& bs, mfxU32 b) { bs.PutBit(!!b); return true; };
+        static bool PutBits (BitstreamWriter& bs, mfxU32 n, mfxU32 b) { if (n) bs.PutBits(n, b); return !!n; };
+
+        static bool PackSSHPWT(
+            BitstreamWriter& bs
+            , const SPS&     sps
+            , const PPS&     pps
+            , const Slice&   slice);
+
+        static void PackSSHPartPB(
+            BitstreamWriter& bs
+            , const SPS   &  sps
+            , const PPS   &  pps
+            , const Slice &  slice);
+
+        static void PackSSHPartIndependent(
+            BitstreamWriter& bs
+            , const NALU  &  nalu
+            , const SPS   &  sps
+            , const PPS   &  pps
+            , const Slice &  slice);
+
+        static void PackSSHPartNonIDR(
+            BitstreamWriter& bs
+            , const SPS   &  sps
+            , const Slice &  slice);
+
+        void PackSSHPartIdAddr(
+            BitstreamWriter& bs
+            , const NALU  &  nalu
+            , const SPS   &  sps
+            , const PPS   &  pps
+            , const Slice &  slice);
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_parser.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_parser.cpp
@@ -1,0 +1,887 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_parser.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+BitstreamReader::BitstreamReader(mfxU8* bs, mfxU32 size, mfxU8 bitOffset)
+    : m_bsStart(bs)
+    , m_bsEnd(bs + size)
+    , m_bs(bs)
+    , m_bitStart(bitOffset & 7)
+    , m_bitOffset(bitOffset & 7)
+    , m_emulation(true)
+{
+}
+
+BitstreamReader::~BitstreamReader()
+{
+}
+
+void BitstreamReader::Reset(mfxU8* bs, mfxU32 size, mfxU8 bitOffset)
+{
+    if (bs)
+    {
+        m_bsStart = bs;
+        m_bsEnd = bs + size;
+        m_bs = bs;
+        m_bitOffset = (bitOffset & 7);
+        m_bitStart = (bitOffset & 7);
+    }
+    else
+    {
+        m_bs = m_bsStart;
+        m_bitOffset = m_bitStart;
+    }
+}
+
+mfxU32 BitstreamReader::GetBit()
+{
+    assert(m_bs < m_bsEnd);
+    ThrowIf(m_bs >= m_bsEnd, EndOfBuffer());
+
+    mfxU32 b = (*m_bs >> (7 - m_bitOffset)) & 1;
+
+    bool bNewByte = (++m_bitOffset == 8);
+
+    m_bs += bNewByte;
+    m_bitOffset *= !bNewByte;
+
+    bool bSkipEPByte =
+        bNewByte
+        && m_emulation
+        && m_bs - m_bsStart >= 2
+        && (m_bsEnd - m_bs) >= 1
+        && m_bs[ 0] == 0x03
+        && m_bs[-1] == 0x00
+        && m_bs[-2] == 0x00
+        && (m_bs[1] & 0xfc) == 0x00;
+
+    m_bs += bSkipEPByte;
+
+    return b;
+}
+
+mfxU32 BitstreamReader::GetBits(mfxU32 n)
+{
+    mfxU32 b = 0;
+
+    while (n--)
+        b = (b << 1) | GetBit();
+
+    return b;
+}
+
+mfxU32 BitstreamReader::GetUE()
+{
+    mfxU32 lz = 0;
+
+    while (!GetBit())
+        lz++;
+
+    return !lz ? 0 : ((1 << lz) | GetBits(lz)) - 1;
+}
+
+mfxI32 BitstreamReader::GetSE()
+{
+    mfxU32 ue = GetUE();
+    return (ue & 1) ? (mfxI32)((ue + 1) >> 1) : -(mfxI32)((ue + 1) >> 1);
+}
+
+template<class TDst>
+bool TryRead(TDst& dst, StorageR& strg, StorageR::TKey key)
+{
+    if (!strg.Contains(key))
+        return false;
+    dst = strg.Read<TDst>(key);
+    return true;
+}
+
+void Parser::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_LoadSPSPPS
+        , [this](const mfxVideoParam&, mfxVideoParam& par, StorageRW& strg) -> mfxStatus
+    {
+        mfxExtCodingOptionSPSPPS* pSP = ExtBuffer::Get(par);
+
+        MFX_CHECK(pSP, MFX_ERR_NONE);
+
+        auto pSPS = make_storable<SPS>();
+        auto pPPS = make_storable<PPS>();
+
+        TryRead(m_needRextConstraints, strg, Glob::NeedRextConstraints::Key);
+        TryRead(m_readSpsExt, strg, Glob::ReadSpsExt::Key);
+        TryRead(m_readPpsExt, strg, Glob::ReadPpsExt::Key);
+
+        auto sts = LoadSPSPPS(par, *pSPS, *pPPS);
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+        bool bErr = pSP->SPSBuffer && pSP->SPSBufSize && !strg.TryInsert(Glob::SPS::Key, std::move(pSPS));
+        ThrowAssert(bErr, "failed to insert Glob::SPS");
+
+        bErr = pSP->PPSBuffer && pSP->PPSBufSize && !strg.TryInsert(Glob::PPS::Key, std::move(pPPS));
+        ThrowAssert(bErr, "failed to insert Glob::PPS");
+
+        return sts;
+    });
+}
+
+mfxStatus Parser::LoadSPSPPS(mfxVideoParam& par, SPS & sps, PPS & pps)
+{
+    mfxExtCodingOptionSPSPPS* pSP = ExtBuffer::Get(par);
+    if (!pSP)
+        return MFX_ERR_NONE;
+
+    mfxStatus sts = MFX_ERR_NONE;
+
+    if (pSP->SPSBuffer)
+    {
+        BitstreamReader bs(pSP->SPSBuffer, pSP->SPSBufSize);
+
+        sts = ParseSPS(bs, sps);
+        MFX_CHECK_STS(sts);
+
+        sts = SpsToMFX(sps, par);
+        MFX_CHECK_STS(sts);
+    }
+
+    if (pSP->PPSBuffer)
+    {
+        BitstreamReader bs(pSP->PPSBuffer, pSP->PPSBufSize);
+
+        sts = ParsePPS(bs, pps);
+        MFX_CHECK_STS(sts);
+
+        sts = PpsToMFX(pps, par);
+        MFX_CHECK_STS(sts);
+    }
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Parser::ParseNALU(BitstreamReader& bs, NALU & nalu)
+{
+    mfxStatus sts = MFX_ERR_NONE;
+    bool emulation = bs.GetEmulation();
+
+    bs.SetEmulation(false);
+
+    try
+    {
+        mfxU32 start_code = bs.GetBits(24);
+        mfxU32 n = 3;
+
+        while ((start_code & 0x00FFFFFF) != 1)
+        {
+            start_code <<= 8;
+            start_code |= bs.GetBits(8);
+            n++;
+        }
+
+        if (bs.GetBit())
+            return MFX_ERR_INVALID_VIDEO_PARAM;
+
+        nalu.long_start_code = (n > 3) && !(start_code >> 24);
+        nalu.nal_unit_type = bs.GetBits(6);
+        nalu.nuh_layer_id = bs.GetBits(6);
+        nalu.nuh_temporal_id_plus1 = bs.GetBits(3);
+    }
+    catch (std::exception &)
+    {
+        sts = MFX_ERR_INVALID_VIDEO_PARAM;
+    }
+
+    bs.SetEmulation(emulation);
+
+    return sts;
+}
+
+mfxStatus ParsePTL(
+    BitstreamReader& bs
+    , PTL& ptl
+    , std::function<bool(const PTL&)> NeedRextConstraints)
+{
+    if (ptl.profile_present_flag)
+    {
+        ptl.profile_space               = bs.GetBits(2);
+        ptl.tier_flag                   = bs.GetBit();
+        ptl.profile_idc                 = bs.GetBits(5);
+        ptl.profile_compatibility_flags = bs.GetBits(32);
+        ptl.progressive_source_flag     = bs.GetBit();
+        ptl.interlaced_source_flag      = bs.GetBit();
+        ptl.non_packed_constraint_flag  = bs.GetBit();
+        ptl.frame_only_constraint_flag  = bs.GetBit();
+
+        bool bREXT =
+            ((ptl.profile_idc >= 4) && (ptl.profile_idc <= 7))
+            || (ptl.profile_compatibility_flags & 0xf0)
+            || (NeedRextConstraints && NeedRextConstraints(ptl));
+        
+        ptl.constraint.max_12bit        = bs.CondBit(bREXT, 0);
+        ptl.constraint.max_10bit        = bs.CondBit(bREXT, 0);
+        ptl.constraint.max_8bit         = bs.CondBit(bREXT, 0);
+        ptl.constraint.max_422chroma    = bs.CondBit(bREXT, 0);
+        ptl.constraint.max_420chroma    = bs.CondBit(bREXT, 0);
+        ptl.constraint.max_monochrome   = bs.CondBit(bREXT, 0);
+        ptl.constraint.intra            = bs.CondBit(bREXT, 0);
+        ptl.constraint.one_picture_only = bs.CondBit(bREXT, 0);
+        ptl.constraint.lower_bit_rate   = bs.CondBit(bREXT, 0);
+
+        //general_reserved_zero_34bits
+        MFX_CHECK(!bs.GetBits(24), MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(!bs.GetBits(10), MFX_ERR_UNSUPPORTED);
+        //general_reserved_zero_43bits
+        MFX_CHECK(bREXT || !bs.GetBits(9), MFX_ERR_UNSUPPORTED);
+
+        /*if (   ptl.profile_idc >= 1 && ptl.profile_idc <= 5
+            || (ptl.profile_compatibility_flags & 0x3e))
+        {
+            ptl.inbld_flag = bs.GetBit();
+        }
+        else*/
+        MFX_CHECK(!bs.GetBit(), MFX_ERR_UNSUPPORTED);//general_reserved_zero_bit
+    }
+
+    ptl.level_idc = (mfxU8)bs.CondBits(ptl.level_present_flag, 8, 0);
+
+    return MFX_ERR_NONE;
+}
+
+bool DPocSort(mfxI16 l, mfxI16 r)
+{
+    if (l < 0 && r > 0) return true;
+    if (r < 0 && l > 0) return false;
+    if (l < 0) return (l > r);
+    return (l < r);
+}
+
+void ParseSTRPS(
+    BitstreamReader& bs
+    , SPS & sps
+    , mfxU32 idx)
+{
+    STRPS & strps = sps.strps[idx];
+
+    strps.inter_ref_pic_set_prediction_flag = bs.CondBit(idx != 0, 0);
+
+    if (strps.inter_ref_pic_set_prediction_flag)
+    {
+        auto& cur = strps;
+
+        strps.delta_rps_sign = bs.GetBit();
+        strps.abs_delta_rps_minus1 = (mfxU16)bs.GetUE();
+
+        mfxU32 RefRpsIdx = idx - (strps.delta_idx_minus1 + 1);
+        STRPS& ref = sps.strps[RefRpsIdx];
+        mfxI16 NumDeltaPocs = 0;
+        mfxI16 RefNumDeltaPocs = NumDeltaPocs;
+        mfxI16 deltaRps = (1 - 2 * strps.delta_rps_sign) * (strps.abs_delta_rps_minus1 + 1);
+        bool used_by_curr_pic_flag[std::extent<decltype(cur.pic)>::value] = {};
+        bool use_delta_flag[std::extent<decltype(cur.pic)>::value] = {};
+
+        for (mfxI16 i = 0; i <= RefNumDeltaPocs; ++i)
+        {
+            auto& curPic = cur.pic[NumDeltaPocs];
+            used_by_curr_pic_flag[i] = !!bs.GetBit();
+
+            use_delta_flag[i] = used_by_curr_pic_flag[i] || bs.GetBit();
+            if (use_delta_flag[i])
+            {
+                curPic.used_by_curr_pic_sx_flag = used_by_curr_pic_flag[i];
+                curPic.DeltaPocSX = (i < RefNumDeltaPocs) * ref.pic[i].DeltaPocSX + deltaRps;
+                cur.num_negative_pics += (curPic.DeltaPocSX < 0);
+                cur.num_positive_pics += (curPic.DeltaPocSX > 0);
+                NumDeltaPocs++;
+            }
+        }
+
+        std::sort(
+            cur.pic
+            , cur.pic + NumDeltaPocs
+            , [](STRPS::Pic& l, STRPS::Pic& r)
+        {
+            return DPocSort(l.DeltaPocSX, r.DeltaPocSX);
+        });
+
+        for (mfxI16 i = 0; i <= RefNumDeltaPocs; ++i)
+        {
+            cur.pic[i].used_by_curr_pic_flag = used_by_curr_pic_flag[i];
+            cur.pic[i].use_delta_flag = use_delta_flag[i];
+        }
+    }
+    else
+    {
+        strps.num_negative_pics = bs.GetUE();
+        strps.num_positive_pics = bs.GetUE();
+
+        mfxI16 sign = -1;
+        auto ParseIntraPic = [&](STRPS::Pic& pic)
+        {
+            pic.delta_poc_sx_minus1      = bs.GetUE();
+            pic.used_by_curr_pic_sx_flag = bs.GetBit();
+            pic.DeltaPocSX = mfxI16(sign * (pic.delta_poc_sx_minus1 + 1));
+        };
+
+        std::for_each(
+            strps.pic
+            , strps.pic + strps.num_negative_pics
+            , ParseIntraPic);
+
+        sign = 1;
+        std::for_each(
+            strps.pic + strps.num_negative_pics
+            , strps.pic + strps.num_negative_pics + strps.num_positive_pics
+            , ParseIntraPic);
+    }
+}
+
+mfxStatus ParseHRD(
+    BitstreamReader& bs
+    , SPS & sps)
+{
+    HRDInfo & hrd = sps.vui.hrd;
+
+    hrd.nal_hrd_parameters_present_flag = bs.GetBit();
+    hrd.vcl_hrd_parameters_present_flag = bs.GetBit();
+
+    bool bHrdParam =
+        hrd.nal_hrd_parameters_present_flag
+        || hrd.vcl_hrd_parameters_present_flag;
+
+    hrd.sub_pic_hrd_params_present_flag              = bs.CondBit(bHrdParam, 0);
+    hrd.tick_divisor_minus2                          = bs.CondBits(hrd.sub_pic_hrd_params_present_flag, 8, 0);
+    hrd.du_cpb_removal_delay_increment_length_minus1 = bs.CondBits(hrd.sub_pic_hrd_params_present_flag, 5, 0);
+    hrd.sub_pic_cpb_params_in_pic_timing_sei_flag    = bs.CondBit(hrd.sub_pic_hrd_params_present_flag, 0);
+    hrd.dpb_output_delay_du_length_minus1            = bs.CondBits(hrd.sub_pic_hrd_params_present_flag, 5, 0);
+    hrd.bit_rate_scale                               = bs.CondBits(bHrdParam, 4, 0);
+    hrd.cpb_size_scale                               = bs.CondBits(bHrdParam, 4, 0);
+    hrd.cpb_size_du_scale                            = bs.CondBits(hrd.sub_pic_hrd_params_present_flag, 4, 0);
+    hrd.initial_cpb_removal_delay_length_minus1      = bs.CondBits(bHrdParam, 5, 0);
+    hrd.au_cpb_removal_delay_length_minus1           = bs.CondBits(bHrdParam, 5, 0);
+    hrd.dpb_output_delay_length_minus1               = bs.CondBits(bHrdParam, 5, 0);
+
+    bool bErr = std::any_of(
+        hrd.sl
+        , hrd.sl + sps.max_sub_layers_minus1 + 1
+        , [&](HRDInfo::SubLayer& sl)
+    {
+        sl.fixed_pic_rate_general_flag = bs.GetBit();
+        sl.fixed_pic_rate_within_cvs_flag = !sl.fixed_pic_rate_general_flag && bs.GetBit();
+
+        bool bFixedPicRate =
+            sl.fixed_pic_rate_within_cvs_flag || sl.fixed_pic_rate_general_flag;
+
+        sl.elemental_duration_in_tc_minus1  = bs.CondUE(bFixedPicRate, 0);
+        sl.low_delay_hrd_flag               = bs.CondBit(!bFixedPicRate, 0);
+        sl.cpb_cnt_minus1                   = bs.CondUE(!sl.low_delay_hrd_flag, 0);
+
+        std::for_each(
+            sl.cpb
+            , sl.cpb + (sl.cpb_cnt_minus1 + 1) * hrd.nal_hrd_parameters_present_flag
+            , [&](decltype(*sl.cpb) cpb)
+        {
+            cpb.bit_rate_value_minus1 = bs.GetUE();
+            cpb.cpb_size_value_minus1 = bs.GetUE();
+
+            cpb.cpb_size_du_value_minus1 = bs.CondUE(hrd.sub_pic_hrd_params_present_flag, 0);
+            cpb.bit_rate_du_value_minus1 = bs.CondUE(hrd.sub_pic_hrd_params_present_flag, 0);
+
+            cpb.cbr_flag = (mfxU8)bs.GetBit();
+        });
+
+        return !!hrd.vcl_hrd_parameters_present_flag;
+    });
+
+    MFX_CHECK(!bErr, MFX_ERR_UNSUPPORTED);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus ParseVUI(
+    BitstreamReader& bs
+    , SPS & sps)
+{
+    VUI & vui = sps.vui;
+
+    vui.aspect_ratio_info_present_flag = bs.GetBit();
+
+    vui.aspect_ratio_idc = (mfxU8)bs.CondBits(vui.aspect_ratio_info_present_flag, 8, 0);
+    vui.sar_width  = (mfxU16)bs.CondBits(vui.aspect_ratio_idc == 255, 16, 0);
+    vui.sar_height = (mfxU16)bs.CondBits(vui.aspect_ratio_idc == 255, 16, 0);
+
+    vui.overscan_info_present_flag = bs.GetBit();
+    vui.overscan_appropriate_flag = bs.CondBit(vui.overscan_info_present_flag, 0);
+
+    vui.video_signal_type_present_flag  = bs.GetBit();
+    vui.video_format                    = bs.CondBits(vui.video_signal_type_present_flag, 3, 0);
+    vui.video_full_range_flag           = bs.CondBit(vui.video_signal_type_present_flag, 0);
+    vui.colour_description_present_flag = bs.CondBit(vui.video_signal_type_present_flag, 0);
+    vui.colour_primaries                = (mfxU8)bs.CondBits(vui.colour_description_present_flag, 8, 0);
+    vui.transfer_characteristics        = (mfxU8)bs.CondBits(vui.colour_description_present_flag, 8, 0);
+    vui.matrix_coeffs                   = (mfxU8)bs.CondBits(vui.colour_description_present_flag, 8, 0);
+
+    vui.chroma_loc_info_present_flag        = bs.GetBit();
+    vui.chroma_sample_loc_type_top_field    = bs.CondUE(vui.chroma_loc_info_present_flag, 0);
+    vui.chroma_sample_loc_type_bottom_field = bs.CondUE(vui.chroma_loc_info_present_flag, 0);
+
+    vui.neutral_chroma_indication_flag  = bs.GetBit();
+    vui.field_seq_flag                  = bs.GetBit();
+    vui.frame_field_info_present_flag   = bs.GetBit();
+
+    vui.default_display_window_flag = bs.GetBit();
+    vui.def_disp_win_left_offset    = bs.CondUE(vui.default_display_window_flag, 0);
+    vui.def_disp_win_right_offset   = bs.CondUE(vui.default_display_window_flag, 0);
+    vui.def_disp_win_top_offset     = bs.CondUE(vui.default_display_window_flag, 0);
+    vui.def_disp_win_bottom_offset  = bs.CondUE(vui.default_display_window_flag, 0);
+
+    vui.timing_info_present_flag = bs.GetBit();
+
+    vui.num_units_in_tick               = bs.CondBits(vui.timing_info_present_flag, 32, 0);
+    vui.time_scale                      = bs.CondBits(vui.timing_info_present_flag, 32, 0);
+    vui.poc_proportional_to_timing_flag = bs.CondBit(vui.timing_info_present_flag, 0);
+    vui.num_ticks_poc_diff_one_minus1   = bs.CondUE(vui.poc_proportional_to_timing_flag, 0);
+
+    vui.hrd_parameters_present_flag = bs.GetBit();
+
+    mfxStatus sts = MFX_ERR_NONE;
+    bool bErr = vui.hrd_parameters_present_flag && Res2Bool(sts, ParseHRD(bs, sps));
+    MFX_CHECK(!bErr, sts);
+
+    vui.bitstream_restriction_flag              = bs.GetBit();
+    vui.tiles_fixed_structure_flag              = bs.CondBit(vui.bitstream_restriction_flag, 0);
+    vui.motion_vectors_over_pic_boundaries_flag = bs.CondBit(vui.bitstream_restriction_flag, 0);
+    vui.restricted_ref_pic_lists_flag           = bs.CondBit(vui.bitstream_restriction_flag, 0);
+    vui.min_spatial_segmentation_idc            = bs.CondUE(vui.bitstream_restriction_flag, 0);
+    vui.max_bytes_per_pic_denom                 = bs.CondUE(vui.bitstream_restriction_flag, 0);
+    vui.max_bits_per_min_cu_denom               = bs.CondUE(vui.bitstream_restriction_flag, 0);
+    vui.log2_max_mv_length_horizontal           = bs.CondUE(vui.bitstream_restriction_flag, 0);
+    vui.log2_max_mv_length_vertical             = bs.CondUE(vui.bitstream_restriction_flag, 0);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Parser::ParseSPS(BitstreamReader& bs, SPS & sps)
+{
+    mfxStatus sts = MFX_ERR_NONE;
+    NALU nalu = {};
+
+    sps = SPS{};
+
+    do
+    {
+        sts = ParseNALU(bs, nalu);
+        MFX_CHECK_STS(sts);
+    } while (nalu.nal_unit_type != SPS_NUT);
+
+    try
+    {
+        sps.video_parameter_set_id = bs.GetBits(4);
+        sps.max_sub_layers_minus1 = bs.GetBits(3);
+        sps.temporal_id_nesting_flag = bs.GetBit();
+
+        sps.general.profile_present_flag = 1;
+        sps.general.level_present_flag = 1;
+
+        sts = ParsePTL(bs, sps.general, m_needRextConstraints);
+        MFX_CHECK_STS(sts);
+
+        std::for_each(sps.sub_layer, sps.sub_layer + sps.max_sub_layers_minus1
+            , [&](decltype(*sps.sub_layer) sl)
+        {
+            sl.profile_present_flag = bs.GetBit();
+            sl.level_present_flag = bs.GetBit();
+        });
+
+        MFX_CHECK(!(sps.max_sub_layers_minus1 && bs.GetBits(2 * 8)) // reserved_zero_2bits[ i ]
+            , MFX_ERR_INVALID_VIDEO_PARAM);
+
+        auto ParsePTLWrap = [&](PTL& ptl) { return Res2Bool(sts, ParsePTL(bs, ptl, m_needRextConstraints)); };
+        bool bErr = std::any_of(sps.sub_layer, sps.sub_layer + sps.max_sub_layers_minus1, ParsePTLWrap);
+        MFX_CHECK(!bErr, sts);
+
+        sps.seq_parameter_set_id = bs.GetUE();
+        sps.chroma_format_idc = bs.GetUE();
+
+        sps.separate_colour_plane_flag = (sps.chroma_format_idc == 3) && bs.GetBit();
+
+        sps.pic_width_in_luma_samples = bs.GetUE();
+        sps.pic_height_in_luma_samples = bs.GetUE();
+
+        sps.conformance_window_flag = bs.GetBit();
+
+        sps.conf_win_left_offset    = bs.CondUE(sps.conformance_window_flag, 0);
+        sps.conf_win_right_offset   = bs.CondUE(sps.conformance_window_flag, 0);
+        sps.conf_win_top_offset     = bs.CondUE(sps.conformance_window_flag, 0);
+        sps.conf_win_bottom_offset  = bs.CondUE(sps.conformance_window_flag, 0);
+
+        sps.bit_depth_luma_minus8 = bs.GetUE();
+        sps.bit_depth_chroma_minus8 = bs.GetUE();
+        sps.log2_max_pic_order_cnt_lsb_minus4 = bs.GetUE();
+
+        sps.sub_layer_ordering_info_present_flag = bs.GetBit();
+
+        std::for_each(
+            sps.sub_layer + (sps.max_sub_layers_minus1 * sps.sub_layer_ordering_info_present_flag)
+            , sps.sub_layer + sps.max_sub_layers_minus1 + 1
+            , [&](decltype(*sps.sub_layer) sl)
+        {
+            sl.max_dec_pic_buffering_minus1 = bs.GetUE();
+            sl.max_num_reorder_pics = bs.GetUE();
+            sl.max_latency_increase_plus1 = bs.GetUE();
+        });
+
+        sps.log2_min_luma_coding_block_size_minus3 = bs.GetUE();
+        sps.log2_diff_max_min_luma_coding_block_size = bs.GetUE();
+        sps.log2_min_transform_block_size_minus2 = bs.GetUE();
+        sps.log2_diff_max_min_transform_block_size = bs.GetUE();
+        sps.max_transform_hierarchy_depth_inter = bs.GetUE();
+        sps.max_transform_hierarchy_depth_intra = bs.GetUE();
+        sps.scaling_list_enabled_flag = bs.GetBit();
+
+        MFX_CHECK(!sps.scaling_list_enabled_flag, MFX_ERR_UNSUPPORTED);
+
+        sps.amp_enabled_flag                    = bs.GetBit();
+        sps.sample_adaptive_offset_enabled_flag = bs.GetBit();
+        sps.pcm_enabled_flag                    = bs.GetBit();
+
+        sps.pcm_sample_bit_depth_luma_minus1                = bs.CondBits(sps.pcm_enabled_flag, 4, 0);
+        sps.pcm_sample_bit_depth_chroma_minus1              = bs.CondBits(sps.pcm_enabled_flag, 4, 0);
+        sps.log2_min_pcm_luma_coding_block_size_minus3      = bs.CondUE(sps.pcm_enabled_flag, 0);
+        sps.log2_diff_max_min_pcm_luma_coding_block_size    = bs.CondUE(sps.pcm_enabled_flag, 0);
+        sps.pcm_loop_filter_disabled_flag                   = bs.CondBit(sps.pcm_enabled_flag, 0);
+
+        sps.num_short_term_ref_pic_sets = (mfxU8)bs.GetUE();
+
+        for (mfxU32 idx = 0; idx < sps.num_short_term_ref_pic_sets; idx++)
+        {
+            ParseSTRPS(bs, sps, idx);
+        }
+
+        sps.long_term_ref_pics_present_flag = bs.GetBit();
+        sps.num_long_term_ref_pics_sps = bs.CondUE(sps.long_term_ref_pics_present_flag, 0);
+
+        for (mfxU32 i = 0; i < sps.num_long_term_ref_pics_sps; i++)
+        {
+            sps.lt_ref_pic_poc_lsb_sps[i] = (mfxU16)bs.GetBits(sps.log2_max_pic_order_cnt_lsb_minus4 + 4);
+            sps.used_by_curr_pic_lt_sps_flag[i] = (mfxU8)bs.GetBit();
+        }
+
+        sps.temporal_mvp_enabled_flag = bs.GetBit();
+        sps.strong_intra_smoothing_enabled_flag = bs.GetBit();
+
+        sps.vui_parameters_present_flag = bs.GetBit();
+
+        bErr = sps.vui_parameters_present_flag && Res2Bool(sts, ParseVUI(bs, sps));
+        MFX_CHECK(!bErr, sts);
+
+        sps.extension_flag = bs.GetBit();
+        MFX_CHECK(sps.extension_flag, sts);
+
+        sps.range_extension_flag = bs.GetBit();
+        sps.ExtensionFlags = mfxU8((sps.range_extension_flag << 7) + bs.GetBits(7));
+
+
+        sps.transform_skip_rotation_enabled_flag    = bs.CondBit(sps.range_extension_flag, 0);
+        sps.transform_skip_context_enabled_flag     = bs.CondBit(sps.range_extension_flag, 0);
+        sps.implicit_rdpcm_enabled_flag             = bs.CondBit(sps.range_extension_flag, 0);
+        sps.explicit_rdpcm_enabled_flag             = bs.CondBit(sps.range_extension_flag, 0);
+        sps.extended_precision_processing_flag      = bs.CondBit(sps.range_extension_flag, 0);
+        sps.intra_smoothing_disabled_flag           = bs.CondBit(sps.range_extension_flag, 0);
+        sps.high_precision_offsets_enabled_flag     = bs.CondBit(sps.range_extension_flag, 0);
+        sps.persistent_rice_adaptation_enabled_flag = bs.CondBit(sps.range_extension_flag, 0);
+        sps.cabac_bypass_alignment_enabled_flag     = bs.CondBit(sps.range_extension_flag, 0);
+
+        mfxU8 extFlags = (sps.ExtensionFlags << 1);
+        MFX_CHECK(!(extFlags && !m_readSpsExt), MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(extFlags && m_readSpsExt, MFX_ERR_NONE);
+
+        for (mfxU8 extId = 1; extFlags; extId++)
+        {
+            MFX_CHECK(!(extFlags & 0x80) || m_readSpsExt(sps, extId, bs), MFX_ERR_UNSUPPORTED);
+            extFlags <<= 1;
+        }
+    }
+    catch (std::exception &)
+    {
+        return MFX_ERR_INVALID_VIDEO_PARAM;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Parser::ParsePPS(BitstreamReader& bs, PPS & pps)
+{
+    NALU nalu = {};
+
+    pps = PPS{};
+
+    do
+    {
+        mfxStatus sts = ParseNALU(bs, nalu);
+        MFX_CHECK_STS(sts);
+    } while (nalu.nal_unit_type != PPS_NUT);
+
+    try
+    {
+        pps.pic_parameter_set_id = bs.GetUE();
+        pps.seq_parameter_set_id = bs.GetUE();
+        pps.dependent_slice_segments_enabled_flag = bs.GetBit();
+        pps.output_flag_present_flag = bs.GetBit();
+        pps.num_extra_slice_header_bits = bs.GetBits(3);
+        pps.sign_data_hiding_enabled_flag = bs.GetBit();
+        pps.cabac_init_present_flag = bs.GetBit();
+        pps.num_ref_idx_l0_default_active_minus1 = bs.GetUE();
+        pps.num_ref_idx_l1_default_active_minus1 = bs.GetUE();
+        pps.init_qp_minus26 = bs.GetSE();
+        pps.constrained_intra_pred_flag = bs.GetBit();
+        pps.transform_skip_enabled_flag = bs.GetBit();
+        pps.cu_qp_delta_enabled_flag = bs.GetBit();
+
+        pps.diff_cu_qp_delta_depth = bs.CondUE(pps.cu_qp_delta_enabled_flag, 0);
+
+        pps.cb_qp_offset = bs.GetSE();
+        pps.cr_qp_offset = bs.GetSE();
+        pps.slice_chroma_qp_offsets_present_flag = bs.GetBit();
+        pps.weighted_pred_flag = bs.GetBit();
+        pps.weighted_bipred_flag = bs.GetBit();
+        pps.transquant_bypass_enabled_flag = bs.GetBit();
+        pps.tiles_enabled_flag = bs.GetBit();
+        pps.entropy_coding_sync_enabled_flag = bs.GetBit();
+
+        pps.num_tile_columns_minus1 = (mfxU16)bs.CondUE(pps.tiles_enabled_flag, 0);
+        pps.num_tile_rows_minus1 = (mfxU16)bs.CondUE(pps.tiles_enabled_flag, 0);
+        pps.uniform_spacing_flag = bs.CondBit(pps.tiles_enabled_flag, 1);
+
+        std::generate_n(
+            pps.column_width
+            , pps.num_tile_columns_minus1 * !pps.uniform_spacing_flag
+            , [&]() { return mfxU16(bs.GetUE() + 1); });
+
+        std::generate_n(
+            pps.row_height
+            , pps.num_tile_rows_minus1 * !pps.uniform_spacing_flag
+            , [&]() { return mfxU16(bs.GetUE() + 1); });
+
+        pps.loop_filter_across_tiles_enabled_flag = bs.CondBit(pps.tiles_enabled_flag, 0);
+
+        pps.loop_filter_across_slices_enabled_flag = bs.GetBit();
+        pps.deblocking_filter_control_present_flag = bs.GetBit();
+
+        pps.deblocking_filter_override_enabled_flag = bs.CondBit(pps.deblocking_filter_control_present_flag, 0);
+        pps.deblocking_filter_disabled_flag = bs.CondBit(pps.deblocking_filter_control_present_flag, 0);
+
+        bool bDblkOffsets = pps.deblocking_filter_control_present_flag && !pps.deblocking_filter_disabled_flag;
+        pps.beta_offset_div2 = bs.CondSE(bDblkOffsets, 0);
+        pps.tc_offset_div2 = bs.CondSE(bDblkOffsets, 0);
+
+        pps.scaling_list_data_present_flag = bs.GetBit();
+        MFX_CHECK(!pps.scaling_list_data_present_flag, MFX_ERR_UNSUPPORTED);
+
+        pps.lists_modification_present_flag = bs.GetBit();
+        pps.log2_parallel_merge_level_minus2 = (mfxU16)bs.GetUE();
+        pps.slice_segment_header_extension_present_flag = bs.GetBit();
+
+        pps.extension_flag = bs.GetBit();
+
+        MFX_CHECK(pps.extension_flag, MFX_ERR_NONE);
+
+        pps.range_extension_flag = bs.GetBit();
+        pps.ExtensionFlags = mfxU8((pps.range_extension_flag << 7) + bs.GetBits(7));
+
+        pps.log2_max_transform_skip_block_size_minus2 = bs.CondUE(
+            pps.range_extension_flag && pps.transform_skip_enabled_flag, 0);
+
+        pps.cross_component_prediction_enabled_flag = bs.CondBit(pps.range_extension_flag, 0);
+        pps.chroma_qp_offset_list_enabled_flag = bs.CondBit(pps.range_extension_flag, 0);
+
+        pps.diff_cu_chroma_qp_offset_depth = bs.CondUE(pps.chroma_qp_offset_list_enabled_flag, 0);
+        pps.chroma_qp_offset_list_len_minus1 = bs.CondUE(pps.chroma_qp_offset_list_enabled_flag, 0);
+
+        mfxU32 nChromaQpOffsets = (pps.chroma_qp_offset_list_len_minus1 + 1) * pps.chroma_qp_offset_list_enabled_flag;
+        for (mfxU32 i = 0; i < nChromaQpOffsets; i++)
+        {
+            pps.cb_qp_offset_list[i] = (mfxI8)bs.GetSE();
+            pps.cr_qp_offset_list[i] = (mfxI8)bs.GetSE();
+        }
+
+        pps.log2_sao_offset_scale_luma = bs.CondUE(pps.range_extension_flag, 0);
+        pps.log2_sao_offset_scale_chroma = bs.CondUE(pps.range_extension_flag, 0);
+
+        mfxU8 extFlags = (pps.ExtensionFlags << 1);
+        MFX_CHECK(!extFlags || m_readPpsExt, MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(extFlags && m_readPpsExt, MFX_ERR_NONE);
+
+        for (mfxU8 extId = 1; extFlags; extId++)
+        {
+            bool bExtSts = !(extFlags & 0x80) || m_readPpsExt(pps, extId, bs);
+            MFX_CHECK(bExtSts, MFX_ERR_UNSUPPORTED);
+            extFlags <<= 1;
+        }
+    }
+    catch (std::exception &)
+    {
+        return MFX_ERR_INVALID_VIDEO_PARAM;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+const mfxU8 AspectRatioByIdc[][2] =
+{
+    {  0,  0}, {  1,  1}, { 12, 11}, { 10, 11},
+    { 16, 11}, { 40, 33}, { 24, 11}, { 20, 11},
+    { 32, 11}, { 80, 33}, { 18, 11}, { 15, 11},
+    { 64, 33}, {160, 99}, {  4,  3}, {  3,  2},
+    {  2,  1},
+};
+
+mfxStatus Parser::SpsToMFX(const SPS& sps, mfxVideoParam par)
+{
+    mfxExtHEVCParam* pHEVCParam = ExtBuffer::Get(par);
+    mfxExtCodingOption* pCO = ExtBuffer::Get(par);
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+    mfxFrameInfo& fi = par.mfx.FrameInfo;
+    mfxU16 SubWidthC[4] = { 1, 2, 2, 1 };
+    mfxU16 SubHeightC[4] = { 1, 2, 1, 1 };
+    mfxU16 cropUnitX = SubWidthC[sps.chroma_format_idc];
+    mfxU16 cropUnitY = SubHeightC[sps.chroma_format_idc];
+
+    par.mfx.CodecProfile = sps.general.profile_idc;
+    par.mfx.CodecLevel = sps.general.level_idc / 3;
+
+    par.mfx.CodecLevel |= (sps.general.tier_flag * MFX_TIER_HEVC_HIGH);
+
+    if (pHEVCParam)
+    {
+        pHEVCParam->GeneralConstraintFlags = sps.general.rext_constraint_flags_0_31;
+        pHEVCParam->GeneralConstraintFlags |= ((mfxU64)sps.general.rext_constraint_flags_32_42 << 32);
+
+        pHEVCParam->PicWidthInLumaSamples = (mfxU16)sps.pic_width_in_luma_samples;
+        pHEVCParam->PicHeightInLumaSamples = (mfxU16)sps.pic_height_in_luma_samples;
+    }
+
+    par.mfx.NumRefFrame = sps.sub_layer[0].max_dec_pic_buffering_minus1;
+
+    par.mfx.FrameInfo.ChromaFormat = sps.chroma_format_idc;
+    fi.BitDepthLuma = sps.bit_depth_luma_minus8 + 8;
+    fi.BitDepthChroma = sps.bit_depth_chroma_minus8 + 8;
+
+    if (pCO3)
+    {
+        pCO3->TargetChromaFormatPlus1 = 1 + sps.chroma_format_idc;
+        pCO3->TargetBitDepthLuma = sps.bit_depth_luma_minus8 + 8;
+        pCO3->TargetBitDepthChroma = sps.bit_depth_chroma_minus8 + 8;
+    }
+
+    fi.Width  = mfx::align2_value((mfxU16)sps.pic_width_in_luma_samples, HW_SURF_ALIGN_W);
+    fi.Height = mfx::align2_value((mfxU16)sps.pic_height_in_luma_samples, HW_SURF_ALIGN_H);
+
+    fi.CropX = 0;
+    fi.CropY = 0;
+    fi.CropW = fi.Width;
+    fi.CropH = fi.Height;
+
+    fi.CropX += cropUnitX * (mfxU16)sps.conf_win_left_offset;
+    fi.CropW -= cropUnitX * (mfxU16)sps.conf_win_left_offset;
+    fi.CropW -= cropUnitX * (mfxU16)sps.conf_win_right_offset;
+    fi.CropY += cropUnitY * (mfxU16)sps.conf_win_top_offset;
+    fi.CropH -= cropUnitY * (mfxU16)sps.conf_win_top_offset;
+    fi.CropH -= cropUnitY * (mfxU16)sps.conf_win_bottom_offset;
+
+    MFX_CHECK(sps.vui_parameters_present_flag, MFX_ERR_NONE);
+
+    auto& vui = sps.vui;
+
+    bool bArFromSarWH = vui.aspect_ratio_info_present_flag && vui.aspect_ratio_idc == 255;
+    SetIf(fi.AspectRatioW, bArFromSarWH, vui.sar_width);
+    SetIf(fi.AspectRatioH, bArFromSarWH, vui.sar_height);
+
+    bool bArFromIdc =
+        vui.aspect_ratio_info_present_flag
+        && !bArFromSarWH
+        && vui.aspect_ratio_idc < Size(AspectRatioByIdc);
+    auto ArIdc = vui.aspect_ratio_idc * bArFromIdc;
+    SetIf(fi.AspectRatioW, bArFromIdc, AspectRatioByIdc[ArIdc][0]);
+    SetIf(fi.AspectRatioH, bArFromIdc, AspectRatioByIdc[ArIdc][1]);
+
+    SetIf(fi.FrameRateExtN, vui.timing_info_present_flag, vui.time_scale);
+    SetIf(fi.FrameRateExtD, vui.timing_info_present_flag, vui.num_units_in_tick);
+
+    cropUnitX *= vui.default_display_window_flag;
+    cropUnitY *= vui.default_display_window_flag;
+    fi.CropX += cropUnitX * (mfxU16)vui.def_disp_win_left_offset;
+    fi.CropW -= cropUnitX * (mfxU16)vui.def_disp_win_left_offset;
+    fi.CropW -= cropUnitX * (mfxU16)vui.def_disp_win_right_offset;
+    fi.CropY += cropUnitY * (mfxU16)vui.def_disp_win_top_offset;
+    fi.CropH -= cropUnitY * (mfxU16)vui.def_disp_win_top_offset;
+    fi.CropH -= cropUnitY * (mfxU16)vui.def_disp_win_bottom_offset;
+
+    MFX_CHECK(sps.vui.hrd_parameters_present_flag, MFX_ERR_NONE);
+
+    if (pCO)
+        pCO->VuiNalHrdParameters = MFX_CODINGOPTION_ON;
+
+    auto& hrd = sps.vui.hrd;
+    auto& sl0 = hrd.sl[0];
+    auto& cpb0 = sl0.cpb[0];
+
+    MaxKbps(par.mfx) = ((cpb0.bit_rate_value_minus1 + 1) << (6 + hrd.bit_rate_scale)) / 1000;
+    BufferSizeInKB(par.mfx) = ((cpb0.cpb_size_value_minus1 + 1) << (4 + hrd.cpb_size_scale)) / 8000;
+
+    par.mfx.TargetKbps = par.mfx.MaxKbps;
+
+    par.mfx.RateControlMethod =
+        MFX_RATECONTROL_CBR * cpb0.cbr_flag
+        + MFX_RATECONTROL_VBR * !cpb0.cbr_flag;
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus Parser::PpsToMFX(const PPS& pps, mfxVideoParam par)
+{
+    mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    if (pCO3)
+    {
+        std::fill_n(pCO3->NumRefActiveP, 8, mfxU16(pps.num_ref_idx_l0_default_active_minus1 + 1));
+        std::fill_n(pCO3->NumRefActiveBL1, 8, mfxU16(pps.num_ref_idx_l1_default_active_minus1 + 1));
+
+        pCO3->TransformSkip = (pps.transform_skip_enabled_flag
+            ? (mfxU16)MFX_CODINGOPTION_ON 
+            : (mfxU16)MFX_CODINGOPTION_OFF);
+    }
+
+    mfxExtHEVCTiles* pTiles = ExtBuffer::Get(par);
+
+    if (pps.tiles_enabled_flag)
+    {
+        pTiles->NumTileColumns = pps.num_tile_columns_minus1 + 1;
+        pTiles->NumTileRows = pps.num_tile_rows_minus1 + 1;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_parser.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_parser.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class BitstreamReader
+        : public IBsReader
+    {
+    public:
+        BitstreamReader(mfxU8* bs, mfxU32 size, mfxU8 bitOffset = 0);
+        ~BitstreamReader();
+
+        virtual mfxU32 GetBit() override;
+        virtual mfxU32 GetBits(mfxU32 n) override;
+        virtual mfxU32 GetUE() override;
+        virtual mfxI32 GetSE() override;
+
+        mfxU32 GetOffset() { return (mfxU32)(m_bs - m_bsStart) * 8 + m_bitOffset - m_bitStart; }
+        mfxU8* GetStart() { return m_bsStart; }
+
+        void SetEmulation(bool f) { m_emulation = f; };
+        bool GetEmulation() { return m_emulation; };
+
+        void Reset(mfxU8* bs = 0, mfxU32 size = 0, mfxU8 bitOffset = 0);
+
+    private:
+        mfxU8 * m_bsStart;
+        mfxU8* m_bsEnd;
+        mfxU8* m_bs;
+        mfxU8  m_bitStart;
+        mfxU8  m_bitOffset;
+        bool   m_emulation;
+    };
+
+    class Parser
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(LoadSPSPPS)
+#define DECL_FEATURE_NAME "G11_Parser"
+#include "hevcehw_decl_blocks.h"
+
+        Parser(mfxU32 id)
+            : FeatureBase(id)
+        {}
+
+    protected:
+        std::function<bool(const PTL&)> m_needRextConstraints;
+        std::function<bool(const SPS&, mfxU8, IBsReader&)> m_readSpsExt;
+        std::function<bool(const PPS&, mfxU8, IBsReader&)> m_readPpsExt;
+
+        virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+
+        mfxStatus LoadSPSPPS(mfxVideoParam& par, SPS & sps, PPS & pps);
+
+        mfxStatus ParseNALU(BitstreamReader& bs, NALU & nalu);
+        mfxStatus ParseSPS(BitstreamReader& bs, SPS & sps);
+        mfxStatus ParsePPS(BitstreamReader& bs, PPS & pps);
+
+        mfxStatus SpsToMFX(const SPS& sps, mfxVideoParam par);
+        mfxStatus PpsToMFX(const PPS& pps, mfxVideoParam par);
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_roi.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_roi.cpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_ROI)
+
+#include "hevcehw_g11_roi.h"
+#include "hevcehw_g11_legacy.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+static bool ROIViaMBQP(const ENCODE_CAPS_HEVC caps, const mfxVideoParam par)
+{
+    return (!caps.MaxNumOfROI || !caps.ROIDeltaQPSupport) && Legacy::IsSWBRC(par, ExtBuffer::Get(par));
+}
+
+static mfxStatus CheckAndFixRect(
+    ROI::RectData& rect
+    , mfxVideoParam const & par
+    , ENCODE_CAPS_HEVC const & caps)
+{
+    mfxU32 changed = 0;
+
+    changed += CheckMaxOrClip(rect.Left, par.mfx.FrameInfo.Width);
+    changed += CheckMaxOrClip(rect.Right, par.mfx.FrameInfo.Width);
+    changed += CheckMaxOrClip(rect.Top, par.mfx.FrameInfo.Height);
+    changed += CheckMaxOrClip(rect.Bottom, par.mfx.FrameInfo.Height);
+
+    mfxU32 blockSize = 1 << (caps.BlockSize + 3);
+    changed += AlignDown(rect.Left, blockSize);
+    changed += AlignDown(rect.Top, blockSize);
+    changed += AlignUp(rect.Right, blockSize);
+    changed += AlignUp(rect.Bottom, blockSize);
+
+    MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+    return MFX_ERR_NONE;
+}
+
+static mfxStatus CheckAndFixROI(
+    ENCODE_CAPS_HEVC const & caps
+    , mfxVideoParam const & par
+    , mfxExtEncoderROI& roi)
+{
+    mfxStatus sts = MFX_ERR_NONE, rsts = MFX_ERR_NONE;
+    mfxU32 changed = 0, invalid = 0;
+
+    bool bSWBRC = Legacy::IsSWBRC(par, ExtBuffer::Get(par));
+    bool bROIViaMBQP = ROIViaMBQP(caps, par);
+    bool bForcedQPMode = par.mfx.RateControlMethod == MFX_RATECONTROL_CQP || bSWBRC;
+
+    changed += CheckOrZero<mfxU16>(roi.ROIMode, MFX_ROI_MODE_PRIORITY, MFX_ROI_MODE_QP_DELTA);
+
+    if (!bForcedQPMode)
+    {
+        invalid += !(roi.ROIMode != MFX_ROI_MODE_QP_DELTA || caps.ROIDeltaQPSupport);
+        invalid += !(roi.ROIMode != MFX_ROI_MODE_PRIORITY || caps.ROIBRCPriorityLevelSupport);
+        roi.ROIMode *= !invalid;
+    }
+
+    invalid += !(par.mfx.RateControlMethod == MFX_RATECONTROL_CBR
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_VBR
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+        || par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR);
+
+    invalid += !(caps.MaxNumOfROI || bROIViaMBQP);
+    invalid += !(par.mfx.RateControlMethod != MFX_RATECONTROL_CQP || caps.ROIDeltaQPSupport);
+
+    mfxU16 maxNumOfRoi = !invalid * std::max<mfxU16>(
+        mfxU16(bROIViaMBQP * (caps.MbQpDataSupport * ROI::MAX_NUM_ROI))
+        , mfxU16(!bROIViaMBQP * caps.MaxNumOfROI));
+
+    changed += CheckMaxOrClip(roi.NumROI, maxNumOfRoi);
+
+    mfxI16 minVal = std::min<mfxI16>(-51 * (roi.ROIMode == MFX_ROI_MODE_QP_DELTA), -3);
+    mfxI16 maxVal = std::max<mfxI16>(51 * (roi.ROIMode == MFX_ROI_MODE_QP_DELTA), 3);
+
+    std::for_each(roi.ROI, roi.ROI + roi.NumROI
+        , [&](ROI::RectData& rect)
+    {
+        rsts = GetWorstSts(rsts, CheckAndFixRect(rect, par, caps));
+        invalid += CheckMinOrZero(rect.Priority, minVal);
+        invalid += CheckMaxOrZero(rect.Priority, maxVal);
+    });
+
+    auto IsInvalidRect = [](const ROI::RectData& rect)
+    {
+        return ((rect.Left >= rect.Right) || (rect.Top >= rect.Bottom));
+    };
+    mfxU16 numValidROI = mfxU16(std::remove_if(roi.ROI, roi.ROI + roi.NumROI, IsInvalidRect) - roi.ROI);
+    changed += CheckMaxOrClip(roi.NumROI, numValidROI);
+
+    sts = GetWorstSts(
+        mfxStatus(MFX_WRN_INCOMPATIBLE_VIDEO_PARAM * !!changed)
+        , mfxStatus(MFX_ERR_UNSUPPORTED * !!invalid));
+
+    return GetWorstSts(sts, rsts);
+}
+
+void ROI::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_ENCODER_ROI].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& src = *(const mfxExtEncoderROI*)pSrc;
+        auto& dst = *(mfxExtEncoderROI*)pDst;
+
+        dst.NumROI = src.NumROI;
+        dst.ROIMode = src.ROIMode;
+
+        std::transform(src.ROI, src.ROI + Size(src.ROI), dst.ROI
+            , [](const RectData& s)
+        {
+            RectData d = {};
+
+            d.Left     = s.Left;
+            d.Top      = s.Top;
+            d.Right    = s.Right;
+            d.Bottom   = s.Bottom;
+            d.DeltaQP  = s.DeltaQP;
+
+            return d;
+        });
+    });
+}
+
+void ROI::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFix
+        , [](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& global) -> mfxStatus
+    {
+        mfxExtEncoderROI* pROI = ExtBuffer::Get(par);
+        MFX_CHECK(pROI && pROI->NumROI, MFX_ERR_NONE);
+
+        auto& caps = Glob::EncodeCaps::Get(global);
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+        bool changed = false;
+
+        auto sts = CheckAndFixROI(caps, par, *pROI);
+        MFX_CHECK(sts >= MFX_ERR_NONE && pCO3, sts);
+
+        changed |= CheckOrZero<mfxU16>(pCO3->EnableMBQP
+            , MFX_CODINGOPTION_UNKNOWN
+            , MFX_CODINGOPTION_ON
+            , !ROIViaMBQP(caps, par) * MFX_CODINGOPTION_OFF);
+
+        return GetWorstSts(sts, mfxStatus(changed * MFX_WRN_INCOMPATIBLE_VIDEO_PARAM));
+    });
+}
+
+void ROI::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaults
+        , [this](mfxVideoParam& par, StorageW& strg, StorageRW&)
+    {
+        auto& defaults = Glob::Defaults::Get(strg);
+        auto& bSet = defaults.SetForFeature[GetID()];
+        if (!bSet)
+        {
+            defaults.GetPPS.Push([](
+                Defaults::TGetPPS::TExt prev
+                , const Defaults::Param& defPar
+                , const Gen11::SPS& sps
+                , Gen11::PPS& pps)
+            {
+                auto sts = prev(defPar, sps, pps);
+
+                pps.cu_qp_delta_enabled_flag |= !!((const mfxExtEncoderROI&)ExtBuffer::Get(defPar.mvp)).NumROI;
+
+                return sts;
+            });
+
+            bSet = true;
+        }
+
+        mfxExtEncoderROI* pROI = ExtBuffer::Get(par);
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+        MFX_CHECK(pCO3 && pROI && pROI->NumROI, MFX_ERR_NONE);
+
+        auto& caps = Glob::EncodeCaps::Get(strg);
+
+        SetDefault(pCO3->EnableMBQP, mfxU16(ROIViaMBQP(caps, par) * MFX_CODINGOPTION_ON));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void ROI::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
+{
+    Push(BLK_SetPPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        m_bViaCuQp = ROIViaMBQP(Glob::EncodeCaps::Get(strg), Glob::VideoParam::Get(strg));
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_roi.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_roi.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_ROI)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+class ROI
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(CheckAndFix)\
+    DECL_BLOCK(SetDefaults)\
+    DECL_BLOCK(SetCallChains)\
+    DECL_BLOCK(SetPPS)\
+    DECL_BLOCK(ConfigureTask)\
+    DECL_BLOCK(PatchDDITask)
+#define DECL_FEATURE_NAME "G11_ROI"
+#include "hevcehw_decl_blocks.h"
+
+    ROI(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+    typedef std::remove_reference<decltype (mfxExtEncoderROI::ROI[0])>::type RectData;
+    static const mfxU32 MAX_NUM_ROI = 16;
+
+protected:
+    virtual void SetSupported(ParamSupport& par) override;
+    virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+    virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override {};
+    virtual void SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push) override;
+    virtual void InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push) override;
+
+    bool m_bViaCuQp = false;
+};
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_task.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_task.cpp
@@ -1,0 +1,399 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_task.h"
+
+#include <thread>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void TaskManager::InitAlloc(const FeatureBlocks& blocks, TPushIA Push)
+{
+    Push(BLK_Init
+        , [this, &blocks](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+        auto rdrBuf = Glob::Reorder::Get(strg).BufferSize;
+
+        mfxStatus sts = Reset(par.AsyncDepth + rdrBuf + (par.AsyncDepth > 1));
+        MFX_CHECK_STS(sts);
+
+        for (auto& task : m_stages[0])
+        {
+            sts = RunBlocks(Check<mfxStatus, MFX_ERR_NONE>, FeatureBlocks::BQ<AT>::Get(blocks), strg, task);
+            MFX_CHECK_STS(sts);
+        }
+
+        m_nPicBuffered       = 0;
+        m_bufferSize         = !par.mfx.EncodedOrder * (rdrBuf + (par.AsyncDepth > 1));
+        m_maxParallelSubmits = std::min<mfxU16>(2, Glob::AllocBS::Get(strg).Response().NumFrameActual);
+        m_nTasksInExecution  = 0;
+
+        return sts;
+    });
+}
+
+void TaskManager::FrameSubmit(const FeatureBlocks& blocks, TPushFS Push)
+{
+    Push(BLK_NewTask
+        , [this, &blocks](
+             mfxEncodeCtrl* pCtrl
+            , mfxFrameSurface1* pSurf
+            , mfxBitstream& bs
+            , StorageW& global
+            , StorageRW& local) -> mfxStatus
+    {
+        MFX_CHECK(pSurf || m_nPicBuffered, MFX_ERR_MORE_DATA);
+
+        auto pBs = &bs;
+        auto pTask = MoveTask(S_NEW, S_PREPARE);
+        MFX_CHECK(pTask, MFX_WRN_DEVICE_BUSY);
+
+        local.Insert(Tmp::CurrTask::Key, make_unique<StorableRef<StorageW>>(*pTask));
+
+        bool bBufferPic = pSurf && m_nPicBuffered < m_bufferSize;
+        if (bBufferPic)
+        {
+            pBs = nullptr;
+            m_nPicBuffered++;
+        }
+
+        m_nPicBuffered -= !pSurf && m_nPicBuffered;
+
+        auto sts = RunBlocks(
+            CheckGE<mfxStatus, MFX_ERR_NONE>
+            , FeatureBlocks::BQ<IT>::Get(blocks)
+            , pCtrl, pSurf, pBs, global, *pTask);
+
+        MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+        MFX_CHECK(pBs, MFX_ERR_MORE_DATA_SUBMIT_TASK);
+
+        return sts;
+    });
+}
+
+void TaskManager::AsyncRoutine(const FeatureBlocks& blocks, TPushAR Push)
+{
+    Push(BLK_PrepareTask
+        , [this, &blocks](
+            StorageW& global
+            , StorageW& task) -> mfxStatus
+    {
+        std::unique_lock<std::mutex> closeGuard(m_closeMtx);
+        auto& tpar = Task::Common::Get(task);
+
+        MFX_CHECK(!m_nRecodeTasks, MFX_ERR_NONE);
+        MFX_CHECK(tpar.stage == S_PREPARE, MFX_ERR_NONE);
+        MFX_CHECK(tpar.pSurfIn, MFX_ERR_NONE);// leave fake task in "prepare" stage for now
+
+        auto sts = RunBlocks(Check<mfxStatus, MFX_ERR_NONE>, FeatureBlocks::BQ<PreRT>::Get(blocks), global, task);
+        MFX_CHECK_STS(sts);
+
+        auto pTask = MoveTask(S_PREPARE, S_REORDER, FixedTask(task));
+
+        MFX_CHECK(&(StorageW&)*pTask == &task, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_ReorderTask
+        , [this, &blocks](
+            StorageW& global
+            , StorageW& task) -> mfxStatus
+    {
+        std::unique_lock<std::mutex> closeGuard(m_closeMtx);
+        bool bNeedTask = !m_nRecodeTasks
+            && (m_stages.at(S_SUBMIT).size() + m_nTasksInExecution) < m_maxParallelSubmits;
+        MFX_CHECK(bNeedTask, MFX_ERR_NONE);
+
+        auto       IsInputTask = [](StorageR& rTask) { return !!Task::Common::Get(rTask).pSurfIn; };
+        StorageW*  pTask       = nullptr;
+        bool       bBypass     = !!Glob::VideoParam::Get(global).mfx.EncodedOrder;
+        bool       bFlush      = !IsInputTask(task) && !GetTask(S_PREPARE, SimpleCheck(IsInputTask));
+        TFnGetTask GetNextTask = [&](TTaskIt b, TTaskIt e)
+        {
+            auto IsIdrTask = [](const StorageR& rTask) { return IsIdr(Task::Common::Get(rTask).FrameType); };
+            auto it = std::find_if(b, e, IsIdrTask);
+            bFlush |= (it != e);
+            return Glob::Reorder::Get(global)(b, it, bFlush);
+        };
+
+        SetIf(GetNextTask, bBypass, FirstTask);
+
+        pTask = MoveTask(S_REORDER, S_SUBMIT, GetNextTask);
+        MFX_CHECK(pTask, MFX_ERR_NONE);
+
+        return RunBlocks(
+            Check<mfxStatus, MFX_ERR_NONE>
+            , FeatureBlocks::BQ<PostRT>::Get(blocks)
+            , global
+            , *pTask);
+    });
+
+    Push(BLK_SubmitTask
+        , [this, &blocks](
+            StorageW& global
+            , StorageW& /*task*/) -> mfxStatus
+    {
+        std::unique_lock<std::mutex> closeGuard(m_closeMtx);
+        mfxStatus sts;
+
+        while (StorageW* pTask = GetTask(S_SUBMIT))
+        {
+            auto& task = Task::Common::Get(*pTask);
+            bool bSync =
+                (m_maxParallelSubmits <= m_nTasksInExecution)
+                || (task.bForceSync && GetTask(S_QUERY));
+            MFX_CHECK(!bSync, MFX_ERR_NONE);
+
+            sts = RunBlocks(
+                Check<mfxStatus, MFX_ERR_NONE>
+                , FeatureBlocks::BQ<ST>::Get(blocks)
+                , global
+                , *pTask);
+            MFX_CHECK_STS(sts);
+
+            MoveTask(S_SUBMIT, S_QUERY, FixedTask(*pTask));
+            ++m_nTasksInExecution;
+            m_nRecodeTasks -= !!m_nRecodeTasks;
+        }
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_QueryTask
+        , [this, &blocks](
+            StorageW& global
+            , StorageW& inTask) -> mfxStatus
+    {
+        std::unique_lock<std::mutex> closeGuard(m_closeMtx);
+        auto pBs = Task::Common::Get(inTask).pBsOut;
+        MFX_CHECK(pBs, MFX_ERR_NONE);
+
+        StorageRW*          pTask             = nullptr;
+        StorageRW*          pPrevRecode       = nullptr;
+        bool                bCallAgain        = false;
+        const mfxStatus     NoTaskErr[2]      = { MFX_ERR_UNDEFINED_BEHAVIOR, MFX_TASK_BUSY };
+        auto                RanQueryTaskBlock =
+            [&](FeatureBlocks::BQ<QT>::TQueue::const_reference block)
+        {
+            mfxStatus sts = block.Call(global, *pTask);
+            bCallAgain = (pPrevRecode && sts == MFX_TASK_BUSY);
+
+            if (bCallAgain)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                return true;
+            }
+            ThrowIf(!!sts, sts);
+
+            auto& task = Task::Common::Get(*pTask);
+
+            return (task.bRecode && task.BsDataLength);
+        };
+        auto NextToPrevRecode = [&](TTaskIt begin, TTaskIt end)
+        {
+            auto it = FixedTask(*pPrevRecode)(begin, end);
+            return std::next(it, it != end);
+        };
+
+        auto& qQueryTask = FeatureBlocks::BQ<QT>::Get(blocks);
+
+        do
+        {
+            pTask = GetTask(S_QUERY);
+            MFX_CHECK(pTask, NoTaskErr[!!pPrevRecode]);
+
+            auto& task        = Task::Common::Get(*pTask);
+            task.pBsOut       = pBs;
+            task.bRecode      = !!pPrevRecode;
+            task.BsDataLength *= !task.bRecode; //reset value from prev. recode if any
+            bool  bRecode     = false;
+
+            do
+            {
+                bRecode = std::any_of(qQueryTask.begin(), qQueryTask.end(), RanQueryTaskBlock);
+            } while (bCallAgain);
+
+            task.NumRecode += bRecode && !pPrevRecode;
+
+            SetIf(pPrevRecode, !!pPrevRecode
+                , std::mem_fn(&TaskManager::MoveTask)
+                , *this, mfxU16(S_QUERY), mfxU16(S_SUBMIT), FixedTask(*pTask), NextToPrevRecode);
+
+            SetIf(pPrevRecode, bRecode && !pPrevRecode
+                , std::mem_fn(&TaskManager::MoveTask)
+                , *this, mfxU16(S_QUERY), mfxU16(S_SUBMIT), FixedTask(*pTask), FirstTask);
+
+            --m_nTasksInExecution;
+            m_nRecodeTasks += bRecode;
+        } while (pPrevRecode);
+
+        ThrowAssert(pPrevRecode, "For recode must exit by \"no task for query\" condition");
+
+        auto sts = RunBlocks(
+            Check<mfxStatus, MFX_ERR_NONE>
+            , FeatureBlocks::BQ<FT>::Get(blocks)
+            , global, *pTask);
+        MFX_CHECK_STS(sts);
+
+        if (!Task::Common::Get(inTask).pSurfIn)
+        {
+            MoveTask(S_PREPARE, S_NEW, FixedTask(inTask)); //don't need fake task anymore
+        }
+
+        MoveTask(S_QUERY, S_NEW, FixedTask(*pTask));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void TaskManager::ResetState(const FeatureBlocks& blocks, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this, &blocks](
+            StorageW& global, StorageW&) -> mfxStatus
+    {
+        if (Glob::ResetHint::Get(global).Flags & (RF_IDR_REQUIRED | RF_CANCEL_TASKS))
+        {
+            CancelTasks(Glob::RealState::Get(global), FeatureBlocks::BQ<FT>::Get(blocks));
+            m_nTasksInExecution = 0;
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void TaskManager::Close(const FeatureBlocks& blocks, TPushCLS Push)
+{
+    Push(BLK_Close
+        , [this, &blocks](
+            StorageW& global) -> mfxStatus
+    {
+        CancelTasks(global, FeatureBlocks::BQ<FT>::Get(blocks));
+        return MFX_ERR_NONE;
+    });
+}
+
+void TaskManager::CancelTasks(StorageW& global, const FeatureBlocks::BQ<FT>::TQueue& qFreeTask)
+{
+    std::unique_lock<std::mutex> closeGuard(m_closeMtx);
+
+    auto stageIt = m_stages.begin();
+
+    while (++stageIt != m_stages.end())
+    {
+        std::for_each(stageIt->begin(), stageIt->end()
+            , [&](StorageRW& task)
+        {
+            RunBlocks(CheckGE<mfxStatus, MFX_ERR_NONE>, qFreeTask, global, task);
+        });
+
+        m_stages.front().splice(m_stages.front().end(), *stageIt);
+    }
+}
+
+mfxStatus TaskManager::Reset(mfxU32 numTask)
+{
+    std::unique_lock<std::mutex> lock(m_mtx);
+
+    MFX_CHECK(m_cv.wait_for(
+        lock
+        , std::chrono::seconds(600)
+        , [&] { return m_stages.back().empty(); })
+        , MFX_ERR_GPU_HANG);
+
+    MFX_CHECK(numTask, MFX_ERR_NONE);
+
+    for (size_t i = 1; i < m_stages.size(); i++)
+        m_stages.front().splice(m_stages.front().end(), m_stages[i]);
+
+    m_stages.front().resize(numTask);
+
+    return MFX_ERR_NONE;
+}
+
+StorageRW* TaskManager::GetTask(
+    mfxU16 stage
+    , TFnGetTask which)
+{
+    if (stage >= m_stages.size())
+        throw std::out_of_range("Invalid task stage id");
+
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        auto& src = m_stages[stage];
+        auto it = which(src.begin(), src.end());
+
+        if (it != src.end())
+            return &*it;
+    }
+
+    return nullptr;
+}
+
+StorageRW* TaskManager::MoveTask(
+    mfxU16 from
+    , mfxU16 to
+    , TFnGetTask which
+    , TFnGetTask where)
+{
+    StorageRW* pTask = nullptr;
+    bool bNotify = false;
+
+    if (from >= m_stages.size() || to >= m_stages.size())
+        throw std::out_of_range("Invalid task stage id");
+
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        auto& src = m_stages[from];
+        auto& dst = m_stages[to];
+
+        if (!m_stages[from].empty())
+        {
+            auto itWhich = which(src.begin(), src.end());
+            auto itWhere = where(dst.begin(), dst.end());
+
+            if (itWhich == src.end())
+                return nullptr;
+
+            pTask = &*itWhich;
+            dst.splice(itWhere, src, itWhich);
+
+            bNotify = (to == 0 && m_stages.back().empty());
+
+            auto& stage = Task::Common::Get(*pTask).stage;
+            stage |= (1 << from);
+            stage &= ~(0xffffffff << to);
+        }
+    }
+
+    if (bNotify)
+        m_cv.notify_one();
+
+    return pTask;
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_task.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_task.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+#include <mutex>
+#include <condition_variable>
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+
+    class TaskManager
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(Init) \
+    DECL_BLOCK(Reset) \
+    DECL_BLOCK(NewTask) \
+    DECL_BLOCK(PrepareTask) \
+    DECL_BLOCK(ReorderTask) \
+    DECL_BLOCK(SubmitTask) \
+    DECL_BLOCK(QueryTask) \
+    DECL_BLOCK(Close)
+#define DECL_FEATURE_NAME "G11_TaskManager"
+#include "hevcehw_decl_blocks.h"
+
+        TaskManager(mfxU32 id)
+            : FeatureBase(id)
+            , m_stages(NUM_STAGES)
+        {}
+
+    protected:
+        std::vector<std::list<StorageRW>> m_stages;
+        std::mutex m_mtx, m_closeMtx;
+        std::condition_variable m_cv;
+        mfxU16 m_nPicBuffered       = 0;
+        mfxU16 m_bufferSize         = 0;
+        mfxU16 m_maxParallelSubmits = 0;
+        mfxU16 m_nTasksInExecution  = 0;
+        mfxU16 m_nRecodeTasks       = 0;
+
+        virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+        virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+        virtual void FrameSubmit(const FeatureBlocks& blocks, TPushFS Push) override;
+        virtual void AsyncRoutine(const FeatureBlocks& blocks, TPushAR Push) override;
+        virtual void Close(const FeatureBlocks& blocks, TPushCLS Push) override;
+
+        void CancelTasks(StorageW& global, const FeatureBlocks::BQ<FT>::TQueue& qFreeTask);
+
+        static TTaskIt FirstTask(TTaskIt begin, TTaskIt) { return begin; }
+        static TTaskIt EndTask(TTaskIt, TTaskIt end) { return end; }
+        static TTaskIt CheckTask(TTaskIt b, TTaskIt e, std::function<bool(StorageR&)> cond)
+        {
+            while (b != e && !cond(*b))
+                b++;
+            return b;
+        }
+
+        using TFnGetTask = std::function<TTaskIt(TTaskIt, TTaskIt)>;
+
+        static TFnGetTask SimpleCheck(std::function<bool(StorageR&)> cond)
+        {
+            using namespace std::placeholders;
+            return std::bind(CheckTask, _1, _2, cond);
+        }
+        static TFnGetTask FixedTask(const StorageR& task)
+        {
+            auto pTask = &task;
+            return SimpleCheck([pTask](StorageR& b) { return &b == pTask; });
+        }
+
+        using FeatureBase::Reset;
+        //blocking
+        mfxStatus Reset(mfxU32 numTask);
+        //non-blocking
+        StorageRW* MoveTask(
+            mfxU16 from
+            , mfxU16 to
+            , TFnGetTask which = FirstTask
+            , TFnGetTask where = EndTask);
+        StorageRW* GetTask(mfxU16 stage, TFnGetTask which = FirstTask);
+    };
+
+} //Gen11
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_weighted_prediction.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_weighted_prediction.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+
+#include "hevcehw_g11_weighted_prediction.h"
+#include <numeric>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void WeightPred::SetSupported(ParamSupport& blocks)
+{
+    blocks.m_ebCopySupported[MFX_EXTBUFF_CODING_OPTION3].emplace_back(
+        [](const mfxExtBuffer* pSrc, mfxExtBuffer* pDst) -> void
+    {
+        auto& buf_src = *(const mfxExtCodingOption3*)pSrc;
+        auto& buf_dst = *(mfxExtCodingOption3*)pDst;
+
+        MFX_COPY_FIELD(WeightedPred);
+        MFX_COPY_FIELD(WeightedBiPred);
+        MFX_COPY_FIELD(FadeDetection);
+    });
+}
+
+void WeightPred::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFix
+        , [this](const mfxVideoParam& /*in*/, mfxVideoParam& par, StorageW& global) -> mfxStatus
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        auto&  caps         = Glob::EncodeCaps::Get(global);
+        auto   hw           = Glob::VideoCore::Get(global).GetHWType();
+        bool   bFDSupported = !caps.NoWeightedPred && (hw < MFX_HW_ICL);
+        mfxU32 changed      = 0;
+
+        changed += CheckOrZero<mfxU16>(
+            pCO3->WeightedPred
+            , mfxU16(MFX_WEIGHTED_PRED_UNKNOWN)
+            , mfxU16(MFX_WEIGHTED_PRED_DEFAULT)
+            , mfxU16(!caps.NoWeightedPred * MFX_WEIGHTED_PRED_EXPLICIT));
+
+        changed += CheckOrZero<mfxU16>(
+            pCO3->WeightedBiPred
+            , mfxU16(MFX_WEIGHTED_PRED_UNKNOWN)
+            , mfxU16(MFX_WEIGHTED_PRED_DEFAULT)
+            , mfxU16(!caps.NoWeightedPred * MFX_WEIGHTED_PRED_EXPLICIT));
+
+        changed += CheckOrZero<mfxU16>(
+            pCO3->FadeDetection
+            , mfxU16(MFX_CODINGOPTION_UNKNOWN)
+            , mfxU16(MFX_CODINGOPTION_OFF)
+            , mfxU16(bFDSupported * MFX_CODINGOPTION_ON));
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void WeightPred::SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push)
+{
+    Push(BLK_SetDefaults
+        , [this](mfxVideoParam& par, StorageW& /*strg*/, StorageRW&)
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        SetDefault(pCO3->FadeDetection, MFX_CODINGOPTION_OFF);
+        SetDefault(pCO3->WeightedPred
+            , IsOn(pCO3->FadeDetection) * MFX_WEIGHTED_PRED_EXPLICIT
+            + IsOff(pCO3->FadeDetection) * MFX_WEIGHTED_PRED_DEFAULT);
+        SetDefault(pCO3->WeightedBiPred, pCO3->WeightedPred);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void WeightPred::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
+{
+    Push(BLK_SetPPS
+        , [this](StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(strg);
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+
+        PPS& pps = Glob::PPS::Get(strg);
+        pps.weighted_pred_flag   = (CO3.WeightedPred   == MFX_WEIGHTED_PRED_EXPLICIT);
+        pps.weighted_bipred_flag = (CO3.WeightedBiPred == MFX_WEIGHTED_PRED_EXPLICIT) || (IsOn(CO3.GPB) && pps.weighted_pred_flag);
+
+        MFX_CHECK(strg.Contains(Glob::RealState::Key), MFX_ERR_NONE);
+
+        const PPS& oldPPS = Glob::PPS::Get(Glob::RealState::Get(strg));
+        Glob::ResetHint::Get(strg).Flags |=
+            RF_PPS_CHANGED
+            * (    (pps.weighted_pred_flag != oldPPS.weighted_pred_flag)
+                || (pps.weighted_bipred_flag != oldPPS.weighted_bipred_flag));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void WeightPred::PostReorderTask(const FeatureBlocks& /*blocks*/, TPushPostRT Push)
+{
+    Push(BLK_SetSSH
+        , [](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& pps = Glob::PPS::Get(global);
+        auto& ssh = Task::SSH::Get(s_task);
+
+        bool bNeedPWT =
+            (pps.weighted_pred_flag && ssh.type == 1)
+            || (pps.weighted_bipred_flag && ssh.type == 0);
+
+        MFX_CHECK(bNeedPWT, MFX_ERR_NONE);
+
+        const mfxU16 Y = 0, Cb = 1, Cr = 2, W = 0, O = 1;
+        auto& task             = Task::Common::Get(s_task);
+        auto& caps             = Glob::EncodeCaps::Get(global);
+        auto  pExtPWT          = (mfxExtPredWeightTable*)ExtBuffer::Get(task.ctrl);
+        auto  SetDefaultWeight = [&](mfxI16 (&pwt)[3][2])
+        {
+            pwt[Y][W]  = (1 << ssh.luma_log2_weight_denom);
+            pwt[Y][O]  = 0;
+            pwt[Cb][W] = (1 << ssh.chroma_log2_weight_denom);
+            pwt[Cb][O] = 0;
+            pwt[Cr][W] = (1 << ssh.chroma_log2_weight_denom);
+            pwt[Cr][O] = 0;
+        };
+        auto  CopyLxPWT        = [&](mfxU16 l, mfxU16 sz)
+        {
+            auto CopyY = [&](mfxU16 i)
+            {
+                ssh.pwt[l][i][Y][W] = pExtPWT->Weights[l][i][Y][W];
+                ssh.pwt[l][i][Y][O] = pExtPWT->Weights[l][i][Y][O];
+            };
+            auto CopyC = [&](mfxU16 i)
+            {
+                ssh.pwt[l][i][Cb][W] = pExtPWT->Weights[l][i][Cb][W];
+                ssh.pwt[l][i][Cb][O] = pExtPWT->Weights[l][i][Cb][O];
+                ssh.pwt[l][i][Cr][W] = pExtPWT->Weights[l][i][Cr][W];
+                ssh.pwt[l][i][Cr][O] = pExtPWT->Weights[l][i][Cr][O];
+            };
+
+            std::list<mfxI16> idxY(sz * caps.LumaWeightedPred, 0);
+            std::list<mfxI16> idxC(sz * caps.ChromaWeightedPred, 0);
+
+            std::iota(idxY.begin(), idxY.end(), mfxI16(0));
+            std::iota(idxC.begin(), idxC.end(), mfxI16(0));
+
+            idxY.remove_if([&](mfxI16 i) { return !pExtPWT->LumaWeightFlag[l][i]; });
+            idxC.remove_if([&](mfxI16 i) { return !pExtPWT->ChromaWeightFlag[l][i]; });
+
+            for_each(idxY.begin(), idxY.end(), CopyY);
+            for_each(idxC.begin(), idxC.end(), CopyC);
+        };
+
+        ssh.luma_log2_weight_denom   = 6;
+        ssh.chroma_log2_weight_denom = ssh.luma_log2_weight_denom;
+
+        if (pExtPWT)
+        {
+            ssh.luma_log2_weight_denom   = pExtPWT->LumaLog2WeightDenom;
+            ssh.chroma_log2_weight_denom = pExtPWT->ChromaLog2WeightDenom;
+        }
+
+        std::for_each(std::begin(ssh.pwt[0]), std::end(ssh.pwt[0]), SetDefaultWeight);
+        std::for_each(std::begin(ssh.pwt[1]), std::end(ssh.pwt[1]), SetDefaultWeight);
+
+        MFX_CHECK(pExtPWT, MFX_ERR_NONE);
+
+        CopyLxPWT(0, std::min<mfxU16>(ssh.num_ref_idx_l0_active_minus1 + 1, caps.MaxNum_WeightedPredL0));
+        CopyLxPWT(1, std::min<mfxU16>(ssh.num_ref_idx_l1_active_minus1 + 1, caps.MaxNum_WeightedPredL1));
+        
+        bool bForceSameWeights =
+            task.isLDB
+            && std::equal(
+                std::begin(task.RefPicList[0])
+                , std::end(task.RefPicList[0])
+                , std::begin(task.RefPicList[1]));
+
+        MFX_CHECK(bForceSameWeights, MFX_ERR_NONE);
+
+        std::copy_n((mfxU8*)ssh.pwt[0], sizeof(ssh.pwt[0]), (mfxU8*)ssh.pwt[1]);
+
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_weighted_prediction.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g11/hevcehw_g11_weighted_prediction.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen11
+{
+    class WeightPred
+        : public FeatureBase
+    {
+    public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(CheckAndFix)\
+    DECL_BLOCK(SetDefaults)\
+    DECL_BLOCK(SetPPS)\
+    DECL_BLOCK(SetSSH)\
+    DECL_BLOCK(PatchDDITask)
+#define DECL_FEATURE_NAME "G11_WeightPred"
+#include "hevcehw_decl_blocks.h"
+
+        WeightPred(mfxU32 FeatureId)
+            : FeatureBase(FeatureId)
+        {}
+
+    protected:
+        virtual void SetSupported(ParamSupport& par) override;
+        virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+        virtual void SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push) override;
+        virtual void InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push) override;
+        virtual void PostReorderTask(const FeatureBlocks& blocks, TPushPostRT Push) override;
+    };
+} //Gen11
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g12_caps.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen12;
+
+void Caps::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_SetDefaultsCallChain,
+        [this](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+    {
+        auto& defaults = Glob::Defaults::GetOrConstruct(strg);
+        auto& bSet = defaults.SetForFeature[GetID()];
+        MFX_CHECK(!bSet, MFX_ERR_NONE);
+
+        defaults.GetMaxNumRef.Push([](
+            Gen11::Defaults::TChain<std::tuple<mfxU16, mfxU16>>::TExt
+            , const Gen11::Defaults::Param& dpar)
+        {
+            const mfxU16 nRef[3][2][7] =
+            {
+                {   // VME
+                    { 4, 4, 3, 3, 3, 1, 1 },
+                    { 2, 2, 1, 1, 1, 1, 1 }
+                },
+                {   // VDENC P
+                    { 3, 3, 2, 2, 2, 1, 1 },
+                    { 3, 3, 2, 2, 2, 1, 1 }
+                },
+                {   // Gen12 VDENC RA B
+                    { 2, 2, 1, 1, 1, 1, 1 },
+                    { 1, 1, 1, 1, 1, 1, 1 }
+                }
+            };
+            bool    bBFrames = (dpar.mvp.mfx.GopRefDist > 1);
+            bool    bVDEnc   = IsOn(dpar.mvp.mfx.LowPower);
+            mfxU16  tu       = dpar.mvp.mfx.TargetUsage;
+            mfxU32  idx      = bVDEnc * (1 + bBFrames);
+
+            CheckRangeOrSetDefault<mfxU16>(tu, 1, 7, 4);
+            --tu;
+
+            return std::make_tuple(
+                std::min<mfxU16>(nRef[idx][0][tu], dpar.caps.MaxNum_Reference0)
+                , std::min<mfxU16>(nRef[idx][1][tu], dpar.caps.MaxNum_Reference1));
+        });
+
+        bSet = true;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void Caps::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_HardcodeCaps
+        , [this](const mfxVideoParam&, mfxVideoParam& par, StorageRW& strg) -> mfxStatus
+    {
+        auto& caps = Glob::EncodeCaps::Get(strg);
+
+        caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && (par.mfx.TargetUsage == 7);
+        caps.msdk.bSingleSliceMultiTile = false;
+
+        caps.YUV422ReconSupport |= (!caps.Color420Only && IsOff(par.mfx.LowPower));
+
+        SetSpecificCaps(caps);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g12_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen12
+{
+class Caps
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(SetDefaultsCallChain)\
+    DECL_BLOCK(HardcodeCaps)
+#define DECL_FEATURE_NAME "G12_Caps"
+#include "hevcehw_decl_blocks.h"
+
+    Caps(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+protected:
+
+    virtual void Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+    virtual void Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override;
+
+    virtual void SetSpecificCaps(Gen11::EncodeCapsHevc& /*caps*/) {};
+};
+
+} //Gen12
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_data.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_data.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_g11_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen12
+{
+    using Gen11::Defaults;
+    using Gen11::FrameBaseInfo;
+    using Gen11::Task;
+
+    enum eFeatureId
+    {
+        FEATURE_REXT = Gen11::eFeatureId::NUM_FEATURES
+        , FEATURE_CAPS
+        , FEATURE_SAO
+        , FEATURE_QP_MODULATION
+        , NUM_FEATURES
+    };
+
+    struct Glob
+        : Gen11::Glob
+    {
+        static const StorageR::TKey _KD = __LINE__ + 1 - Gen11::Glob::NUM_KEYS;
+        static const StorageR::TKey ReservedKey12_0 = __LINE__ - _KD;
+        static const StorageR::TKey ReservedKey12_1 = __LINE__ - _KD;
+        static const StorageR::TKey NUM_KEYS = __LINE__ - _KD;
+    };
+
+
+} //namespace Gen12
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && (MFX_VERSION >= 1031)
+
+#include "hevcehw_g12_rext.h"
+#include "hevcehw_g11_legacy.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen12;
+
+const GUID RExt::DXVA2_Intel_Encode_HEVC_Main12 =
+{ 0xd6d6bc4f, 0xd51a, 0x4712,{ 0x97, 0xe8, 0x75, 0x9, 0x17, 0xc8, 0x60, 0xfd } };
+const GUID RExt::DXVA2_Intel_Encode_HEVC_Main422_12 =
+{ 0x7fef652d, 0x3233, 0x44df,{ 0xac, 0xf7, 0xec, 0xfb, 0x58, 0x4d, 0xab, 0x35 } };
+const GUID RExt::DXVA2_Intel_Encode_HEVC_Main444_12 =
+{ 0xf8fa34b7, 0x93f5, 0x45a4,{ 0xbf, 0xc0, 0x38, 0x17, 0xce, 0xe6, 0xbb, 0x93 } };
+
+void RExt::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
+{
+    Push(BLK_SetRecInfo
+        , [](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        MFX_CHECK(!local.Contains(Gen11::Tmp::RecInfo::Key), MFX_ERR_NONE);
+
+        auto& par = Gen11::Glob::VideoParam::Get(strg);
+        mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+
+        bool bG12SpecificRec =
+            CO3.TargetBitDepthLuma == 12
+            || (CO3.TargetBitDepthLuma == 10
+                && (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV420)
+                    || CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV422)));
+
+        MFX_CHECK(bG12SpecificRec, MFX_ERR_NONE);
+
+        const std::map<mfxU16, std::function<void(mfxFrameInfo&, mfxU16&)>> mUpdateRecInfo =
+        {
+            {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV444)
+                , [](mfxFrameInfo& rec, mfxU16& type)
+                {
+                    rec.FourCC = MFX_FOURCC_Y416;
+                    rec.Width  = mfx::align2_value<mfxU16>(rec.Width, 256 / 4);
+                    rec.Height = mfx::align2_value<mfxU16>(rec.Height * 3 / 2, 8);
+
+                    type = (
+                        MFX_MEMTYPE_FROM_ENCODE
+                        | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+                        | MFX_MEMTYPE_INTERNAL_FRAME);
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV422)
+                , [](mfxFrameInfo& rec, mfxU16& type)
+                {
+                    rec.FourCC = MFX_FOURCC_Y216;
+                    rec.Width /= 2;
+                    rec.Height *= 2;
+
+                    type = (
+                        MFX_MEMTYPE_FROM_ENCODE
+                        | MFX_MEMTYPE_DXVA2_DECODER_TARGET
+                        | MFX_MEMTYPE_INTERNAL_FRAME);
+                }
+            }
+            , {
+                mfxU16(1 + MFX_CHROMAFORMAT_YUV420)
+                , [](mfxFrameInfo& rec, mfxU16&)
+                {
+                    rec.FourCC = MFX_FOURCC_NV12;
+                    rec.Width = mfx::align2_value(rec.Width, 32) * 2;
+                }
+            }
+        };
+
+        MFX_CHECK(mUpdateRecInfo.count(CO3.TargetChromaFormatPlus1), MFX_ERR_NONE);
+
+        auto pRI = make_storable<mfxFrameAllocRequest>(mfxFrameAllocRequest{});
+        auto& rec = pRI->Info;
+
+        rec = par.mfx.FrameInfo;
+
+        mUpdateRecInfo.at(CO3.TargetChromaFormatPlus1)(rec, pRI->Type);
+        
+        rec.ChromaFormat   = CO3.TargetChromaFormatPlus1 - 1;
+        rec.BitDepthLuma   = CO3.TargetBitDepthLuma;
+        rec.BitDepthChroma = CO3.TargetBitDepthChroma;
+
+        local.Insert(Gen11::Tmp::RecInfo::Key, std::move(pRI));
+
+        return MFX_ERR_NONE;
+    });
+}
+
+mfxStatus RExt::SetGuid(mfxVideoParam& par, StorageRW& strg)
+{
+    auto& fi = par.mfx.FrameInfo;
+    const GUID* pGUID = nullptr;
+    const mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+    MFX_CHECK(fi.BitDepthLuma <= 12, MFX_ERR_NONE);
+    MFX_CHECK(fi.BitDepthChroma <= 12, MFX_ERR_NONE);
+    MFX_CHECK(!pCO3 || pCO3->TargetBitDepthLuma <= 12, MFX_ERR_NONE);
+    MFX_CHECK(!pCO3 || pCO3->TargetBitDepthChroma <= 12, MFX_ERR_NONE);
+    MFX_CHECK(!IsOn(par.mfx.LowPower), MFX_ERR_NONE);
+
+    SetIf(pGUID, fi.FourCC == MFX_FOURCC_P016, &DXVA2_Intel_Encode_HEVC_Main12);
+    SetIf(pGUID, fi.FourCC == MFX_FOURCC_Y216, &DXVA2_Intel_Encode_HEVC_Main422_12);
+    SetIf(pGUID, fi.FourCC == MFX_FOURCC_Y416, &DXVA2_Intel_Encode_HEVC_Main444_12);
+
+    MFX_CHECK(pGUID, MFX_ERR_NONE);
+
+    Gen11::Glob::GUID::GetOrConstruct(strg) = *pGUID;
+
+    return MFX_ERR_NONE;
+}
+
+void RExt::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_SetDefaultsCallChain
+        , [this](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+    {
+        auto& defaults = Glob::Defaults::GetOrConstruct(strg);
+        auto& bSet = defaults.SetForFeature[GetID()];
+        MFX_CHECK(!bSet, MFX_ERR_NONE);
+
+        defaults.CheckFourCC.Push(
+            [](Gen11::Defaults::TCheckAndFix::TExt prev
+                , const Gen11::Defaults::Param& dpar
+                , mfxVideoParam& par)
+        {
+            MFX_CHECK(IsRextFourCC(par.mfx.FrameInfo.FourCC), prev(dpar, par));
+            return MFX_ERR_NONE;
+        });
+
+        defaults.CheckInputFormatByFourCC.Push(
+            [](Gen11::Defaults::TCheckAndFix::TExt prev
+                , const Gen11::Defaults::Param& dpar
+                , mfxVideoParam& par)
+        {
+            MFX_CHECK(IsRextFourCC(par.mfx.FrameInfo.FourCC), prev(dpar, par));
+
+            auto&  fi      = par.mfx.FrameInfo; 
+            mfxU32 invalid = 0;
+
+            invalid += CheckOrZero<mfxU16, 12, 0>(fi.BitDepthLuma);
+            invalid += CheckOrZero<mfxU16, 12, 0>(fi.BitDepthChroma);
+            invalid += (fi.FourCC == MFX_FOURCC_P016) && CheckOrZero<mfxU16, MFX_CHROMAFORMAT_YUV420>(fi.ChromaFormat);
+            invalid += (fi.FourCC == MFX_FOURCC_Y216) && CheckOrZero<mfxU16, MFX_CHROMAFORMAT_YUV422>(fi.ChromaFormat);
+            invalid += (fi.FourCC == MFX_FOURCC_Y416) && CheckOrZero<mfxU16, MFX_CHROMAFORMAT_YUV444>(fi.ChromaFormat);
+
+            MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+            return MFX_ERR_NONE;
+        });
+
+        defaults.CheckTargetBitDepth.Push(
+            [](Gen11::Defaults::TCheckAndFix::TExt prev
+                , const Gen11::Defaults::Param& dpar
+                , mfxVideoParam& par)
+        {
+            mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+            MFX_CHECK(pCO3 && IsRextFourCC(par.mfx.FrameInfo.FourCC), prev(dpar, par));
+
+            mfxU32 invalid = 0;
+
+            invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthLuma);
+            invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthChroma);
+
+            MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+            return MFX_ERR_NONE;
+        });
+
+        defaults.CheckFourCCByTargetFormat.Push(
+            [](Gen11::Defaults::TCheckAndFix::TExt prev
+                , const Gen11::Defaults::Param& dpar
+                , mfxVideoParam& par)
+        {
+            MFX_CHECK(IsRextFourCC(par.mfx.FrameInfo.FourCC), prev(dpar, par));
+
+            auto   tcf = dpar.base.GetTargetChromaFormat(dpar);
+            auto&  fi = par.mfx.FrameInfo;
+            mfxU32 invalid = 0;
+
+            invalid +=
+                (tcf == MFX_CHROMAFORMAT_YUV444 + 1)
+                && Check<mfxU32, MFX_FOURCC_Y416>(fi.FourCC);
+
+            invalid +=
+                (tcf == MFX_CHROMAFORMAT_YUV422 + 1)
+                && Check<mfxU32, MFX_FOURCC_Y216, MFX_FOURCC_Y416>(fi.FourCC);
+
+            MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+            return MFX_ERR_NONE;
+        });
+
+        defaults.CheckProfile.Push(
+            [](Gen11::Defaults::TCheckAndFix::TExt prev
+                , const Gen11::Defaults::Param& dpar
+                , mfxVideoParam& par)
+        {
+            MFX_CHECK(IsRextFourCC(par.mfx.FrameInfo.FourCC), prev(dpar, par));
+
+            bool bInvalid = CheckOrZero<mfxU16, 0, MFX_PROFILE_HEVC_REXT>(par.mfx.CodecProfile);
+
+            MFX_CHECK(!bInvalid, MFX_ERR_UNSUPPORTED);
+            return MFX_ERR_NONE;
+        });
+
+        defaults.GetMaxChromaByFourCC.Push(
+            [](Gen11::Defaults::TChain<mfxU16>::TExt prev
+                , const Gen11::Defaults::Param& dpar)
+        {
+            MFX_CHECK(IsRextFourCC(dpar.mvp.mfx.FrameInfo.FourCC), prev(dpar));
+            auto fcc = dpar.mvp.mfx.FrameInfo.FourCC;
+            return mfxU16(
+                  (fcc == MFX_FOURCC_P016) * MFX_CHROMAFORMAT_YUV420
+                + (fcc == MFX_FOURCC_Y216) * MFX_CHROMAFORMAT_YUV422
+                + (fcc == MFX_FOURCC_Y416) * MFX_CHROMAFORMAT_YUV444);
+        });
+
+        defaults.GetMaxBitDepthByFourCC.Push(
+            [](Gen11::Defaults::TChain<mfxU16>::TExt prev
+                , const Gen11::Defaults::Param& dpar)
+        {
+            MFX_CHECK(IsRextFourCC(dpar.mvp.mfx.FrameInfo.FourCC), prev(dpar));
+            return mfxU16(12);
+        });
+
+        bSet = true;
+
+        return MFX_ERR_NONE;
+
+    });
+    Push(BLK_SetGUID
+        , [this](const mfxVideoParam&, mfxVideoParam& par, StorageRW& strg) -> mfxStatus
+    {
+        //don't change GUID in Reset
+        MFX_CHECK(!strg.Contains(Glob::RealState::Key), MFX_ERR_NONE);
+        return SetGuid(par, strg);
+    });
+}
+
+void RExt::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckShift
+        , [](const mfxVideoParam&, mfxVideoParam& out, StorageW&) -> mfxStatus
+    {
+        auto& fi = out.mfx.FrameInfo;
+        bool bVideoMem = Gen11::Legacy::IsInVideoMem(out, ExtBuffer::Get(out));
+
+        bool bNeedShift =
+            (bVideoMem && !fi.Shift)
+            && (   fi.FourCC == MFX_FOURCC_P016
+                || fi.FourCC == MFX_FOURCC_Y216
+                || fi.FourCC == MFX_FOURCC_Y416);
+
+        SetIf(fi.Shift, bNeedShift, 1);
+        MFX_CHECK(!bNeedShift, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_HardcodeCaps
+        , [](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+    {
+        Gen11::Glob::EncodeCaps::Get(strg).MaxEncodedBitDepth = 2;
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && (MFX_VERSION >= 1031)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g12_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen12
+{
+class RExt
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(SetRecInfo)\
+    DECL_BLOCK(SetGUID)\
+    DECL_BLOCK(HardcodeCaps)\
+    DECL_BLOCK(SetDefaultsCallChain)\
+    DECL_BLOCK(CheckShift)
+#define DECL_FEATURE_NAME "G12_RExt"
+#include "hevcehw_decl_blocks.h"
+
+    RExt(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+protected:
+    virtual void InitInternal(const FeatureBlocks& blocks, TPushII Push) override;
+    virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+
+    mfxStatus SetGuid(mfxVideoParam& par, StorageRW& strg);
+
+    static bool IsRextFourCC(mfxU32 FourCC)
+    {
+        return !Check<mfxU32
+            , MFX_FOURCC_P016
+            , MFX_FOURCC_Y216
+            , MFX_FOURCC_Y416>(FourCC);
+    }
+
+    static const GUID DXVA2_Intel_Encode_HEVC_Main12;
+    static const GUID DXVA2_Intel_Encode_HEVC_Main422_12;
+    static const GUID DXVA2_Intel_Encode_HEVC_Main444_12;
+};
+
+} //Gen12
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_sao.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_sao.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g12_data.h"
+
+namespace HEVCEHW
+{
+namespace Gen12
+{
+class SAO
+    : public FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST\
+    DECL_BLOCK(SetDefaultsCallChain)
+#define DECL_FEATURE_NAME "G12_SAO"
+#include "hevcehw_decl_blocks.h"
+
+    SAO(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+    {}
+
+protected:
+
+    virtual void Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push) override
+    {
+        Push(BLK_SetDefaultsCallChain,
+            [this](const mfxVideoParam&, mfxVideoParam&, StorageRW& strg) -> mfxStatus
+        {
+            auto& defaults = Glob::Defaults::GetOrConstruct(strg);
+            auto& bSet = defaults.SetForFeature[GetID()];
+            MFX_CHECK(!bSet, MFX_ERR_NONE);
+
+            defaults.CheckSAO.Push([](
+                Gen11::Defaults::TCheckAndFix::TExt
+                , const Gen11::Defaults::Param& defPar
+                , mfxVideoParam& par)
+            {
+                mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
+                MFX_CHECK(pHEVC, MFX_ERR_NONE);
+
+                mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
+
+                bool bNoSAO =
+                    (pCO3 && pCO3->WeightedPred == MFX_WEIGHTED_PRED_EXPLICIT)
+                    || (pCO3 && pCO3->WeightedBiPred == MFX_WEIGHTED_PRED_EXPLICIT)
+                    || defPar.base.GetLCUSize(defPar) == 16;
+
+                bool bChanged = CheckOrZero<mfxU16>(
+                    pHEVC->SampleAdaptiveOffset
+                    , mfxU16(MFX_SAO_UNKNOWN)
+                    , mfxU16(MFX_SAO_DISABLE)
+                    , mfxU16(!bNoSAO * MFX_SAO_ENABLE_LUMA)
+                    , mfxU16(!bNoSAO * MFX_SAO_ENABLE_CHROMA)
+                    , mfxU16(!bNoSAO * (MFX_SAO_ENABLE_LUMA | MFX_SAO_ENABLE_CHROMA)));
+
+                MFX_CHECK(!bChanged, MFX_ERR_UNSUPPORTED);
+                return MFX_ERR_NONE;
+            });
+
+            bSet = true;
+
+            return MFX_ERR_NONE;
+        });
+    }
+};
+
+} //Gen12
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_base.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_base.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_base.h"
+#include <thread>
+#include <sstream>
+
+#if defined(_DEBUG)
+    //#define HEVCE_LOG_FUNCTION_CALLS
+#endif
+
+namespace HEVCEHW
+{
+
+BlockTracer::BlockTracer(
+    ID id
+    , const char* fName
+    , const char* bName)
+    : ID(id)
+    , m_featureName(fName)
+    , m_blockName(bName)
+{
+#if defined(HEVCE_LOG_FUNCTION_CALLS)
+    std::stringstream thid;
+    thid << std::this_thread::get_id();
+    printf("HEVCEHW TH#%s: Enter %d::%d -> %s::%s\n"
+        , thid.str().c_str()
+        , FeatureID, BlockID, m_featureName, m_blockName);
+    fflush(stdout);
+#endif
+}
+
+BlockTracer::~BlockTracer()
+{
+#if defined(HEVCE_LOG_FUNCTION_CALLS)
+    std::stringstream thid;
+    thid << std::this_thread::get_id();
+    printf("HEVCEHW TH#%s: Exit  %d::%d -> %s::%s\n"
+        , thid.str().c_str()
+        , FeatureID, BlockID, m_featureName, m_blockName);
+    fflush(stdout);
+#endif
+}
+
+const char* FeatureBlocks::GetFeatureName(mfxU32 featureID)
+{
+#if defined(HEVCE_LOG_FUNCTION_CALLS)
+    return m_trace.at(featureID)->first.c_str();
+#else
+    std::ignore = featureID;
+    return nullptr;
+#endif
+}
+const char* FeatureBlocks::GetBlockName(ID id)
+{
+#if defined(HEVCE_LOG_FUNCTION_CALLS)
+    return m_trace.at(id.FeatureID)->second.at(id.BlockID).c_str();
+#else
+    std::ignore = id;
+    return nullptr;
+#endif
+}
+
+void FeatureBase::Init(
+    mfxU32 mode/*eFeatureMode*/
+    , FeatureBlocks& blocks)
+{
+    mfxU32 prevMode = blocks.Init(m_id, mode);
+
+    if (!prevMode)
+    {
+        SetSupported(blocks);
+
+        ThrowAssert(blocks.m_trace.find(m_id) != blocks.m_trace.end(), "FeatureID must be unique");
+
+        blocks.m_trace[m_id] = GetTrace();
+    }
+
+    mode &= ~prevMode;
+
+    bool   bNeedQ0  = !!(mode & QUERY0);
+    bool   bNeedQ1  = (mode & (QUERY1 | QUERY_IO_SURF | INIT)) && !(prevMode & (QUERY1 | QUERY_IO_SURF | INIT));
+    bool   bNeedQIS = !!(mode & QUERY_IO_SURF);
+    bool   bNeedIX  = !!(mode & INIT);
+    bool   bNeedSD  = bNeedQIS || bNeedIX;
+    bool   bNeedRT  = !!(mode & RUNTIME);
+    mfxU32 nQ = 0;
+
+    nQ += bNeedQ0  && InitQueue<Q0>(&FeatureBase::Query0, blocks);
+    nQ += bNeedQ1  && InitQueue<Q1NC>(&FeatureBase::Query1NoCaps, blocks);
+    nQ += bNeedQ1  && InitQueue<Q1WC>(&FeatureBase::Query1WithCaps, blocks);
+    nQ += bNeedQIS && InitQueue<QIS>(&FeatureBase::QueryIOSurf, blocks);
+    nQ += bNeedSD  && InitQueue<SD>(&FeatureBase::SetDefaults, blocks);
+
+    if (bNeedIX)
+    {
+        nQ += InitQueue<IE>(&FeatureBase::InitExternal, blocks);
+        nQ += InitQueue<II>(&FeatureBase::InitInternal, blocks);
+        nQ += InitQueue<IA>(&FeatureBase::InitAlloc, blocks);
+        nQ += InitQueue<AT>(&FeatureBase::AllocTask, blocks);
+    }
+
+    if (bNeedRT)
+    {
+        SetInherited(blocks);
+
+        nQ += InitQueue<R>(&FeatureBase::Reset, blocks);
+        nQ += InitQueue<RS>(&FeatureBase::ResetState, blocks);
+        nQ += InitQueue<FS>(&FeatureBase::FrameSubmit, blocks);
+        nQ += InitQueue<AR>(&FeatureBase::AsyncRoutine, blocks);
+        nQ += InitQueue<IT>(&FeatureBase::InitTask, blocks);
+        nQ += InitQueue<PreRT>(&FeatureBase::PreReorderTask, blocks);
+        nQ += InitQueue<PostRT>(&FeatureBase::PostReorderTask, blocks);
+        nQ += InitQueue<ST>(&FeatureBase::SubmitTask, blocks);
+        nQ += InitQueue<QT>(&FeatureBase::QueryTask, blocks);
+        nQ += InitQueue<FT>(&FeatureBase::FreeTask, blocks);
+        nQ += InitQueue<CLS>(&FeatureBase::Close, blocks);
+        nQ += InitQueue<GVP>(&FeatureBase::GetVideoParam, blocks);
+    }
+
+    assert(nQ > 0);
+}
+
+}; //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_base.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_base.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "feature_blocks/mfx_feature_blocks_init_macros.h"
+#include "feature_blocks/mfx_feature_blocks_base.h"
+#include "hevcehw_utils.h"
+#include "hevcehw_extbuf.h"
+#include "mfxvideo++int.h"
+
+namespace HEVCEHW
+{
+using namespace MfxFeatureBlocks;
+
+class BlockTracer
+    : public ID
+{
+public:
+    using TFeatureTrace = std::pair<std::string, const std::map<mfxU32, const std::string>>;
+
+    BlockTracer(
+        ID id
+        , const char* fName = nullptr
+        , const char* bName = nullptr);
+
+    ~BlockTracer();
+
+    const char* m_featureName;
+    const char* m_blockName;
+};
+
+struct FeatureBlocks
+    : FeatureBlocksCommon<BlockTracer>
+{
+MFX_FEATURE_BLOCKS_DECLARE_BQ_UTILS_IN_FEATURE_BLOCK
+#define DEF_BLOCK_Q MFX_FEATURE_BLOCKS_DECLARE_QUEUES_IN_FEATURE_BLOCK
+#include "hevcehw_block_queues.h"
+#undef DEF_BLOCK_Q
+
+    virtual const char* GetFeatureName(mfxU32 featureID) override;
+    virtual const char* GetBlockName(ID id) override;
+
+    std::map<mfxU32, const BlockTracer::TFeatureTrace*> m_trace;
+};
+
+#define DEF_BLOCK_Q MFX_FEATURE_BLOCKS_DECLARE_QUEUES_EXTERNAL
+    #include "hevcehw_block_queues.h"
+#undef DEF_BLOCK_Q
+
+class FeatureBase
+    : public FeatureBaseCommon<FeatureBlocks>
+{
+public:
+    FeatureBase();
+    virtual ~FeatureBase() {}
+
+    virtual void Init(
+        mfxU32 mode/*eFeatureMode*/
+        , FeatureBlocks& blocks) override;
+
+protected:
+#define DEF_BLOCK_Q MFX_FEATURE_BLOCKS_DECLARE_QUEUES_IN_FEATURE_BASE
+#include "hevcehw_block_queues.h"
+#undef DEF_BLOCK_Q
+    typedef TPushQ1NC TPushQ1;
+
+    FeatureBase(mfxU32 id)
+        : FeatureBaseCommon<FeatureBlocks>(id)
+    {}
+
+    virtual const BlockTracer::TFeatureTrace* GetTrace() { return nullptr; }
+    virtual void SetTraceName(std::string&& /*name*/) {}
+};
+
+class ImplBase
+    : virtual public VideoENCODE
+{
+public:
+    virtual mfxStatus InternalQuery(
+        VideoCORE& core
+        , mfxVideoParam *in
+        , mfxVideoParam& out) = 0;
+
+    virtual mfxStatus InternalQueryIOSurf(
+        VideoCORE& core
+        , mfxVideoParam& par
+        , mfxFrameAllocRequest& request) = 0;
+};
+
+}; //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_block_queues.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_block_queues.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+DEF_BLOCK_Q(Query0, Q0, void, mfxVideoParam&)
+DEF_BLOCK_Q(Query1NoCaps, Q1NC, mfxStatus, const mfxVideoParam&, mfxVideoParam&, StorageRW&)
+DEF_BLOCK_Q(Query1WithCaps, Q1WC, mfxStatus, const mfxVideoParam&, mfxVideoParam&, StorageRW&)
+DEF_BLOCK_Q(QueryIOSurf, QIS, mfxStatus, const mfxVideoParam&, mfxFrameAllocRequest& request, StorageRW&)
+DEF_BLOCK_Q(SetDefaults, SD, void, mfxVideoParam&, StorageW&, StorageRW&)
+DEF_BLOCK_Q(InitExternal, IE, mfxStatus, const mfxVideoParam&, StorageRW&, StorageRW&)
+DEF_BLOCK_Q(InitInternal, II, mfxStatus, StorageRW&, StorageRW&)
+DEF_BLOCK_Q(InitAlloc, IA, mfxStatus, StorageRW&, StorageRW&)
+DEF_BLOCK_Q(Reset, R, mfxStatus, const mfxVideoParam&, StorageRW&, StorageRW&)
+DEF_BLOCK_Q(ResetState, RS, mfxStatus, StorageRW&, StorageRW&)
+DEF_BLOCK_Q(FrameSubmit, FS, mfxStatus, mfxEncodeCtrl*, mfxFrameSurface1*, mfxBitstream&, StorageW&, StorageRW&)
+DEF_BLOCK_Q(AsyncRoutine, AR, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(AllocTask, AT, mfxStatus, StorageW&, StorageRW&)
+DEF_BLOCK_Q(InitTask, IT, mfxStatus, mfxEncodeCtrl*, mfxFrameSurface1*, mfxBitstream*, StorageW&, StorageW&)
+DEF_BLOCK_Q(PreReorderTask, PreRT, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(PostReorderTask, PostRT, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(SubmitTask, ST, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(QueryTask, QT, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(FreeTask, FT, mfxStatus, StorageW&, StorageW&)
+DEF_BLOCK_Q(Close, CLS, void, StorageW&)
+DEF_BLOCK_Q(GetVideoParam, GVP, void, mfxVideoParam&, StorageR&)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_ddi.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_ddi.h
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#if !defined(MFX_VA_LINUX)
+//TODO: move content here
+#include "hevce_ddi_main.h"
+#else
+namespace HEVCEHW
+{
+typedef struct tagENCODE_CAPS_HEVC
+{
+    union{
+        struct {
+            uint32_t CodingLimitSet          : 1;
+            uint32_t BitDepth8Only           : 1;
+            uint32_t Color420Only            : 1;
+            uint32_t SliceStructure          : 3;
+            uint32_t SliceIPOnly             : 1;
+            uint32_t SliceIPBOnly            : 1;
+            uint32_t NoWeightedPred          : 1;
+            uint32_t NoMinorMVs              : 1;
+            uint32_t RawReconRefToggle       : 1;
+            uint32_t NoInterlacedField       : 1;
+            uint32_t BRCReset                : 1;
+            uint32_t RollingIntraRefresh     : 1;
+            uint32_t UserMaxFrameSizeSupport : 1;
+            uint32_t FrameLevelRateCtrl      : 1;
+            uint32_t SliceByteSizeCtrl       : 1;
+            uint32_t VCMBitRateControl       : 1;
+            uint32_t ParallelBRC             : 1;
+            uint32_t TileSupport             : 1;
+            uint32_t SkipFrame               : 1;
+            uint32_t MbQpDataSupport         : 1;
+            uint32_t SliceLevelWeightedPred  : 1;
+            uint32_t LumaWeightedPred        : 1;
+            uint32_t ChromaWeightedPred      : 1;
+            uint32_t QVBRBRCSupport          : 1;
+            uint32_t HMEOffsetSupport        : 1;
+            uint32_t YUV422ReconSupport      : 1;
+            uint32_t YUV444ReconSupport      : 1;
+            uint32_t RGBReconSupport         : 1;
+            uint32_t MaxEncodedBitDepth      : 2;
+        };
+        uint32_t CodingLimits;
+    };
+
+    uint32_t MaxPicWidth;
+    uint32_t MaxPicHeight;
+    uint8_t  MaxNum_Reference0;
+    uint8_t  MaxNum_Reference1;
+    uint8_t  MBBRCSupport;
+    uint8_t  TUSupport;
+
+    union {
+        struct {
+            uint8_t MaxNumOfROI                : 5; // [0..16]    
+            uint8_t ROIBRCPriorityLevelSupport : 1;
+            uint8_t BlockSize                  : 2;
+        };
+        uint8_t ROICaps;
+    };
+
+    union {
+        struct {
+            uint32_t SliceLevelReportSupport         : 1;
+            uint32_t CTULevelReportSupport           : 1;
+            uint32_t SearchWindow64Support           : 1;
+            uint32_t CustomRoundingControl           : 1;
+            uint32_t LowDelayBRCSupport              : 1;
+            uint32_t IntraRefreshBlockUnitSize       : 2;
+            uint32_t LCUSizeSupported                : 3;
+            uint32_t MaxNumDeltaQPMinus1             : 4;
+            uint32_t DirtyRectSupport                : 1;
+            uint32_t MoveRectSupport                 : 1;
+            uint32_t FrameSizeToleranceSupport       : 1;
+            uint32_t HWCounterAutoIncrementSupport   : 2;
+            uint32_t ROIDeltaQPSupport               : 1;
+            uint32_t NumScalablePipesMinus1          : 5;
+            uint32_t NegativeQPSupport               : 1;
+            uint32_t HRDConformanceSupport           : 1;
+            uint32_t TileBasedEncodingSupport        : 1;
+            uint32_t PartialFrameUpdateSupport       : 1;
+            uint32_t RGBEncodingSupport              : 1;
+            uint32_t LLCStreamingBufferSupport       : 1;
+            uint32_t DDRStreamingBufferSupport       : 1;
+        };
+        uint32_t CodingLimits2;
+    };
+
+    uint8_t  MaxNum_WeightedPredL0;
+    uint8_t  MaxNum_WeightedPredL1;
+    uint16_t MaxNumOfDirtyRect;
+    uint16_t MaxNumOfMoveRect;
+    uint16_t MaxNumOfConcurrentFramesMinus1;
+    uint16_t LLCSizeInMBytes;
+
+    union {
+        struct {
+            uint16_t PFrameSupport            : 1;
+            uint16_t LookaheadAnalysisSupport : 1;
+            uint16_t LookaheadBRCSupport      : 1;
+            uint16_t reservedbits             : 13;
+        };
+        uint16_t	CodingLimits3;
+    };
+
+    uint32_t reserved32bits1;
+    uint32_t reserved32bits2;
+    uint32_t reserved32bits3;
+
+} ENCODE_CAPS_HEVC;
+}; //namespace HEVCEHW
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_decl_blocks.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_decl_blocks.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//use customized version w/trace support instead of default one
+#define DECL_BLOCK_CLEANUP_DISABLE
+#include "feature_blocks/mfx_feature_blocks_decl_blocks.h"
+
+#if defined(_DEBUG)
+BlockTracer::TFeatureTrace m_trace =
+{
+    DECL_FEATURE_NAME,
+    {
+    #define DECL_BLOCK(NAME) {BLK_##NAME, #NAME},
+        DECL_BLOCK_LIST
+    #undef DECL_BLOCK
+    }
+};
+
+virtual const BlockTracer::TFeatureTrace* GetTrace() override { return &m_trace; }
+virtual void SetTraceName(std::string&& name) override { m_trace.first = std::move(name); }
+#endif // defined(_DEBUG)
+
+#undef DECL_BLOCK_LIST
+#undef DECL_FEATURE_NAME
+#undef DECL_BLOCK_CLEANUP_DISABLE

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_extbuf.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_extbuf.h
@@ -1,0 +1,281 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "mfxvideo.h"
+#include "mfxla.h"
+#include "mfxbrc.h"
+#include "mfx_ext_buffers.h"
+
+#if !defined(MFX_VA_LINUX)
+#include "mfxpcp.h"
+#include "mfxwidi.h"
+#endif //!defined(MFX_VA_LINUX)
+
+#include "hevcehw_utils.h"
+
+#include <array>
+#include <memory>
+#include <map>
+#include <exception>
+#include <algorithm>
+
+namespace HEVCEHW
+{
+
+namespace ExtBuffer
+{
+    template<class T> struct IdMap {};
+    template<mfxU32 ID> struct TypeMap {};
+#define EXTBUF(TYPE, ID)\
+    template<> struct IdMap <TYPE> : std::integral_constant<mfxU32, ID> {};\
+    template<> struct TypeMap <ID> { using Type = TYPE; };
+
+    #include "../mediasdk_structures/ts_ext_buffers_decl.h"
+#undef EXTBUF
+
+    const mfxU32 IdSizePairs[][2] = {
+#define EXTBUF(TYPE, ID) {mfxU32(ID), mfxU32(sizeof(TYPE))},
+    #include "../mediasdk_structures/ts_ext_buffers_decl.h"
+#undef EXTBUF
+    };
+
+    inline mfxU32 IdToSize(mfxU32 Id)
+    {
+        auto IsIdEq = [Id](const mfxU32 (&p)[2]) { return p[0] == Id; };
+        auto pIt    = std::find_if(std::begin(IdSizePairs), std::end(IdSizePairs), IsIdEq);
+        if (pIt == std::end(IdSizePairs))
+            throw std::logic_error("unknown ext. buffer Id");
+        return pIt[0][1];
+    }
+
+    template<class T> void Init(T& buf)
+    {
+        buf = T{};
+        mfxExtBuffer& header = *((mfxExtBuffer*)&buf);
+        header.BufferId = IdMap<T>::value;
+        header.BufferSz = sizeof(T);
+    }
+
+    class ParamBase
+    {
+    public:
+        ParamBase() = default;
+
+        ParamBase(mfxExtBuffer** ExtParam, mfxU32 NumExtParam)
+        {
+            std::for_each(ExtParam, ExtParam + NumExtParam
+                , [&](mfxExtBuffer* p) { _ConstructEB(p); });
+        }
+
+        mfxExtBuffer* Get(mfxU32 id) const
+        {
+            auto it = m_eb.find(id);
+            return (it == m_eb.end()) ? nullptr : (mfxExtBuffer*)m_eb.at(id).get();
+        }
+
+    protected:
+        using TEBMap = std::map<mfxU32, std::unique_ptr<mfxU8[]>>;
+        using TEBIt  = TEBMap::iterator;
+
+        TEBMap m_eb;
+
+        std::pair<TEBIt, bool> _AllocEB(mfxU32 id, mfxU32 sz = 0, bool bReset = true)
+        {
+            auto it = m_eb.find(id);
+            mfxU8* p;
+
+            if (m_eb.end() == it)
+            {
+                if (!sz)
+                    sz = IdToSize(id);
+
+                p = new mfxU8[sz];
+
+                memset(p, 0, sz);
+                *(mfxExtBuffer*)p = { id, sz };
+
+                return m_eb.emplace(id, p);
+            }
+            else if (bReset)
+            {
+                p = it->second.get();
+                sz = ((mfxExtBuffer*)p)->BufferSz;
+                memset(p, 0, sz);
+                *(mfxExtBuffer*)p = { id, sz };
+            }
+
+            return std::make_pair(it, false);
+        }
+
+        std::pair<TEBIt, bool> _ConstructEB(const mfxExtBuffer* src)
+        {
+            if (src)
+            {
+                auto pair = _AllocEB(src->BufferId, src->BufferSz, false);
+                auto dst = pair.first->second.get();
+                if ((mfxU8*)src != dst)
+                    std::copy_n((mfxU8*)src, src->BufferSz, dst);
+                return pair;
+            }
+            return std::make_pair(m_eb.end(), false);
+        }
+
+    };
+
+    template<class T>
+    class Param
+        : public ParamBase
+        , public T
+    {
+    public:
+        Param()
+            : T({})
+        {
+            T::ExtParam = m_ExtParam.data();
+        }
+
+        Param(const T& par)
+            : ParamBase(par.ExtParam, par.NumExtParam)
+            , T(par)
+        {
+            T::NumExtParam = mfxU16(m_eb.size());
+            T::ExtParam = m_ExtParam.data();
+            auto GetEBPtr = [](TEBMap::reference ref) { return (mfxExtBuffer*)ref.second.get(); };
+            std::transform(m_eb.begin(), m_eb.end(), m_ExtParam.begin(), GetEBPtr);
+        }
+
+        mfxExtBuffer* NewEB(mfxU32 id, bool bReset = true)
+        {
+            auto res = _AllocEB(id, 0, bReset);
+            auto pEB = (mfxExtBuffer*)res.first->second.get();
+
+            if (res.second)
+                m_ExtParam.at(T::NumExtParam++) = pEB;
+
+            return pEB;
+        }
+    protected:
+        std::array<mfxExtBuffer*, 64> m_ExtParam;
+    };
+
+    class CastExtractor
+    {
+    private:
+        mfxExtBuffer**      m_b;
+        mfxU16              m_n;
+        const ParamBase*    m_p;
+
+        mfxExtBuffer* _Get(mfxU32 id) const
+        {
+            if (m_p)
+                return m_p->Get(id);
+
+            if (m_b)
+            {
+                auto pIt = std::find_if(m_b, m_b + m_n
+                    , [id](mfxExtBuffer* p) { return p && p->BufferId == id; });
+
+                if (pIt != (m_b + m_n))
+                    return *pIt;
+            }
+
+            return nullptr;
+        }
+
+    public:
+        CastExtractor(const ParamBase& par)
+            : m_b(nullptr)
+            , m_n(0)
+            , m_p(&par)
+        {}
+
+        CastExtractor(mfxExtBuffer ** b, mfxU16 n)
+            : m_b(b)
+            , m_n(n)
+            , m_p(nullptr)
+        {}
+
+        template <class T>
+        operator T*()
+        {
+            return (T*)_Get(IdMap<typename std::remove_cv<T>::type>::value);
+        }
+
+        template <class T>
+        operator const T*() const 
+        {
+            return (const T*)_Get(IdMap<typename std::remove_cv<T>::type>::value);
+        }
+
+        template <class T>
+        operator T&()
+        {
+            T* p = (T*)_Get(IdMap<typename std::remove_cv<T>::type>::value);
+            if (!p)
+                throw std::logic_error("ext. buffer expected to be always attached");
+            return *p;
+        }
+
+        template <class T>
+        operator const T&() const
+        {
+            const T* p = (const T*)_Get(IdMap<typename std::remove_cv<T>::type>::value);
+            if (!p)
+                throw std::logic_error("ext. buffer expected to be always attached");
+            return *p;
+        }
+    };
+
+    template <class P>
+    CastExtractor Get(P & par) { return CastExtractor(par.ExtParam, par.NumExtParam); }
+    template <class P>
+    const CastExtractor Get(const P & par) { return CastExtractor(par.ExtParam, par.NumExtParam); }
+
+    template <class P>
+    CastExtractor Get(Param<P>& par) { return CastExtractor(par); }
+    template <class P>
+    const CastExtractor Get(const Param<P>& par) { return CastExtractor(par); }
+
+    template <class P>
+    mfxExtBuffer* Get(P& par, mfxU32 BufferId)
+    {
+        if (par.ExtParam)
+        {
+            auto pIt = std::find_if(par.ExtParam, par.ExtParam + par.NumExtParam
+                , [BufferId](mfxExtBuffer* p) { return p && p->BufferId == BufferId; });
+
+            if (pIt != (par.ExtParam + par.NumExtParam))
+                return *pIt;
+        }
+
+        return nullptr;
+    }
+}; //namespace ExtBuffer
+
+}; //namespace HEVCEHW
+
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_utils.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/hevcehw_utils.h
@@ -1,0 +1,642 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "mfxvideo.h"
+#include <memory>
+#include <map>
+#include <list>
+#include <exception>
+#include <functional>
+#include <algorithm>
+#include <assert.h>
+#include "feature_blocks/mfx_feature_blocks_utils.h"
+
+namespace HEVCEHW
+{
+using namespace MfxFeatureBlocks;
+
+template <class T>
+class NotNull
+{
+public:
+typedef typename std::remove_reference<decltype(*T(nullptr))>::type TBase;
+    NotNull(T p = nullptr)
+        : m_ptr(p)
+    {
+    }
+
+    T get() const
+    {
+        if (!m_ptr)
+            throw std::logic_error("nullptr deref");
+        return m_ptr;
+    }
+    operator T() const
+    {
+        return get();
+    }
+    T operator->() const
+    {
+        return get();
+    }
+
+    TBase& operator*() const
+    {
+        return *get();
+    }
+
+private:
+    T m_ptr = nullptr;
+};
+
+template <class T>
+inline T& Deref(T* ptr)
+{
+    return *((NotNull<T*>(ptr)).get());
+}
+
+class OnExit
+    : public std::function<void()>
+{
+public:
+    OnExit(const OnExit&) = delete;
+
+    template<class... TArg>
+    OnExit(TArg&& ...arg)
+        : std::function<void()>(std::forward<TArg>(arg)...)
+    {}
+
+    ~OnExit()
+    {
+        if (operator bool())
+            operator()();
+    }
+
+    template<class... TArg>
+    OnExit& operator=(TArg&& ...arg)
+    {
+        std::function<void()> tmp(std::forward<TArg>(arg)...);
+        swap(tmp);
+        return *this;
+    }
+};
+
+inline void ThrowAssert(bool bThrow, const char* msg)
+{
+    if (bThrow)
+        throw std::logic_error(msg);
+}
+
+template <class T>
+constexpr std::size_t Size(const T& c) { return (std::size_t)c.size(); }
+
+template <class T, std::size_t N>
+constexpr std::size_t Size(const T(&)[N]) { return N; }
+
+template<typename T, size_t N>
+inline std::reverse_iterator<T*> RBegin(T (&arr)[N])
+{
+    return std::reverse_iterator<T*>(arr + N);
+}
+
+template<typename T>
+inline typename std::reverse_iterator<
+    typename std::conditional<
+        std::is_const<T>::value
+        , typename T::const_iterator
+        , typename T::iterator
+    >::type
+> RBegin(T& container)
+{
+    return container.rbegin();
+}
+
+template<typename T, size_t N>
+inline std::reverse_iterator<T*> REnd(T (&arr)[N])
+{
+    return std::reverse_iterator<T*>(arr);
+}
+
+template<typename T>
+inline typename std::reverse_iterator<
+    typename std::conditional<
+        std::is_const<T>::value
+        , typename T::const_iterator
+        , typename T::iterator
+    >::type
+> REnd(T& container)
+{
+    return container.rend();
+}
+
+template<class T>
+inline std::reverse_iterator<T> MakeRIter(T i)
+{
+    return std::reverse_iterator<T>(i);
+}
+
+template<class TIn, class TOut, class TPred>
+inline void MoveIf(TIn& src, TOut& dst, TPred pred)
+{
+    TIn newSrc;
+    std::partition_copy(
+        std::make_move_iterator(std::begin(src))
+        , std::make_move_iterator(std::end(src))
+        , std::back_inserter(dst)
+        , std::back_inserter(newSrc)
+        , pred);
+    src = std::move(newSrc);
+}
+
+template <class T>
+inline bool Check(const T&)
+{
+    return true;
+}
+
+template <class T, T val, T... other>
+inline bool Check(const T & opt)
+{
+    if (opt == val)
+        return false;
+    return Check<T, other...>(opt);
+}
+
+template <class T, T val>
+inline bool CheckGE(T opt)
+{
+    return !(opt >= val);
+}
+
+template <class T, class... U>
+inline bool Check(T & opt, T next, U... other)
+{
+    if (opt == next)
+        return false;
+    return Check(opt, other...);
+}
+
+template <class T>
+inline bool CheckOrZero(T& opt)
+{
+    opt = T(0);
+    return true;
+}
+
+template <class T, T val, T... other>
+inline bool CheckOrZero(T & opt)
+{
+    if (opt == val)
+        return false;
+    return CheckOrZero<T, other...>(opt);
+}
+
+template <class T, class... U>
+inline bool CheckOrZero(T & opt, T next, U... other)
+{
+    if (opt == next)
+        return false;
+    return CheckOrZero(opt, (T)other...);
+}
+
+template <class T, class U>
+inline bool CheckMaxOrZero(T & opt, U max)
+{
+    if (opt <= max)
+        return false;
+    opt = 0;
+    return true;
+}
+
+template <class T, class U>
+inline bool CheckMinOrZero(T & opt, U min)
+{
+    if (opt >= min)
+        return false;
+    opt = 0;
+    return true;
+}
+
+template <class T, class U>
+inline bool CheckMaxOrClip(T & opt, U max)
+{
+    if (opt <= max)
+        return false;
+    opt = T(max);
+    return true;
+}
+
+template <class T, class U>
+inline bool CheckMinOrClip(T & opt, U min)
+{
+    if (opt >= min)
+        return false;
+    opt = T(min);
+    return true;
+}
+
+template <class T>
+inline bool CheckRangeOrSetDefault(T & opt, T min, T max, T dflt)
+{
+    if (opt >= min && opt <= max)
+        return false;
+    opt = dflt;
+    return true;
+}
+
+inline bool CheckTriState(mfxU16 opt)
+{
+    return Check<mfxU16
+        , MFX_CODINGOPTION_UNKNOWN
+        , MFX_CODINGOPTION_ON
+        , MFX_CODINGOPTION_OFF>(opt);
+}
+
+inline bool CheckTriStateOrZero(mfxU16& opt)
+{
+    return CheckOrZero<mfxU16
+        , MFX_CODINGOPTION_UNKNOWN
+        , MFX_CODINGOPTION_ON
+        , MFX_CODINGOPTION_OFF>(opt);
+}
+
+template<class TVal, class TArg, typename std::enable_if<!std::is_constructible<TVal, TArg>::value, int>::type = 0>
+inline TVal GetOrCall(TArg val) { return val(); }
+
+template<class TVal, class TArg, typename = typename std::enable_if<std::is_constructible<TVal, TArg>::value>::type>
+inline TVal GetOrCall(TArg val) { return TVal(val); }
+
+template<typename T, typename TF>
+inline bool SetDefault(T& opt, TF get_dflt)
+{
+    if (opt)
+        return false;
+    opt = GetOrCall<T>(get_dflt);
+    return true;
+}
+
+template<typename T, typename TF>
+inline bool SetIf(T& opt, bool bSet, TF get)
+{
+    if (!bSet)
+        return false;
+    opt = GetOrCall<T>(get);
+    return true;
+}
+template<class T, class TF, class... TA>
+inline bool SetIf(T& opt, bool bSet, TF&& get, TA&&... arg)
+{
+    if (!bSet)
+        return false;
+    opt = get(std::forward<TA>(arg)...);
+    return true;
+}
+
+inline bool IsIdr(mfxU32 type)
+{
+    return !!(type & MFX_FRAMETYPE_IDR);
+}
+inline bool IsI(mfxU32 type)
+{
+    return !!(type & MFX_FRAMETYPE_I);
+}
+inline bool IsB(mfxU32 type)
+{
+    return !!(type & MFX_FRAMETYPE_B);
+}
+inline bool IsP(mfxU32 type)
+{
+    return !!(type & MFX_FRAMETYPE_P);
+}
+inline bool IsRef(mfxU32 type)
+{
+    return !!(type & MFX_FRAMETYPE_REF);
+}
+
+template<class T>
+inline bool AlignDown(T& value, mfxU32 alignment)
+{
+    assert((alignment & (alignment - 1)) == 0); // should be 2^n
+    if (!(value & (alignment - 1))) return false;
+    value = value & ~(alignment - 1);
+    return true;
+}
+
+template<class T>
+inline bool AlignUp(T& value, mfxU32 alignment)
+{
+    assert((alignment & (alignment - 1)) == 0); // should be 2^n
+    if (!(value & (alignment - 1))) return false;
+    value = (value + alignment - 1) & ~(alignment - 1);
+    return true;
+}
+
+template<typename T>
+inline mfxU32 CountTrailingZeroes(T x)
+{
+    mfxU32 l = 0;
+    if (!x)
+        return sizeof(x) * 8;
+    while (!((x >> l) & 1))
+        ++l;
+    return l;
+}
+inline mfxU32 CeilLog2(mfxU32 x) { mfxU32 l = 0; while (x > (1U << l)) l++; return l; }
+inline mfxU32 Ceil(mfxF64 x) { return (mfxU32)(.999 + x); }
+template<class T> inline T CeilDiv(T x, T y) { return (x + y - 1) / y; }
+
+template<class T, class Enable = void>
+struct DefaultFiller
+{
+    static constexpr typename std::remove_reference<T>::type Get()
+    {
+        return typename std::remove_reference<T>::type();
+    }
+};
+
+template<class T>
+struct DefaultFiller<T, typename std::enable_if<
+        std::is_arithmetic<
+            typename std::remove_reference<T>::type
+        >::value
+    >::type>
+{
+    static constexpr typename std::remove_reference<T>::type Get()
+    {
+        return typename std::remove_reference<T>::type(-1);
+    }
+};
+
+template<class A>
+inline void Remove(
+    A &_from
+    , size_t _where
+    , size_t _num = 1)
+{
+    if (std::end(_from) < std::begin(_from) + _where + _num)
+        throw std::out_of_range("Remove() target is out of array range");
+
+    auto it = std::copy(std::begin(_from) + _where + _num, std::end(_from), std::begin(_from) + _where);
+    std::fill(it, std::end(_from), DefaultFiller<decltype(*it)>::Get());
+}
+
+template<class T, class Pr>
+inline T RemoveIf(
+    T _begin
+    , T _end
+    , Pr _pr)
+{
+    _begin = std::remove_if(_begin, _end, _pr);
+    std::fill(_begin, _end, DefaultFiller<decltype(*_begin)>::Get());
+    return _begin;
+}
+
+template<class T, class A>
+inline void Insert(
+    A &_to
+    , size_t _where
+    , T const & _what)
+{
+    if (std::begin(_to) + _where + 1 >= std::end(_to))
+        throw std::out_of_range("Insert() target is out of array range");
+
+    std::copy_backward(std::begin(_to) + _where, std::end(_to) - 1, std::end(_to));
+    _to[_where] = _what;
+}
+
+template <class T>
+inline bool InheritOption(T optInit, T & optReset)
+{
+    if (optReset == 0)
+    {
+        optReset = optInit;
+        return true;
+    }
+    return false;
+}
+template<class TSrcIt, class TDstIt>
+TDstIt InheritOptions(TSrcIt initFirst, TSrcIt initLast, TDstIt resetFirst)
+{
+    while (initFirst != initLast)
+    {
+        InheritOption(*initFirst++, *resetFirst++);
+    }
+    return resetFirst;
+}
+
+inline void UpdateMultiplier(mfxInfoMFX& mfx, mfxU16 MN)
+{
+    auto& MO = mfx.BRCParamMultiplier;
+
+    SetDefault(MO, 1);
+
+    if (MO != MN)
+    {
+        mfx.BufferSizeInKB = (mfxU16)CeilDiv<mfxU32>(mfx.BufferSizeInKB * MO, MN);
+
+        if (   mfx.RateControlMethod == MFX_RATECONTROL_CBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_VBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_VCM
+            || mfx.RateControlMethod == MFX_RATECONTROL_QVBR
+            || mfx.RateControlMethod == MFX_RATECONTROL_LA_EXT)
+        {
+            mfx.TargetKbps = (mfxU16)CeilDiv<mfxU32>(mfx.TargetKbps * MO, MN);
+            mfx.InitialDelayInKB = (mfxU16)CeilDiv<mfxU32>(mfx.InitialDelayInKB * MO, MN);
+            mfx.MaxKbps = (mfxU16)CeilDiv<mfxU32>(mfx.MaxKbps * MO, MN);
+        }
+
+        MO = MN;
+    }
+}
+
+template<size_t offset>
+class BRCMultiplied
+{
+public:
+    BRCMultiplied(mfxInfoMFX& par)
+        : pMfx(&par)
+        , pcMfx(&par)
+    {}
+
+    BRCMultiplied(const mfxInfoMFX& par)
+        : pMfx(nullptr)
+        , pcMfx(&par)
+    {}
+
+    operator mfxU32 () const { return CV() * std::max<mfxU16>(1, pcMfx->BRCParamMultiplier); }
+
+    mfxU32 operator= (mfxU32 x)
+    {
+        if (pMfx)
+        {
+            mfxU16 MN = std::max<mfxU16>(1, pcMfx->BRCParamMultiplier);
+
+            while (CeilDiv<mfxU32>(x, MN) >= (1 << 16))
+                ++MN;
+
+            UpdateMultiplier(*pMfx, MN);
+            V() = (mfxU16)CeilDiv<mfxU32>(x, MN);
+        }
+        return *this;
+    }
+
+    BRCMultiplied& operator= (const BRCMultiplied& other)
+    {
+        *this = (mfxU32)other;
+        return *this;
+    }
+
+private:
+    mfxInfoMFX* pMfx;
+    const mfxInfoMFX* pcMfx;
+
+    inline mfxU16& V() { return *(mfxU16*)((mfxU8*)pMfx + offset); }
+    inline mfxU16 CV() const { return *(const mfxU16*)((const mfxU8*)pcMfx + offset); }
+};
+
+typedef BRCMultiplied<offsetof(mfxInfoMFX, InitialDelayInKB)> InitialDelayInKB;
+typedef BRCMultiplied<offsetof(mfxInfoMFX, BufferSizeInKB)> BufferSizeInKB;
+typedef BRCMultiplied<offsetof(mfxInfoMFX, TargetKbps)> TargetKbps;
+typedef BRCMultiplied<offsetof(mfxInfoMFX, MaxKbps)> MaxKbps;
+
+template<class T>
+class IterStepWrapper
+    : public std::iterator_traits<T>
+{
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using iterator_type     = IterStepWrapper;
+    using reference         = typename std::iterator_traits<T>::reference;
+    using pointer           = typename std::iterator_traits<T>::pointer;
+
+    IterStepWrapper(T ptr, ptrdiff_t step = 1)
+        : m_ptr(ptr)
+        , m_step(step)
+    { }
+
+    iterator_type& operator++()
+    {
+        std::advance(m_ptr, m_step);
+        return *this;
+    }
+
+    iterator_type operator++(int)
+    {
+        auto i = *this;
+        ++(*this);
+        return i;
+    }
+
+    reference operator*() { return *m_ptr; }
+    pointer operator->() { return m_ptr; }
+    bool operator==(const iterator_type& other)
+    {
+        return
+            m_ptr == other.m_ptr
+            || abs(std::distance(m_ptr, other.m_ptr)) < abs(m_step);
+    }
+    bool operator!=(const iterator_type& other)
+    {
+        return !((*this) == other);
+    }
+private:
+    T m_ptr;
+    ptrdiff_t m_step;
+};
+
+template <class T>
+inline IterStepWrapper<T> MakeStepIter(T ptr, ptrdiff_t step = 1)
+{
+    return IterStepWrapper<T>(ptr, step);
+}
+
+template<class T>
+inline bool Res2Bool(T& res2store, T res)
+{
+    res2store = res;
+    return !!res;
+}
+
+inline mfxU16 Bool2CO(bool bOptON)
+{
+    return mfxU16(MFX_CODINGOPTION_OFF - !!bOptON * MFX_CODINGOPTION_ON);
+}
+
+template <class F>
+struct ReturnType;
+
+template <typename TRes, typename... TArgs>
+struct ReturnType<TRes(*const)(TArgs...)>
+{
+    using type = TRes;
+};
+
+template <typename TRes, typename... TArgs>
+struct ReturnType<const std::function<TRes(TArgs...)>>
+{
+    using type = TRes;
+};
+
+template <typename TRes, typename... TArgs>
+inline std::tuple<TArgs...> TupleArgs(TRes(*)(TArgs...))
+{
+    return std::tuple<TArgs...>();
+}
+
+template<int ...>
+struct IntSeq
+{};
+
+template<int N, int ...S>
+struct MakeIntSeq
+    : MakeIntSeq<N - 1, N - 1, S...>
+{};
+
+template<int ...S>
+struct MakeIntSeq<0, S...>
+{
+    using type = IntSeq<S...>;
+};
+
+template<typename TFunc, typename TTuple, int ...S >
+inline typename ReturnType<typename std::remove_reference<TFunc>::type>::type
+    CallWithTupleArgs_(TFunc&& fn, TTuple&& t, IntSeq<S...>)
+{
+    return fn(std::get<S>(t) ...);
+}
+
+template<typename TFunc, typename TTuple>
+inline typename ReturnType<typename std::remove_reference<TFunc>::type>::type
+    CallWithTupleArgs(TFunc&& fn, TTuple&& t)
+{
+    return CallWithTupleArgs_(
+        std::forward<TFunc>(fn)
+        , std::forward<TTuple>(t)
+        , typename MakeIntSeq<std::tuple_size<typename std::remove_reference<TTuple>::type>::value>::type());
+}
+
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/hevcehw_disp.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/hevcehw_disp.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "hevcehw_disp.h"
+#include "hevcehw_base.h"
+#include "mfx_h265_encode_hw.h"
+
+namespace HEVCEHW
+{
+    namespace LegacyFallback
+    {
+        class MFXVideoENCODEH265_HW
+            : public MfxHwH265Encode::MFXVideoENCODEH265_HW
+            , public ImplBase
+        {
+        public:
+            MFXVideoENCODEH265_HW(
+                VideoCORE& core
+                , mfxStatus& status
+                , eFeatureMode)
+                : MfxHwH265Encode::MFXVideoENCODEH265_HW(&core, &status)
+            {
+            }
+            virtual mfxStatus InternalQuery(
+                VideoCORE& core
+                , mfxVideoParam *in
+                , mfxVideoParam& out) override
+            {
+                return MfxHwH265Encode::MFXVideoENCODEH265_HW::Query(&core, in, &out);
+            }
+            virtual mfxStatus InternalQueryIOSurf(
+                VideoCORE& core
+                , mfxVideoParam& par
+                , mfxFrameAllocRequest& request) override
+            {
+                return MfxHwH265Encode::MFXVideoENCODEH265_HW::QueryIOSurf(&core, &par, &request);
+            }
+        };
+    };
+};
+
+#if defined(MFX_ENABLE_HEVCEHW_REFACTORING_LIN_SKL) && defined(MFX_VA_LINUX)
+    #include "hevcehw_g11_lin.h"
+    namespace HEVCEHWDisp { namespace SKL { using namespace HEVCEHW::Linux::Gen11; }; };
+#else
+    namespace HEVCEHWDisp { namespace SKL { using namespace HEVCEHW::LegacyFallback; }; };
+#endif
+
+#if defined(MFX_ENABLE_HEVCEHW_REFACTORING_LIN_ICL) && defined(MFX_VA_LINUX)
+    #include "hevcehw_g11_lin.h"
+    namespace HEVCEHWDisp { namespace ICL { using namespace HEVCEHW::Linux::Gen11; }; };
+#else
+    namespace HEVCEHWDisp { namespace ICL { using namespace HEVCEHW::LegacyFallback; }; };
+#endif
+
+#if defined(MFX_ENABLE_HEVCEHW_REFACTORING_LIN_TGL) && defined(MFX_VA_LINUX)
+    #include "hevcehw_g12_lin.h"
+    namespace HEVCEHWDisp { namespace TGL { using namespace HEVCEHW::Linux::Gen12; }; };
+#else
+    namespace HEVCEHWDisp { namespace TGL { using namespace HEVCEHW::LegacyFallback; }; };
+#endif
+
+namespace HEVCEHW
+{
+
+static ImplBase* CreateSpecific(
+    eMFXHWType HW
+    , VideoCORE& core
+    , mfxStatus& status
+    , eFeatureMode mode)
+{
+    if (HW >= MFX_HW_TGL_LP)
+        return new HEVCEHWDisp::TGL::MFXVideoENCODEH265_HW(core, status, mode);
+    if (HW >= MFX_HW_ICL)
+        return new HEVCEHWDisp::ICL::MFXVideoENCODEH265_HW(core, status, mode);
+    return new HEVCEHWDisp::SKL::MFXVideoENCODEH265_HW(core, status, mode);
+}
+
+VideoENCODE* Create(
+    VideoCORE& core
+    , mfxStatus& status)
+{
+    auto hw = core.GetHWType();
+
+    if (hw < MFX_HW_SCL)
+    {
+        status = MFX_ERR_UNSUPPORTED;
+        return nullptr;
+    }
+
+    return CreateSpecific(hw, core, status, eFeatureMode::INIT);
+}
+
+mfxStatus QueryIOSurf(
+    VideoCORE *core
+    , mfxVideoParam *par
+    , mfxFrameAllocRequest *request)
+{
+    MFX_CHECK_NULL_PTR3(core, par, request);
+
+    auto hw = core->GetHWType();
+
+    if (hw < MFX_HW_SCL)
+        return MFX_ERR_UNSUPPORTED;
+
+    mfxStatus sts = MFX_ERR_NONE;
+    std::unique_ptr<ImplBase> impl(CreateSpecific(hw, *core, sts, eFeatureMode::QUERY_IO_SURF));
+
+    MFX_CHECK_STS(sts);
+    MFX_CHECK(impl, MFX_ERR_UNKNOWN);
+
+    return impl->InternalQueryIOSurf(*core, *par, *request);
+}
+
+mfxStatus Query(
+    VideoCORE *core
+    , mfxVideoParam *in
+    , mfxVideoParam *out)
+{
+    MFX_CHECK_NULL_PTR2(core, out);
+
+    auto hw = core->GetHWType();
+
+    if (hw < MFX_HW_SCL)
+        return MFX_ERR_UNSUPPORTED;
+
+    mfxStatus sts = MFX_ERR_NONE;
+    std::unique_ptr<ImplBase> impl(CreateSpecific(hw, *core, sts, in ? eFeatureMode::QUERY1 : eFeatureMode::QUERY0));
+
+    MFX_CHECK_STS(sts);
+    MFX_CHECK(impl, MFX_ERR_UNKNOWN);
+
+    return impl->InternalQuery(*core, in, *out);
+}
+
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/hevcehw_disp.h
+++ b/_studio/mfx_lib/encode_hw/hevc/hevcehw_disp.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE)
+
+#include "mfxvideo++int.h"
+
+namespace HEVCEHW
+{
+    VideoENCODE* Create(
+        VideoCORE& core
+        , mfxStatus& status);
+
+    mfxStatus QueryIOSurf(
+        VideoCORE *core
+        , mfxVideoParam *par
+        , mfxFrameAllocRequest *request);
+
+    mfxStatus Query(
+        VideoCORE *core
+        , mfxVideoParam *in
+        , mfxVideoParam *out);
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_encoded_frame_info_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_encoded_frame_info_lin.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_VA_LINUX)
+
+#include "hevcehw_g11_encoded_frame_info.h"
+#include "hevcehw_g11_va_packer_lin.h"
+#include "va/va.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+    class EncodedFrameInfo
+        : public HEVCEHW::Gen11::EncodedFrameInfo
+    {
+    public:
+
+        EncodedFrameInfo(mfxU32 FeatureId)
+            : HEVCEHW::Gen11::EncodedFrameInfo(FeatureId)
+        {}
+
+    protected:
+        virtual mfxStatus GetDdiInfo(
+            const void* pDdiFeedback
+            , mfxExtAVCEncodedFrameInfo& info) override
+        {
+            MFX_CHECK(pDdiFeedback, MFX_ERR_UNDEFINED_BEHAVIOR);
+            auto& fb = *(const VACodedBufferSegment*)pDdiFeedback;
+
+            info.QP = mfxU16(fb.status & VA_CODED_BUF_STATUS_PICTURE_AVE_QP_MASK);
+
+            return MFX_ERR_NONE;
+        }
+    };
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_fei_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_fei_lin.cpp
@@ -1,0 +1,396 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+#include "mfxfeihevc.h"
+#include "hevcehw_g11_fei_lin.h"
+#include "hevcehw_g11_va_lin.h"
+#include "hevcehw_g11_va_packer_lin.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+using namespace HEVCEHW::Linux;
+using namespace HEVCEHW::Linux::Gen11;
+
+void FEI::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_SetGuidMap
+        , [](const mfxVideoParam&, mfxVideoParam& /*out*/, StorageRW& strg) -> mfxStatus
+    {
+        auto& gmap = Glob::GuidToVa::GetOrConstruct(strg);
+        gmap[DXVA2_Intel_Encode_HEVC_Main]       = VAGUID{ VAProfileHEVCMain, VAEntrypointFEI };
+        gmap[DXVA2_Intel_Encode_HEVC_Main10]     = VAGUID{ VAProfileHEVCMain10, VAEntrypointFEI };
+#if VA_CHECK_VERSION(1,2,0)
+        gmap[DXVA2_Intel_Encode_HEVC_Main422]    = VAGUID{ VAProfileHEVCMain422_10, VAEntrypointFEI };
+        gmap[DXVA2_Intel_Encode_HEVC_Main422_10] = VAGUID{ VAProfileHEVCMain422_10, VAEntrypointFEI };
+        gmap[DXVA2_Intel_Encode_HEVC_Main444]    = VAGUID{ VAProfileHEVCMain444,    VAEntrypointFEI };
+        gmap[DXVA2_Intel_Encode_HEVC_Main444_10] = VAGUID{ VAProfileHEVCMain444_10, VAEntrypointFEI };
+#endif
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_SetVaCallChain
+        , [](const mfxVideoParam&, mfxVideoParam& /*out*/, StorageRW& strg) -> mfxStatus
+    {
+        auto& ddiExec = Glob::DDI_Execute::GetOrConstruct(strg);
+
+        ddiExec.Push([&](Glob::DDI_Execute::TRef::TExt prev, const DDIExecParam& ep)
+        {
+            MFX_CHECK(ep.Function == DDI_VA::VAFID_GetConfigAttributes, prev(ep));
+
+            using TArgs = decltype(TupleArgs(vaGetConfigAttributes));
+            ThrowAssert(!ep.In.pData || ep.In.Size != sizeof(TArgs), "Invalid arguments for VAFID_GetConfigAttributes");
+
+            TArgs& args         = *(TArgs*)ep.In.pData;
+            auto&  pAttr        = std::get<3>(args);
+            auto&  nAttr        = std::get<4>(args);
+            auto   pAttrInitial = pAttr;
+            auto   nAttrInitial = nAttr;
+
+            std::vector<VAConfigAttrib> vAttr(pAttr, pAttr + nAttr);
+            vAttr.emplace_back(VAConfigAttrib{ VAConfigAttribFEIFunctionType, 0 });
+
+            pAttr = vAttr.data();
+            ++nAttr;
+
+            auto sts = prev(ep);
+            MFX_CHECK_STS(sts);
+            MFX_CHECK(vAttr.back().value & VA_FEI_FUNCTION_ENC_PAK, MFX_ERR_DEVICE_FAILED);
+
+            std::copy_n(pAttr, nAttrInitial, pAttrInitial);
+
+            return sts;
+        });
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void FEI::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_CheckAndFix
+        , [](const mfxVideoParam&, mfxVideoParam& out, StorageW& /*strg*/) -> mfxStatus
+    {
+        mfxExtCodingOption3* pCO3 = ExtBuffer::Get(out);
+        MFX_CHECK(pCO3, MFX_ERR_NONE);
+
+        // HEVC FEI Encoder uses own controls to switch on LCU QP buffer
+        MFX_CHECK(!CheckOrZero(pCO3->EnableMBQP, mfxU16(MFX_CODINGOPTION_OFF), mfxU16(MFX_CODINGOPTION_UNKNOWN))
+            , MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void FEI::Reset(const FeatureBlocks& /*blocks*/, TPushR Push)
+{
+    Push(BLK_CancelTasks
+        , [](
+            const mfxVideoParam& /*par*/
+            , StorageRW& global
+            , StorageRW& /*local*/) -> mfxStatus
+    {
+        Glob::ResetHint::Get(global).Flags |= RF_CANCEL_TASKS;
+        return MFX_ERR_NONE;
+    });
+}
+
+void FEI::FrameSubmit(const FeatureBlocks& /*blocks*/, TPushFS Push)
+{
+    Push(BLK_FrameCheck
+        , [this](
+            const mfxEncodeCtrl* pCtrl
+            , const mfxFrameSurface1* pSurf
+            , mfxBitstream& /*bs*/
+            , StorageW& global
+            , StorageRW& /*local*/) -> mfxStatus
+    {
+
+        MFX_CHECK(pSurf, MFX_ERR_NONE);// In case of frames draining in display order
+        MFX_CHECK(pCtrl, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        eMFXHWType platform = Glob::VideoCore::Get(global).GetHWType();
+
+        bool isSKL = platform == MFX_HW_SCL
+            , isICLplus = platform >= MFX_HW_ICL;
+
+        // mfxExtFeiHevcEncFrameCtrl is a mandatory buffer
+        mfxExtFeiHevcEncFrameCtrl* EncFrameCtrl =
+            reinterpret_cast<mfxExtFeiHevcEncFrameCtrl*>(ExtBuffer::Get(*pCtrl, MFX_EXTBUFF_HEVCFEI_ENC_CTRL));
+        MFX_CHECK(EncFrameCtrl, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        // Check HW limitations for mfxExtFeiHevcEncFrameCtrl parameters
+        MFX_CHECK(EncFrameCtrl->NumMvPredictors[0] <= 4, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(EncFrameCtrl->NumMvPredictors[1] <= 4, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(EncFrameCtrl->MultiPred[0] <= (isICLplus + 1), MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(EncFrameCtrl->MultiPred[1] <= (isICLplus + 1), MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(EncFrameCtrl->SubPelMode <= 3 && EncFrameCtrl->SubPelMode != 2, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(EncFrameCtrl->MVPredictor == 0
+            || EncFrameCtrl->MVPredictor == 1
+            || EncFrameCtrl->MVPredictor == 2
+            || (EncFrameCtrl->MVPredictor == 3 && isICLplus)
+            || EncFrameCtrl->MVPredictor == 7, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(EncFrameCtrl->ForceCtuSplit <= mfxU16(isSKL), MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(EncFrameCtrl->FastIntraMode <= mfxU16(isSKL), MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(!Check<mfxU16>(EncFrameCtrl->NumFramePartitions, (mfxU16)1, (mfxU16)2, (mfxU16)4, (mfxU16)8, (mfxU16)16), MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(EncFrameCtrl->AdaptiveSearch <= 1, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        if (EncFrameCtrl->SearchWindow)
+        {
+            MFX_CHECK(EncFrameCtrl->LenSP == 0
+                && EncFrameCtrl->SearchPath == 0
+                && EncFrameCtrl->RefWidth == 0
+                && EncFrameCtrl->RefHeight == 0, MFX_ERR_INVALID_VIDEO_PARAM);
+
+            MFX_CHECK(EncFrameCtrl->SearchWindow <= 5, MFX_ERR_INVALID_VIDEO_PARAM);
+        }
+        else
+        {
+            MFX_CHECK(EncFrameCtrl->SearchPath <= 2, MFX_ERR_INVALID_VIDEO_PARAM);
+            MFX_CHECK(EncFrameCtrl->LenSP >= 1 && EncFrameCtrl->LenSP <= 63, MFX_ERR_INVALID_VIDEO_PARAM);
+            MFX_CHECK(!EncFrameCtrl->AdaptiveSearch || EncFrameCtrl->LenSP >= 2, MFX_ERR_INVALID_VIDEO_PARAM);
+
+            if (isSKL)
+            {
+                Defaults::Param ccpar(
+                        Glob::VideoParam::Get(global)
+                        , Glob::EncodeCaps::Get(global)
+                        , platform
+                        , Glob::Defaults::Get(global));
+                FrameBaseInfo fi;
+
+                auto sts = ccpar.base.GetPreReorderInfo(ccpar, fi, pSurf, pCtrl, m_lastIDR, m_prevIPoc, m_frameOrder);
+                MFX_CHECK_STS(sts);
+
+                SetIf(m_frameOrder, !!ccpar.mvp.mfx.EncodedOrder, pSurf->Data.FrameOrder);
+                SetIf(m_lastIDR, IsIdr(fi.FrameType), m_frameOrder);
+                SetIf(m_prevIPoc, IsI(fi.FrameType), fi.POC);
+
+                ++m_frameOrder;
+
+                MFX_CHECK(EncFrameCtrl->RefWidth % 4 == 0
+                    && EncFrameCtrl->RefHeight % 4 == 0
+                    && EncFrameCtrl->RefWidth  <= (32 * (2 - IsB(fi.FrameType)))
+                    && EncFrameCtrl->RefHeight <= (32 * (2 - IsB(fi.FrameType)))
+                    && EncFrameCtrl->RefWidth  >= 20
+                    && EncFrameCtrl->RefHeight >= 20
+                    && EncFrameCtrl->RefWidth * EncFrameCtrl->RefHeight <= 2048,
+                    // For B frames actual limit is RefWidth*RefHeight <= 1024.
+                    // Is is already guranteed by limit of 32 pxls for RefWidth and RefHeight in case of B frame
+                    MFX_ERR_INVALID_VIDEO_PARAM);
+            }
+            else
+            {
+                // ICL+
+                MFX_CHECK((EncFrameCtrl->RefWidth == 64 && EncFrameCtrl->RefHeight == 64)
+                    || (EncFrameCtrl->RefWidth == 48 && EncFrameCtrl->RefHeight == 40),
+                    MFX_ERR_INVALID_VIDEO_PARAM);
+            }
+        }
+
+        // Check if requested buffers are provided
+        MFX_CHECK(
+            !EncFrameCtrl->MVPredictor
+            || ExtBuffer::Get(*pCtrl, MFX_EXTBUFF_HEVCFEI_ENC_MV_PRED)
+            , MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(!EncFrameCtrl->PerCuQp
+            || ExtBuffer::Get(*pCtrl, MFX_EXTBUFF_HEVCFEI_ENC_QP)
+            , MFX_ERR_INVALID_VIDEO_PARAM);
+
+        MFX_CHECK(!EncFrameCtrl->PerCtuInput
+            || ExtBuffer::Get(*pCtrl, MFX_EXTBUFF_HEVCFEI_ENC_CTU_CTRL)
+            , MFX_ERR_INVALID_VIDEO_PARAM);
+
+        // Check for mfxExtFeiHevcRepackCtrl
+        mfxExtFeiHevcRepackCtrl* repackctrl =
+            reinterpret_cast<mfxExtFeiHevcRepackCtrl*>(ExtBuffer::Get(*pCtrl, MFX_EXTBUFF_HEVCFEI_REPACK_CTRL));
+
+        MFX_CHECK(!repackctrl || !EncFrameCtrl->PerCuQp, MFX_ERR_INVALID_VIDEO_PARAM);
+        MFX_CHECK(!repackctrl || repackctrl->NumPasses <= 8, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void FEI::PostReorderTask(const FeatureBlocks& /*blocks*/, TPushPostRT Push)
+{
+    Push(BLK_UpdatePPS
+        , [](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+        auto& pps  = Glob::PPS::Get(global);
+
+        mfxExtFeiHevcEncFrameCtrl* EncFrameCtrl =
+            reinterpret_cast<mfxExtFeiHevcEncFrameCtrl*>(ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_ENC_CTRL));
+        mfxExtFeiHevcRepackCtrl* repackctrl =
+            reinterpret_cast<mfxExtFeiHevcRepackCtrl*>(ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_REPACK_CTRL));
+
+        bool bRepackPPS = false;
+
+        // repackctrl or PerCuQp is disabled, so insert PPS and turn the flag off.
+        bRepackPPS |= pps.cu_qp_delta_enabled_flag && !repackctrl && !EncFrameCtrl->PerCuQp;
+
+        // repackctrl or PerCuQp is enabled, so insert PPS and turn the flag on.
+        bRepackPPS |= !pps.cu_qp_delta_enabled_flag && (repackctrl || EncFrameCtrl->PerCuQp);
+
+        MFX_CHECK(bRepackPPS, MFX_ERR_NONE);
+
+        pps.cu_qp_delta_enabled_flag = 1 - pps.cu_qp_delta_enabled_flag;
+
+        // If state of CTU QP buffer changes, PPS header update required
+        task.RepackHeaders |= INSERT_PPS;
+        task.InsertHeaders |= INSERT_PPS;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+template<class TEB, class TBase>
+inline mfxU32 GetVaBufferID(TBase* pBase, mfxU32 ID, bool bSearch = true)
+{
+    if (!pBase || !bSearch)
+        return VA_INVALID_ID;
+
+    auto pEB = reinterpret_cast<TEB*>(ExtBuffer::Get(*pBase, ID));
+    if (!pEB)
+        return VA_INVALID_ID;
+
+    return pEB->VaBufferID;
+}
+
+void FEI::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SetTaskVaParam
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        mfxExtFeiHevcEncFrameCtrl* EncFrameCtrl =
+            reinterpret_cast<mfxExtFeiHevcEncFrameCtrl*>(ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_ENC_CTRL));
+        MFX_CHECK(EncFrameCtrl, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        m_pVaFrameCtrl->function                           = VA_FEI_FUNCTION_ENC_PAK;
+        m_pVaFrameCtrl->search_path                        = EncFrameCtrl->SearchPath;
+        m_pVaFrameCtrl->len_sp                             = EncFrameCtrl->LenSP;
+        m_pVaFrameCtrl->ref_width                          = EncFrameCtrl->RefWidth;
+        m_pVaFrameCtrl->ref_height                         = EncFrameCtrl->RefHeight;
+        m_pVaFrameCtrl->search_window                      = EncFrameCtrl->SearchWindow;
+        m_pVaFrameCtrl->num_mv_predictors_l0               = mfxU16(!!EncFrameCtrl->MVPredictor * EncFrameCtrl->NumMvPredictors[0]);
+        m_pVaFrameCtrl->num_mv_predictors_l1               = mfxU16(!!EncFrameCtrl->MVPredictor * EncFrameCtrl->NumMvPredictors[1]);
+        m_pVaFrameCtrl->multi_pred_l0                      = EncFrameCtrl->MultiPred[0];
+        m_pVaFrameCtrl->multi_pred_l1                      = EncFrameCtrl->MultiPred[1];
+        m_pVaFrameCtrl->sub_pel_mode                       = EncFrameCtrl->SubPelMode;
+        m_pVaFrameCtrl->adaptive_search                    = EncFrameCtrl->AdaptiveSearch;
+        m_pVaFrameCtrl->mv_predictor_input                 = EncFrameCtrl->MVPredictor;
+        m_pVaFrameCtrl->per_block_qp                       = EncFrameCtrl->PerCuQp;
+        m_pVaFrameCtrl->per_ctb_input                      = EncFrameCtrl->PerCtuInput;
+        m_pVaFrameCtrl->force_lcu_split                    = EncFrameCtrl->ForceCtuSplit;
+        m_pVaFrameCtrl->num_concurrent_enc_frame_partition = EncFrameCtrl->NumFramePartitions;
+        m_pVaFrameCtrl->fast_intra_mode                    = EncFrameCtrl->FastIntraMode;
+
+        // Input buffers
+        m_pVaFrameCtrl->mv_predictor =
+            GetVaBufferID<mfxExtFeiHevcEncMVPredictors>(&task.ctrl, MFX_EXTBUFF_HEVCFEI_ENC_MV_PRED, !!EncFrameCtrl->MVPredictor);
+        m_pVaFrameCtrl->qp =
+            GetVaBufferID<mfxExtFeiHevcEncQP>(&task.ctrl, MFX_EXTBUFF_HEVCFEI_ENC_QP, !!EncFrameCtrl->PerCuQp);
+        m_pVaFrameCtrl->ctb_ctrl =
+            GetVaBufferID<mfxExtFeiHevcEncCtuCtrl>(&task.ctrl, MFX_EXTBUFF_HEVCFEI_ENC_QP, !!EncFrameCtrl->PerCtuInput);
+
+        auto* repackctrl = reinterpret_cast<mfxExtFeiHevcRepackCtrl*>(ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_REPACK_CTRL));
+        if (repackctrl)
+        {
+            m_pVaFrameCtrl->max_frame_size  = repackctrl->MaxFrameSize;
+            m_pVaFrameCtrl->num_passes      = repackctrl->NumPasses;
+            m_pVaFrameCtrl->delta_qp        = repackctrl->DeltaQP;
+        }
+
+        // Output buffers
+#if MFX_VERSION >= MFX_VERSION_NEXT
+        m_pVaFrameCtrl->ctb_cmd    = GetVaBufferID<mfxExtFeiHevcPakCtuRecordV0>(task.pBsOut, MFX_EXTBUFF_HEVCFEI_PAK_CTU_REC);
+        m_pVaFrameCtrl->cu_record  = GetVaBufferID<mfxExtFeiHevcPakCuRecordV0>(task.pBsOut, MFX_EXTBUFF_HEVCFEI_PAK_CU_REC);
+        m_pVaFrameCtrl->distortion = GetVaBufferID<mfxExtFeiHevcDistortion>(task.pBsOut, MFX_EXTBUFF_HEVCFEI_ENC_DIST);
+#else
+        m_pVaFrameCtrl->ctb_cmd    = VA_INVALID_ID;
+        m_pVaFrameCtrl->cu_record  = VA_INVALID_ID;
+        m_pVaFrameCtrl->distortion = VA_INVALID_ID;
+#endif
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void FEI::InitAlloc(const FeatureBlocks& blocks, TPushIA Push)
+{
+    Push(BLK_SetFeedbackCallChain
+        , [this](StorageRW& strg, StorageRW& /*local*/) -> mfxStatus
+    {
+        auto& cc = VAPacker::CC::Get(strg);
+
+        cc.ReadFeedback.Push([](
+            VAPacker::CallChains::TReadFeedback::TExt prev
+            , const StorageR& global
+            , StorageW& s_task
+            , const VACodedBufferSegment& fb)
+        {
+            auto& task = Task::Common::Get(s_task);
+
+            mfxExtFeiHevcRepackStat *repackStat = reinterpret_cast<mfxExtFeiHevcRepackStat *>
+                (ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_REPACK_STAT));
+
+            if (repackStat)
+            {
+                repackStat->NumPasses = 0;
+
+                mfxExtFeiHevcRepackCtrl* repackctrl = reinterpret_cast<mfxExtFeiHevcRepackCtrl*>
+                    (ExtBuffer::Get(task.ctrl, MFX_EXTBUFF_HEVCFEI_REPACK_CTRL));
+
+                if (repackctrl)
+                {
+                    mfxU8 QP         = fb.status & VA_CODED_BUF_STATUS_PICTURE_AVE_QP_MASK;
+                    mfxU8 QPOption   = task.QpY;
+                    mfxU32 numPasses = 0;
+
+                    while ((QPOption != QP) && (numPasses < repackctrl->NumPasses))
+                        QPOption += repackctrl->DeltaQP[numPasses++];
+
+                    if (QPOption == QP)
+                        repackStat->NumPasses = numPasses + 1;
+                }
+            }
+
+            return prev(global, s_task, fb);
+        });
+
+        m_pVaFrameCtrl = &AddVaMisc<VAEncMiscParameterFEIFrameControlHEVC>(
+            VAEncMiscParameterTypeFEIFrameControl, m_vaMiscData);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_fei_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_fei_lin.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_iddi_packer.h"
+#include "va/va.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+using namespace HEVCEHW::Gen11;
+
+class FEI
+    : public virtual FeatureBase
+{
+public:
+#define DECL_BLOCK_LIST \
+    DECL_BLOCK(CheckAndFix) \
+    DECL_BLOCK(SetGuidMap) \
+    DECL_BLOCK(SetVaCallChain) \
+    DECL_BLOCK(FrameCheck) \
+    DECL_BLOCK(UpdatePPS) \
+    DECL_BLOCK(SetTaskVaParam) \
+    DECL_BLOCK(SetFeedbackCallChain) \
+    DECL_BLOCK(CancelTasks)
+#define DECL_FEATURE_NAME "G11FEI_FEI"
+#include "hevcehw_decl_blocks.h"
+
+    FEI(mfxU32 FeatureId) : FeatureBase(FeatureId) {}
+
+protected:
+    virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void Reset(const FeatureBlocks& blocks, TPushR Push) override;
+    virtual void FrameSubmit(const FeatureBlocks& blocks, TPushFS Push) override;
+    virtual void PostReorderTask(const FeatureBlocks& blocks, TPushPostRT Push) override;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+
+    mfxU32 m_lastIDR     = 0;
+    mfxI32 m_prevIPoc    = 0;
+    mfxU32 m_frameOrder  = 0;
+    std::list<std::vector<mfxU8>>           m_vaMiscData;
+    VAEncMiscParameterFEIFrameControlHEVC*  m_pVaFrameCtrl = nullptr;
+};
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_interlace_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_interlace_lin.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_VA_LINUX)
+
+#include "hevcehw_g11_interlace_lin.h"
+#include "hevcehw_g11_va_packer_lin.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Linux::Gen11::Interlace::SubmitTask(const FeatureBlocks& blocks, TPushST Push)
+{
+    HEVCEHW::Gen11::Interlace::SubmitTask(blocks, Push);
+
+    Push(BLK_PatchDDITask
+        , [](StorageW& global, StorageW& /*s_task*/) -> mfxStatus
+    {
+        auto& par = Glob::VideoParam::Get(global);
+        MFX_CHECK(IsField(par.mfx.FrameInfo.PicStruct), MFX_ERR_NONE);
+        
+        auto& ddiPar = Glob::DDI_SubmitParam::Get(global);
+        auto it = std::find_if(std::begin(ddiPar), std::end(ddiPar)
+            , [](DDIExecParam& ep) { return (ep.Function == VAEncSequenceParameterBufferType); });
+        MFX_CHECK(it != std::end(ddiPar) && it->In.pData, MFX_ERR_NONE);
+
+        auto& sps = *(VAEncSequenceParameterBufferHEVC*)it->In.pData;
+        sps.intra_period     = par.mfx.GopPicSize * 2;
+        sps.intra_idr_period = par.mfx.GopPicSize * par.mfx.IdrInterval * 2;
+        sps.ip_period        = mfxU8(par.mfx.GopRefDist * 2);
+        return MFX_ERR_NONE;
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_interlace_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_interlace_lin.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_VA_LINUX)
+
+#include "hevcehw_g11_interlace.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+    class Interlace
+        : public HEVCEHW::Gen11::Interlace
+    {
+    public:
+        Interlace(mfxU32 FeatureId)
+            : HEVCEHW::Gen11::Interlace(FeatureId)
+        {}
+
+    protected:
+        virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
+    };
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_lin.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11_lin.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_legacy.h"
+#include "hevcehw_g11_parser.h"
+#include "hevcehw_g11_packer.h"
+#include "hevcehw_g11_hrd.h"
+#include "hevcehw_g11_alloc.h"
+#include "hevcehw_g11_task.h"
+#include "hevcehw_g11_ext_brc.h"
+#include "hevcehw_g11_dirty_rect.h"
+#if !defined(MFX_EXT_DPB_HEVC_DISABLE) && (MFX_VERSION >= MFX_VERSION_NEXT)
+#include "hevcehw_g11_dpb_report.h"
+#endif
+#include "hevcehw_g11_hdr_sei.h"
+#include "hevcehw_g11_va_lin.h"
+#include "hevcehw_g11_va_packer_lin.h"
+#include "hevcehw_g11_interlace_lin.h"
+#include "hevcehw_g11_encoded_frame_info_lin.h"
+#if defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+#include "hevcehw_g11_weighted_prediction_lin.h"
+#endif
+#if defined(MFX_ENABLE_HEVCE_ROI)
+#include "hevcehw_g11_roi_lin.h"
+#endif
+#include "hevcehw_g11_max_frame_size.h"
+#include <algorithm>
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+Linux::Gen11::MFXVideoENCODEH265_HW::MFXVideoENCODEH265_HW(
+    VideoCORE& core
+    , mfxStatus& status
+    , eFeatureMode mode)
+    : HEVCEHW::Gen11::MFXVideoENCODEH265_HW(core)
+{
+    status = MFX_ERR_UNKNOWN;
+    auto vaType = core.GetVAType();
+
+    m_features.emplace_back(new Parser(FEATURE_PARSER));
+    m_features.emplace_back(new Allocator(FEATURE_ALLOCATOR));
+
+    if (vaType == MFX_HW_VAAPI)
+    {
+        m_features.emplace_back(new DDI_VA(FEATURE_DDI));
+    }
+    else
+    {
+        status = MFX_ERR_UNSUPPORTED;
+        return;
+    }
+
+    m_features.emplace_back(new VAPacker(FEATURE_DDI_PACKER));
+    m_features.emplace_back(new Legacy(FEATURE_LEGACY));
+    m_features.emplace_back(new HRD(FEATURE_HRD));
+    m_features.emplace_back(new TaskManager(FEATURE_TASK_MANAGER));
+    m_features.emplace_back(new Packer(FEATURE_PACKER));
+    m_features.emplace_back(new ExtBRC(FEATURE_EXT_BRC));
+    m_features.emplace_back(new DirtyRect(FEATURE_DIRTY_RECT));
+#if !defined(MFX_EXT_DPB_HEVC_DISABLE) && (MFX_VERSION >= MFX_VERSION_NEXT)
+    m_features.emplace_back(new DPBReport(FEATURE_DPB_REPORT));
+#endif
+    m_features.emplace_back(new HdrSei(FEATURE_HDR_SEI));
+    m_features.emplace_back(new Interlace(FEATURE_INTERLACE));
+    m_features.emplace_back(new EncodedFrameInfo(FEATURE_ENCODED_FRAME_INFO));
+#if defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+    m_features.emplace_back(new WeightPred(FEATURE_WEIGHTPRED));
+#endif //defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
+#if defined(MFX_ENABLE_HEVCE_ROI)
+    m_features.emplace_back(new ROI(FEATURE_ROI));
+#endif
+    m_features.emplace_back(new MaxFrameSize(FEATURE_MAX_FRAME_SIZE));
+
+    InternalInitFeatures(status, mode);
+
+#if defined(MFX_ENABLE_HEVCE_ROI)
+    if (mode & INIT)
+    {
+        auto& qIA = BQ<BQ_InitAlloc>::Get(*this);
+        qIA.splice(qIA.end(), qIA, Get(qIA, { FEATURE_ROI, ROI::BLK_SetCallChains }));
+    }
+#endif
+}
+
+mfxStatus Linux::Gen11::MFXVideoENCODEH265_HW::Init(mfxVideoParam *par)
+{
+    mfxStatus sts = HEVCEHW::Gen11::MFXVideoENCODEH265_HW::Init(par);
+    MFX_CHECK(sts >= MFX_ERR_NONE, sts);
+
+    return sts;
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_lin.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+    class MFXVideoENCODEH265_HW
+        : public HEVCEHW::Gen11::MFXVideoENCODEH265_HW
+    {
+    public:
+        MFXVideoENCODEH265_HW(
+            VideoCORE& core
+            , mfxStatus& status
+            , eFeatureMode mode = eFeatureMode::INIT);
+
+        virtual mfxStatus Init(mfxVideoParam *par) override;
+    };
+
+} //Gen11
+} //Linux
+}// namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_roi_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_roi_lin.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_ROI) && defined(MFX_VA_LINUX)
+
+#include "hevcehw_g11_roi_lin.h"
+#include "hevcehw_g11_va_packer_lin.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Linux::Gen11::ROI::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_SetCallChains
+        , [this](StorageRW& global, StorageRW& local) -> mfxStatus
+    {
+        auto& vaPacker = VAPacker::CC::Get(global);
+
+        if (m_bViaCuQp)
+        {
+            vaPacker.FillCUQPData.Push([](
+                VAPacker::CallChains::TFillCUQPData::TExt prev
+                , const StorageR& global
+                , const StorageR& s_task
+                , CUQPMap& qpMap)
+            {
+                bool  bRes = prev(global, s_task, qpMap);
+                auto& task = Task::Common::Get(s_task);
+                auto& roi = GetRTExtBuffer<mfxExtEncoderROI>(global, s_task);
+
+                bool bFillQPMap =
+                    !bRes
+                    && roi.NumROI
+                    && qpMap.m_width
+                    && qpMap.m_height
+                    && qpMap.m_block_width
+                    && qpMap.m_block_height;
+
+                if (bFillQPMap)
+                {
+                    mfxI32 dQPMult = 1 - 2 * (roi.ROIMode == MFX_ROI_MODE_PRIORITY);
+                    mfxU32 x = 0, y = 0;
+                    auto IsXYInRect = [&](const RectData& r)
+                    {
+                        return (x * qpMap.m_block_width) >= r.Left
+                            && (x * qpMap.m_block_width) < r.Right
+                            && (y * qpMap.m_block_height) >= r.Top
+                            && (y * qpMap.m_block_height) < r.Bottom;
+                    };
+                    auto NextQP = [&]()
+                    {
+                        auto pEnd = roi.ROI + roi.NumROI;
+                        auto pRect = std::find_if(roi.ROI, pEnd, IsXYInRect);
+
+                        ++x;
+
+                        if (pRect != pEnd)
+                            return mfxI8(task.QpY + dQPMult * pRect->DeltaQP);
+
+                        return mfxI8(task.QpY);
+                    };
+                    auto FillQpMapRow = [&](mfxI8& qpMapRow)
+                    {
+                        x = 0;
+                        std::generate_n(&qpMapRow, qpMap.m_width, NextQP);
+                        ++y;
+                    };
+                    auto itQpMapRowsBegin = MakeStepIter(qpMap.m_buffer.data(), qpMap.m_pitch);
+                    auto itQpMapRowsEnd = MakeStepIter(qpMap.m_buffer.data() + qpMap.m_height * qpMap.m_pitch);
+
+                    std::for_each(itQpMapRowsBegin, itQpMapRowsEnd, FillQpMapRow);
+
+                    bRes = true;
+                }
+
+                return bRes;
+            });
+        }
+        else
+        {
+            vaPacker.AddPerPicMiscData[VAEncMiscParameterTypeROI].Push([this](
+                VAPacker::CallChains::TAddMiscData::TExt
+                , const StorageR& global
+                , const StorageR& s_task
+                , std::list<std::vector<mfxU8>>& data)
+            {
+                auto& roi = GetRTExtBuffer<mfxExtEncoderROI>(global, s_task);
+                bool bNeedROI = !!roi.NumROI;
+
+                if (bNeedROI)
+                {
+                    auto& vaROI = AddVaMisc<VAEncMiscParameterBufferROI>(VAEncMiscParameterTypeROI, data);
+
+                    mfxI32 dQPMult      = 1 - 2 * (roi.ROIMode == MFX_ROI_MODE_PRIORITY);
+                    auto   MakeVAEncROI = [dQPMult](const RectData& rect)
+                    {
+                        VAEncROI roi = {};
+                        roi.roi_rectangle.x      = rect.Left;
+                        roi.roi_rectangle.y      = rect.Top;
+                        roi.roi_rectangle.width  = rect.Right - rect.Left;
+                        roi.roi_rectangle.height = rect.Bottom - rect.Top;
+                        roi.roi_value            = int8_t(dQPMult * rect.DeltaQP);
+                        return roi;
+                    };
+
+                    m_vaROI.resize(roi.NumROI);
+
+                    vaROI.num_roi = roi.NumROI;
+                    vaROI.roi     = m_vaROI.data();
+
+                    std::transform(roi.ROI, roi.ROI + roi.NumROI, vaROI.roi, MakeVAEncROI);
+
+                    vaROI.max_delta_qp = 51;
+                    vaROI.min_delta_qp = -51;
+                    vaROI.roi_flags.bits.roi_value_is_qp_delta = 1;
+                }
+
+                return bNeedROI;
+            });
+        }
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_roi_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_roi_lin.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_ROI) && defined(MFX_VA_LINUX)
+
+#include "hevcehw_g11_roi.h"
+#include "va/va.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+class ROI
+    : public HEVCEHW::Gen11::ROI
+{
+public:
+
+    ROI(mfxU32 FeatureId)
+        : HEVCEHW::Gen11::ROI(FeatureId)
+    {}
+
+protected:
+    virtual void InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push) override;
+
+    std::vector<VAEncROI> m_vaROI;
+};
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_lin.cpp
@@ -1,0 +1,715 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#include "hevcehw_g11_va_lin.h"
+
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11_legacy.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+using namespace HEVCEHW::Linux;
+using namespace HEVCEHW::Linux::Gen11;
+
+static const Glob::GuidToVa::TRef DefaultGuidToVa =
+{
+    { DXVA2_Intel_Encode_HEVC_Main,                 VAGUID{VAProfileHEVCMain,       VAEntrypointEncSlice}}
+    , { DXVA2_Intel_Encode_HEVC_Main10,             VAGUID{VAProfileHEVCMain10,     VAEntrypointEncSlice}}
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main,       VAGUID{VAProfileHEVCMain,       VAEntrypointEncSliceLP}}
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main10,     VAGUID{VAProfileHEVCMain10,     VAEntrypointEncSliceLP}}
+    , { DXVA2_Intel_Encode_HEVC_Main422,            VAGUID{VAProfileHEVCMain422_10, VAEntrypointEncSlice}} // Unsupported by VA
+    , { DXVA2_Intel_Encode_HEVC_Main422_10,         VAGUID{VAProfileHEVCMain422_10,  VAEntrypointEncSlice}}
+    , { DXVA2_Intel_Encode_HEVC_Main444,            VAGUID{VAProfileHEVCMain444,     VAEntrypointEncSlice}}
+    , { DXVA2_Intel_Encode_HEVC_Main444_10,         VAGUID{VAProfileHEVCMain444_10,  VAEntrypointEncSlice}}
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main422,    VAGUID{VAProfileHEVCMain422_10,  VAEntrypointEncSliceLP}} // Unsupported by VA
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main422_10, VAGUID{VAProfileHEVCMain422_10, VAEntrypointEncSliceLP}}
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main444,    VAGUID{VAProfileHEVCMain444,    VAEntrypointEncSliceLP}}
+    , { DXVA2_Intel_LowpowerEncode_HEVC_Main444_10, VAGUID{VAProfileHEVCMain444_10, VAEntrypointEncSliceLP}}
+};
+
+
+VAGUID DDI_VA::MapGUID(StorageR& strg, const GUID& guid)
+{
+    if (strg.Contains(Glob::GuidToVa::Key))
+    {
+        auto& g2va = Glob::GuidToVa::Get(strg);
+        if (g2va.find(guid) != g2va.end())
+            return g2va.at(guid);
+    }
+
+    return DefaultGuidToVa.at(guid);
+}
+
+mfxStatus DDI_VA::CallVaDefault(const DDIExecParam& ep)
+{
+    bool bUnsupported = false;
+
+    auto vaSts = m_ddiExec.at(VAFID(ep.Function))(ep);
+
+    bUnsupported |= ep.Function == VAFID_CreateContext && (VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED == vaSts);
+    bUnsupported |= ep.Function == VAFID_GetConfigAttributes && (VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT == vaSts);
+    bUnsupported |= ep.Function == VAFID_GetConfigAttributes && (VA_STATUS_ERROR_UNSUPPORTED_PROFILE == vaSts);
+
+    MFX_CHECK(!bUnsupported, MFX_ERR_UNSUPPORTED);
+    MFX_CHECK(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
+    return MFX_ERR_NONE;
+}
+
+void DDI_VA::Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push)
+{
+    Push(BLK_SetCallChains
+        , [this](const mfxVideoParam&, mfxVideoParam& /*par*/, StorageRW& strg) -> mfxStatus
+    {
+        auto& ddiExec = Glob::DDI_Execute::GetOrConstruct(strg);
+
+        MFX_CHECK(!ddiExec, MFX_ERR_NONE);
+
+        ddiExec.Push([&](Glob::DDI_Execute::TRef::TExt, const DDIExecParam& ep)
+        {
+            return CallVaDefault(ep);
+        });
+
+        m_callVa = ddiExec;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DDI_VA::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_QueryCaps
+        , [this](const mfxVideoParam&, mfxVideoParam& /*par*/, StorageRW& strg) -> mfxStatus
+    {
+        MFX_CHECK(strg.Contains(Glob::GUID::Key), MFX_ERR_UNSUPPORTED);
+
+        auto& core = Glob::VideoCore::Get(strg);
+        const GUID& guid = Glob::GUID::Get(strg);
+
+        auto  vaGuid         = MapGUID(strg, guid);
+        auto  vap            = VAProfile(vaGuid.Profile);
+        auto  vaep           = VAEntrypoint(vaGuid.Entrypoint);
+        bool  bNeedNewDevice = vap != m_profile || vaep != m_entrypoint;
+
+        m_callVa = Glob::DDI_Execute::Get(strg);
+
+        if (bNeedNewDevice)
+        {
+            mfxStatus sts = CreateAuxilliaryDevice(core, vap, vaep);
+            MFX_CHECK_STS(sts);
+        }
+
+        Glob::EncodeCaps::GetOrConstruct(strg) = m_caps;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DDI_VA::InitExternal(const FeatureBlocks& /*blocks*/, TPushIE Push)
+{
+    Push(BLK_CreateDevice
+        , [this](const mfxVideoParam& /*par*/, StorageRW& strg, StorageRW&) -> mfxStatus
+    {
+        auto& core           = Glob::VideoCore::Get(strg);
+        auto& guid           = Glob::GUID::Get(strg);
+        auto  vaGuid         = MapGUID(strg, guid);
+        auto  vap            = VAProfile(vaGuid.Profile);
+        auto  vaep           = VAEntrypoint(vaGuid.Entrypoint);
+        bool  bNeedNewDevice = !m_vaDisplay || vap != m_profile || vaep != m_entrypoint;
+
+        m_callVa = Glob::DDI_Execute::Get(strg);
+
+        MFX_CHECK(bNeedNewDevice, MFX_ERR_NONE);
+
+        auto sts = CreateAuxilliaryDevice(core, vap, vaep);
+
+        return sts;
+    });
+}
+
+VABufferID DDI_VA::CreateVABuffer(
+    VABufferType type
+    , void* pData
+    , mfxU32 size
+    , mfxU32 num)
+{
+    VABufferID id = VA_INVALID_ID;
+
+    if (type != VAEncMiscParameterBufferType)
+    {
+        auto sts = CallVA(m_callVa, VAFID_CreateBuffer
+            , m_vaDisplay
+            , m_vaContextEncode
+            , type
+            , size
+            , num
+            , pData
+            , &id);
+        ThrowIf(!!sts, MFX_ERR_DEVICE_FAILED);
+        
+        return id;
+    }
+
+    auto sts = CallVA(m_callVa, VAFID_CreateBuffer
+        , m_vaDisplay
+        , m_vaContextEncode
+        , VAEncMiscParameterBufferType
+        , size
+        , 1
+        , nullptr
+        , &id);
+    ThrowIf(!!sts, MFX_ERR_DEVICE_FAILED);
+
+    VAEncMiscParameterBuffer *pMP;
+
+    sts = CallVA(m_callVa, VAFID_MapBuffer
+        , m_vaDisplay
+        , id
+        , (void **)&pMP);
+    ThrowIf(!!sts, MFX_ERR_DEVICE_FAILED);
+
+    pMP->type = ((VAEncMiscParameterBuffer*)pData)->type;
+    mfxU8* pDst = (mfxU8*)pMP->data;
+    mfxU8* pSrc = (mfxU8*)pData;
+
+    pSrc += sizeof(VAEncMiscParameterBuffer);
+    size -= sizeof(VAEncMiscParameterBuffer);
+
+    std::copy(pSrc, pSrc + size, pDst);
+
+    sts = CallVA(m_callVa, VAFID_UnmapBuffer
+        , m_vaDisplay
+        , id);
+    ThrowIf(!!sts, MFX_ERR_DEVICE_FAILED);
+
+    return id;
+}
+
+mfxStatus DDI_VA::CreateVABuffers(
+    const std::list<DDIExecParam>& par
+    , std::vector<VABufferID>& pool)
+{
+    pool.resize(par.size(), VA_INVALID_ID);
+
+    mfxStatus sts = Catch(
+        MFX_ERR_NONE
+        , std::transform<
+        std::list<DDIExecParam>::const_iterator
+        , std::vector<VABufferID>::iterator
+        , std::function<VABufferID(const DDIExecParam&)>>
+        , par.begin(), par.end(), pool.begin()
+        , [&](const DDIExecParam& p)
+    {
+        return CreateVABuffer(
+            VABufferType(p.Function)
+            , p.In.pData
+            , p.In.Size
+            , std::max<mfxU32>(p.In.Num, 1u));
+    });
+    MFX_CHECK_STS(sts);
+
+    return MFX_ERR_NONE;
+}
+
+mfxStatus DDI_VA::DestroyVABuffers(std::vector<VABufferID>& pool)
+{
+    std::remove(pool.begin(), pool.end(), VA_INVALID_ID);
+
+    mfxStatus sts = Catch(
+        MFX_ERR_NONE
+        , std::for_each<std::vector<VABufferID>::iterator, std::function<void(VABufferID)>>
+        , pool.begin()
+        , pool.end()
+        , [&](VABufferID id)
+    {
+        auto sts = CallVA(m_callVa, VAFID_DestroyBuffer, m_vaDisplay, id);
+        ThrowIf(!!sts, MFX_ERR_DEVICE_FAILED);
+    });
+    MFX_CHECK_STS(sts);
+
+    pool.clear();
+
+    return MFX_ERR_NONE;
+}
+
+DDI_VA::~DDI_VA()
+{
+    //use only class internal data in destructor
+    m_callVa = [&]( const DDIExecParam& ep) { return CallVaDefault(ep); };
+
+    DestroyVABuffers(m_perSeqPar);
+    DestroyVABuffers(m_perPicPar);
+
+    if (m_vaContextEncode != VA_INVALID_ID)
+    {
+        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaDestroyContext");
+        vaDestroyContext(m_vaDisplay, m_vaContextEncode);
+        m_vaContextEncode = VA_INVALID_ID;
+    }
+
+    if (m_vaConfig != VA_INVALID_ID)
+    {
+        vaDestroyConfig(m_vaDisplay, m_vaConfig);
+        m_vaConfig = VA_INVALID_ID;
+    }
+}
+
+void DDI_VA::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_CreateService
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& core = Glob::VideoCore::Get(strg);
+
+        m_callVa = Glob::DDI_Execute::Get(strg);
+
+        auto MidToVA = [&core](mfxMemId mid)
+        {
+            VASurfaceID *pSurface = nullptr;
+            mfxStatus sts = core.GetFrameHDL(mid, (mfxHDL*)&pSurface);
+            ThrowIf(!!sts, sts);
+            return *pSurface;
+        };
+        auto& recResponse = Glob::AllocRec::Get(strg).Response();
+
+        std::vector<VASurfaceID> rec(recResponse.NumFrameActual, VA_INVALID_SURFACE);
+
+        mfxStatus sts = Catch(
+            MFX_ERR_NONE
+            , std::transform<mfxMemId*, VASurfaceID*, std::function<VASurfaceID(mfxMemId)>>
+            , recResponse.mids
+            , recResponse.mids + recResponse.NumFrameActual
+            , rec.data()
+            , MidToVA);
+        MFX_CHECK_STS(sts);
+
+        sts = CreateAccelerationService(Glob::VideoParam::Get(strg), rec.data(), (int)rec.size());
+        MFX_CHECK_STS(sts);
+
+        const auto& par = Glob::VideoParam::Get(strg);
+        auto& fi = par.mfx.FrameInfo;
+        auto pInfo = make_storable<mfxFrameAllocRequest>(mfxFrameAllocRequest{});
+
+        // request linear buffer
+        pInfo->Info.FourCC = MFX_FOURCC_P8;
+
+        // context_id required for allocation video memory (tmp solution)
+        pInfo->AllocId = m_vaContextEncode;
+        pInfo->Info.Width = fi.Width * 2;
+        pInfo->Info.Height = fi.Height;
+
+        local.Insert(Tmp::BSAllocInfo::Key, std::move(pInfo));
+
+        return MFX_ERR_NONE;
+    });
+
+    Push(BLK_Register
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& res = Glob::DDI_Resources::Get(strg);
+
+        auto itBs = std::find_if(res.begin(), res.end()
+            , [](decltype(*res.begin()) r)
+        {
+            return r.Function == MFX_FOURCC_P8;
+        });
+        MFX_CHECK(itBs != res.end(), MFX_ERR_UNDEFINED_BEHAVIOR);
+        MFX_CHECK(itBs->Resource.Size == sizeof(VABufferID), MFX_ERR_UNDEFINED_BEHAVIOR);
+
+        VABufferID* pBsBegin = (VABufferID*)itBs->Resource.pData;
+        m_bs.assign(pBsBegin, pBsBegin + itBs->Resource.Num);
+
+        mfxStatus sts = CreateVABuffers(
+            Tmp::DDI_InitParam::Get(local)
+            , m_perSeqPar);
+        MFX_CHECK_STS(sts);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DDI_VA::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        mfxStatus sts;
+
+        m_callVa = Glob::DDI_Execute::Get(strg);
+
+        sts = DestroyVABuffers(m_perSeqPar);
+        MFX_CHECK_STS(sts);
+
+        sts = CreateVABuffers(
+            Tmp::DDI_InitParam::Get(local)
+            , m_perSeqPar);
+        MFX_CHECK_STS(sts);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DDI_VA::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SubmitTask
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        mfxStatus sts;
+        auto& task = Task::Common::Get(s_task);
+
+        m_callVa = Glob::DDI_Execute::Get(global);
+
+        MFX_CHECK((task.SkipCMD & SKIPCMD_NeedDriverCall), MFX_ERR_NONE);
+
+       auto& par = Glob::DDI_SubmitParam::Get(global);
+
+       sts = DestroyVABuffers(m_perPicPar);
+       MFX_CHECK_STS(sts);
+
+       sts = CreateVABuffers(par, m_perPicPar);
+       MFX_CHECK_STS(sts);
+
+       MFX_LTRACE_2(MFX_TRACE_LEVEL_HOTSPOTS
+           , "A|ENCODE|AVC|PACKET_START|", "%p|%d"
+           , m_vaContextEncode, task.StatusReportId);
+
+       {
+           MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaBeginPicture");
+
+           sts = CallVA(m_callVa, VAFID_BeginPicture
+               , m_vaDisplay
+               , m_vaContextEncode
+               , *(VASurfaceID*)task.HDLRaw.first);
+           MFX_CHECK_STS(sts);
+       }
+
+       {
+           MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaRenderPicture");
+
+           sts = CallVA(m_callVa, VAFID_RenderPicture
+               , m_vaDisplay
+               , m_vaContextEncode
+               , m_perPicPar.data()
+               , (int)m_perPicPar.size());
+           MFX_CHECK_STS(sts);
+       }
+       
+       {
+           MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaRenderPicture");
+
+           sts = CallVA(m_callVa, VAFID_RenderPicture
+               , m_vaDisplay
+               , m_vaContextEncode
+               , m_perSeqPar.data()
+               , (int)m_perSeqPar.size());
+           MFX_CHECK_STS(sts);
+       }
+
+       {
+           MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaEndPicture");
+
+           sts = CallVA(m_callVa, VAFID_EndPicture
+               , m_vaDisplay
+               , m_vaContextEncode);
+           MFX_CHECK_STS(sts);
+       }
+
+       MFX_LTRACE_2(MFX_TRACE_LEVEL_HOTSPOTS
+           , "A|ENCODE|AVC|PACKET_END|", "%d|%d"
+           , m_vaContextEncode, task.StatusReportId);
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void DDI_VA::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_QueryTask
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task = Task::Common::Get(s_task);
+
+        m_callVa = Glob::DDI_Execute::Get(global);
+
+        MFX_CHECK((task.SkipCMD & SKIPCMD_NeedDriverCall), MFX_ERR_NONE);
+
+        auto& ddiFB = Glob::DDI_Feedback::Get(global);
+
+        MFX_CHECK(!ddiFB.Get(task.StatusReportId), MFX_ERR_NONE);
+        mfxStatus sts;
+
+        {
+            MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaSyncSurface");
+            sts = CallVA(m_callVa, VAFID_SyncSurface, m_vaDisplay, *(VASurfaceID*)task.HDLRaw.first);
+            MFX_CHECK_STS(sts);
+        }
+
+        VACodedBufferSegment* pCBS = nullptr;
+        {
+            sts = CallVA(m_callVa, VAFID_MapBuffer, m_vaDisplay, m_bs.at(task.BS.Idx), (void **)&pCBS);
+            MFX_CHECK_STS(sts);
+            MFX_CHECK(pCBS, MFX_ERR_DEVICE_FAILED);
+        }
+
+        MFX_CHECK(ddiFB.Out.Size >= sizeof(VACodedBufferSegment), MFX_ERR_UNDEFINED_BEHAVIOR);
+        *(VACodedBufferSegment*)ddiFB.Out.pData = *pCBS;
+
+        {
+            MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaUnmapBuffer");
+            sts = CallVA(m_callVa, VAFID_UnmapBuffer, m_vaDisplay, m_bs.at(task.BS.Idx));
+        }
+        MFX_CHECK_STS(sts);
+
+        ddiFB.bNotReady = false;
+
+        return ddiFB.Update(task.StatusReportId);
+    });
+}
+
+mfxStatus DDI_VA::CreateAuxilliaryDevice(
+    VideoCORE&  core
+    , VAProfile profile
+    , VAEntrypoint entrypoint)
+{
+    mfxStatus sts = core.GetHandle(MFX_HANDLE_VA_DISPLAY, (mfxHDL*)&m_vaDisplay);
+    MFX_CHECK_STS(sts);
+
+    m_caps = {};
+
+    std::map<VAConfigAttribType, int> idx_map;
+    VAConfigAttribType attr_types[] =
+    {
+        VAConfigAttribRTFormat
+        , VAConfigAttribRateControl
+        , VAConfigAttribEncQuantization
+        , VAConfigAttribEncIntraRefresh
+        , VAConfigAttribMaxPictureHeight
+        , VAConfigAttribMaxPictureWidth
+        , VAConfigAttribEncParallelRateControl
+        , VAConfigAttribEncMaxRefFrames
+        , VAConfigAttribEncSliceStructure
+        , VAConfigAttribEncROI
+        , VAConfigAttribEncTileSupport
+    };
+    std::vector<VAConfigAttrib> attrs;
+    auto AV = [&](VAConfigAttribType t) { return attrs[idx_map[t]].value; };
+
+    mfxI32 i = 0;
+    std::for_each(std::begin(attr_types), std::end(attr_types)
+        , [&](decltype(*std::begin(attr_types)) type)
+    {
+        attrs.push_back({ type, 0 });
+        idx_map[type] = i;
+        ++i;
+    });
+
+    sts = CallVA(
+        m_callVa
+        , VAFID_GetConfigAttributes
+        , m_vaDisplay
+        , profile
+        , entrypoint
+        , attrs.data()
+        , (int)attrs.size());
+    MFX_CHECK_STS(sts);
+
+    m_profile = profile;
+    m_entrypoint = entrypoint;
+
+    m_caps.VCMBitRateControl = !!(AV(VAConfigAttribRateControl) & VA_RC_VCM); //Video conference mode
+    m_caps.MBBRCSupport      = !!(AV(VAConfigAttribRateControl) & VA_RC_MB);
+    m_caps.msdk.CBRSupport   = !!(AV(VAConfigAttribRateControl) & VA_RC_CBR);
+    m_caps.msdk.VBRSupport   = !!(AV(VAConfigAttribRateControl) & VA_RC_VBR);
+    m_caps.msdk.CQPSupport   = !!(AV(VAConfigAttribRateControl) & VA_RC_CQP);
+    m_caps.msdk.ICQSupport   = !!(AV(VAConfigAttribRateControl) & VA_RC_ICQ);
+#ifdef MFX_ENABLE_QVBR
+    m_caps.QVBRBRCSupport    = !!(AV(VAConfigAttribRateControl) & VA_RC_QVBR);
+#endif
+
+    m_caps.RollingIntraRefresh = !!(AV(VAConfigAttribEncIntraRefresh) & (~VA_ATTRIB_NOT_SUPPORTED));
+
+    m_caps.MaxEncodedBitDepth = std::max<mfxU32>(
+          !!(AV(VAConfigAttribRTFormat) & VA_RT_FORMAT_YUV420_12) * 2
+        , !!(AV(VAConfigAttribRTFormat) & VA_RT_FORMAT_YUV420_10));
+
+    m_caps.Color420Only = !(AV(VAConfigAttribRTFormat) & (VA_RT_FORMAT_YUV422 | VA_RT_FORMAT_YUV444));
+    m_caps.BitDepth8Only = !(AV(VAConfigAttribRTFormat) & (VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV420_12));
+    m_caps.YUV422ReconSupport = !!(AV(VAConfigAttribRTFormat) & VA_RT_FORMAT_YUV422);
+    m_caps.YUV444ReconSupport = !!(AV(VAConfigAttribRTFormat) & VA_RT_FORMAT_YUV444);
+
+    m_caps.MaxPicWidth = AV(VAConfigAttribMaxPictureWidth) & ~VA_ATTRIB_NOT_SUPPORTED;
+    SetDefault(m_caps.MaxPicWidth, 1920u);
+    m_caps.MaxPicHeight = AV(VAConfigAttribMaxPictureHeight) & ~VA_ATTRIB_NOT_SUPPORTED;
+    SetDefault(m_caps.MaxPicHeight, 1088u);
+
+    if (AV(VAConfigAttribEncMaxRefFrames) != VA_ATTRIB_NOT_SUPPORTED)
+    {
+        m_caps.MaxNum_Reference0 = mfxU8(AV(VAConfigAttribEncMaxRefFrames));
+        m_caps.MaxNum_Reference1 = mfxU8(AV(VAConfigAttribEncMaxRefFrames) >> 16);
+
+        SetDefault(m_caps.MaxNum_Reference1, m_caps.MaxNum_Reference0);
+        CheckMaxOrClip(m_caps.MaxNum_Reference1, m_caps.MaxNum_Reference0);
+    }
+    else
+    {
+        m_caps.MaxNum_Reference0 = 3;
+        m_caps.MaxNum_Reference1 = 1;
+    }
+
+    if (AV(VAConfigAttribEncROI) != VA_ATTRIB_NOT_SUPPORTED) // VAConfigAttribEncROI
+    {
+        auto roi = *(VAConfigAttribValEncROI*)&attrs[idx_map[VAConfigAttribEncROI]].value;
+
+        assert(roi.bits.num_roi_regions < 32);
+        m_caps.MaxNumOfROI                  = roi.bits.num_roi_regions;
+        m_caps.ROIBRCPriorityLevelSupport   = roi.bits.roi_rc_priority_support;
+        m_caps.ROIDeltaQPSupport            = roi.bits.roi_rc_qp_delta_support;
+    }
+
+    m_caps.TileSupport = (AV(VAConfigAttribEncTileSupport) == 1);
+
+    return MFX_ERR_NONE;
+}
+
+uint32_t ConvertRateControlMFX2VAAPI(mfxU16 rateControl, bool bSWBRC)
+{
+    if (bSWBRC)
+        return VA_RC_CQP;
+
+    static const std::map<mfxU16, uint32_t> RCMFX2VAAPI =
+    {
+        { mfxU16(MFX_RATECONTROL_CQP)   , uint32_t(VA_RC_CQP) },
+        { mfxU16(MFX_RATECONTROL_LA_EXT), uint32_t(VA_RC_CQP) },
+        { mfxU16(MFX_RATECONTROL_CBR)   , uint32_t(VA_RC_CBR | VA_RC_MB) },
+        { mfxU16(MFX_RATECONTROL_VBR)   , uint32_t(VA_RC_VBR | VA_RC_MB) },
+        { mfxU16(MFX_RATECONTROL_ICQ)   , uint32_t(VA_RC_ICQ) },
+        { mfxU16(MFX_RATECONTROL_VCM)   , uint32_t(VA_RC_VCM) },
+#ifdef MFX_ENABLE_QVBR
+        { mfxU16(MFX_RATECONTROL_QVBR)  , uint32_t(VA_RC_QVBR) },
+#endif
+    };
+
+    auto itRC = RCMFX2VAAPI.find(rateControl);
+    if (itRC != RCMFX2VAAPI.end())
+    {
+        return itRC->second;
+    }
+
+    assert(!"Unsupported RateControl");
+    return 0;
+}
+
+mfxStatus DDI_VA::CreateAccelerationService(
+    const mfxVideoParam & par
+    , VASurfaceID* pRec
+    , int nRec)
+{
+    MFX_CHECK(m_vaDisplay, MFX_ERR_NOT_INITIALIZED);
+
+    mfxI32 numEntrypoints = vaMaxNumEntrypoints(m_vaDisplay);
+    MFX_CHECK(numEntrypoints, MFX_ERR_DEVICE_FAILED);
+
+    std::vector<VAEntrypoint> ep_list(numEntrypoints);
+    std::vector<VAProfile> profile_list(vaMaxNumProfiles(m_vaDisplay), VAProfileNone);
+    mfxI32 num_profiles = 0;
+    mfxStatus sts = MFX_ERR_NONE;
+
+    sts = CallVA(
+        m_callVa
+        , VAFID_QueryConfigProfiles
+        , m_vaDisplay
+        , profile_list.data()
+        , &num_profiles);
+    MFX_CHECK_STS(sts);
+    MFX_CHECK(std::find(profile_list.begin(), profile_list.end(), m_profile) != profile_list.end(), MFX_ERR_DEVICE_FAILED);
+
+    sts = CallVA(
+        m_callVa
+        , VAFID_QueryConfigEntrypoints
+        , m_vaDisplay
+        , m_profile
+        , ep_list.data()
+        , &numEntrypoints);
+    MFX_CHECK_STS(sts);
+    MFX_CHECK(std::find(ep_list.begin(), ep_list.end(), m_entrypoint) != ep_list.end(), MFX_ERR_DEVICE_FAILED);
+
+    // Configuration
+    std::vector<VAConfigAttrib> attrib(2);
+
+    attrib[0].type = VAConfigAttribRTFormat;
+    attrib[1].type = VAConfigAttribRateControl;
+
+    sts = CallVA(
+        m_callVa
+        , VAFID_GetConfigAttributes
+        , m_vaDisplay
+        , m_profile
+        , m_entrypoint
+        , attrib.data()
+        , (mfxI32)attrib.size());
+    MFX_CHECK_STS(sts);
+
+    MFX_CHECK(
+           (attrib[0].value & VA_RT_FORMAT_YUV420)
+#if (MFX_VERSION >= 1027)
+        || (attrib[0].value & VA_RT_FORMAT_YUV420_10)
+#endif
+        , MFX_ERR_DEVICE_FAILED);
+
+    uint32_t vaRCType = ConvertRateControlMFX2VAAPI(par.mfx.RateControlMethod, Legacy::IsSWBRC(par, ExtBuffer::Get(par)));
+
+    MFX_CHECK((attrib[1].value & vaRCType), MFX_ERR_DEVICE_FAILED);
+
+    attrib[1].value = vaRCType;
+
+    sts = CallVA(
+        m_callVa
+        , VAFID_CreateConfig
+        , m_vaDisplay
+        , m_profile
+        , m_entrypoint
+        , attrib.data()
+        , (mfxI32)attrib.size()
+        , &m_vaConfig);
+    MFX_CHECK_STS(sts);
+
+    // Encoder create
+    {
+        MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_EXTCALL, "vaCreateContext");
+        sts = CallVA(
+            m_callVa
+            , VAFID_CreateContext
+            , m_vaDisplay
+            , m_vaConfig
+            , (int)par.mfx.FrameInfo.Width
+            , (int)par.mfx.FrameInfo.Height
+            , (int)VA_PROGRESSIVE
+            , pRec
+            , nRec
+            , &m_vaContextEncode
+        );
+    }
+    MFX_CHECK_STS(sts);
+
+    return MFX_ERR_NONE;
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_lin.h
@@ -1,0 +1,166 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#include "hevcehw_base.h"
+
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_ddi.h"
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_iddi.h"
+#include "va/va.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+using namespace HEVCEHW::Gen11;
+
+class DDI_VA
+    : public virtual FeatureBase
+    , protected IDDI
+{
+public:
+    DDI_VA(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+        , IDDI(FeatureId)
+    {
+        SetTraceName("G11_DDI_VA");
+    }
+
+    ~DDI_VA();
+
+    static VAGUID MapGUID(StorageR& strg, const GUID& guid);
+
+    enum VAFID
+    {
+        VAFID_CreateConfig = 1
+        , VAFID_DestroyConfig
+        , VAFID_CreateContext
+        , VAFID_DestroyContext
+        , VAFID_GetConfigAttributes
+        , VAFID_QueryConfigEntrypoints
+        , VAFID_QueryConfigProfiles
+        , VAFID_CreateBuffer
+        , VAFID_MapBuffer
+        , VAFID_UnmapBuffer
+        , VAFID_DestroyBuffer
+        , VAFID_BeginPicture
+        , VAFID_RenderPicture
+        , VAFID_EndPicture
+        , VAFID_SyncSurface
+    };
+
+    using TDdiExec = std::function<VAStatus(const DDIExecParam&)>;
+    using TDdiExecMfx = std::function<mfxStatus(const DDIExecParam&)>;
+
+    template <typename TFn>
+    static TDdiExec CallDefault(TFn fn)
+    {
+        using TArgs = decltype(TupleArgs(fn));
+        return [fn](const DDIExecParam& par) { return CallWithTupleArgs(fn, Deref<TArgs>(par.In)); };
+    }
+
+    template <typename... TArgs>
+    static mfxStatus CallVA(TDdiExecMfx& fn, VAFID id, TArgs... args)
+    {
+        DDIExecParam xPar;
+        auto         tpl = std::make_tuple(args...);
+        xPar.Function = mfxU32(id);
+        xPar.In.pData = &tpl;
+        xPar.In.Size  = sizeof(tpl);
+        return fn(xPar);
+    }
+
+protected:
+    virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void InitExternal(const FeatureBlocks& blocks, TPushIE Push) override;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+
+    mfxStatus CreateAuxilliaryDevice(
+        VideoCORE&  core
+        , VAProfile profile
+        , VAEntrypoint entrypoint);
+
+    mfxStatus CreateAccelerationService(
+        const mfxVideoParam & par
+        , VASurfaceID* pRec
+        , int nRec);
+
+    VABufferID CreateVABuffer(
+        VABufferType type
+        , void* pData
+        , mfxU32 size
+        , mfxU32 num);
+
+    mfxStatus CreateVABuffers(
+        const std::list<DDIExecParam>& par
+        , std::vector<VABufferID>& pool);
+
+    mfxStatus DestroyVABuffers(std::vector<VABufferID>& pool);
+
+    mfxStatus CallVaDefault(const DDIExecParam& ep);
+
+    VideoCORE*                  m_pCore            = nullptr;
+    VAProfile                   m_profile          = VAProfileNone;
+    VAEntrypoint                m_entrypoint       = VAEntrypointEncSlice;
+    VADisplay                   m_vaDisplay        = nullptr;
+    VAContextID                 m_vaContextEncode  = VA_INVALID_ID;
+    VAConfigID                  m_vaConfig         = VA_INVALID_ID;
+    EncodeCapsHevc              m_caps;
+    std::vector<VABufferID>     m_perSeqPar;
+    std::vector<VABufferID>     m_perPicPar;
+    std::vector<VABufferID>     m_bs;
+    TDdiExecMfx                 m_callVa;
+    std::map<VAFID, TDdiExec>   m_ddiExec =
+    {
+        {VAFID_CreateConfig,              CallDefault(&vaCreateConfig)}
+        , {VAFID_DestroyConfig,           CallDefault(&vaDestroyConfig)}
+        , {VAFID_CreateContext,           CallDefault(&vaCreateContext)}
+        , {VAFID_DestroyContext,          CallDefault(&vaDestroyContext)}
+        , {VAFID_GetConfigAttributes,     CallDefault(&vaGetConfigAttributes)}
+        , {VAFID_QueryConfigEntrypoints,  CallDefault(&vaQueryConfigEntrypoints)}
+        , {VAFID_QueryConfigProfiles,     CallDefault(&vaQueryConfigProfiles)}
+        , {VAFID_GetConfigAttributes,     CallDefault(&vaGetConfigAttributes)}
+        , {VAFID_CreateBuffer,            CallDefault(&vaCreateBuffer)}
+        , {VAFID_MapBuffer,               CallDefault(&vaMapBuffer)}
+        , {VAFID_UnmapBuffer,             CallDefault(&vaUnmapBuffer)}
+        , {VAFID_DestroyBuffer,           CallDefault(&vaDestroyBuffer)}
+        , {VAFID_BeginPicture,            CallDefault(&vaBeginPicture)}
+        , {VAFID_RenderPicture,           CallDefault(&vaRenderPicture)}
+        , {VAFID_EndPicture,              CallDefault(&vaEndPicture)}
+        , {VAFID_SyncSurface,             CallDefault(&vaSyncSurface)}
+    };
+};
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_packer_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_packer_lin.cpp
@@ -1,0 +1,883 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#include "hevcehw_g11_va_packer_lin.h"
+
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+#include "mfx_common_int.h"
+#include "hevcehw_g11_va_lin.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+using namespace HEVCEHW::Linux;
+using namespace HEVCEHW::Linux::Gen11;
+
+void VAPacker::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_HardcodeCaps
+        , [this](const mfxVideoParam&, mfxVideoParam& par, StorageRW& strg) -> mfxStatus
+    {
+        auto&       caps     = Glob::EncodeCaps::Get(strg);
+        eMFXHWType  platform = Glob::VideoCore::Get(strg).GetHWType();
+        auto        vaGUID   = DDI_VA::MapGUID(strg, Glob::GUID::Get(strg));
+
+        HardcodeCapsCommon(caps, platform, par);
+
+        bool bGen9 = (platform < MFX_HW_CNL);
+        bool bLP   = (vaGUID.Entrypoint == VAEntrypointEncSliceLP);
+
+        caps.LCUSizeSupported |=
+              (32 >> 4) * ( bGen9 || (!bGen9 && !bLP))
+            + (64 >> 4) * (!bGen9);
+
+        caps.BRCReset                   = 1; // no bitrate resolution control
+        caps.BlockSize                  = 2;
+        caps.UserMaxFrameSizeSupport    = 1;
+        caps.MbQpDataSupport            = 1;
+        caps.TUSupport                  = 73;
+        caps.SliceStructure             = 4;
+
+        caps.MaxEncodedBitDepth |= (!caps.BitDepth8Only);
+        caps.YUV444ReconSupport |= (!caps.Color420Only && IsOn(par.mfx.LowPower));
+        caps.YUV422ReconSupport |= (!caps.Color420Only && IsOff(par.mfx.LowPower));
+
+        return MFX_ERR_NONE;
+    });
+
+}
+
+void InitSPS(
+    const ExtBuffer::Param<mfxVideoParam>& par
+    , const SPS& bs_sps
+    , VAEncSequenceParameterBufferHEVC & sps)
+{
+    sps = {};
+
+    sps.general_profile_idc = bs_sps.general.profile_idc;
+    sps.general_level_idc   = bs_sps.general.level_idc;
+    sps.general_tier_flag   = bs_sps.general.tier_flag;
+
+    sps.intra_period        = par.mfx.GopPicSize;
+    sps.intra_idr_period    = par.mfx.GopPicSize * par.mfx.IdrInterval;
+    sps.ip_period           = par.mfx.GopRefDist;
+
+    if (   par.mfx.RateControlMethod != MFX_RATECONTROL_CQP
+        && par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ
+        && par.mfx.RateControlMethod != MFX_RATECONTROL_LA_EXT)
+    {
+        sps.bits_per_second = TargetKbps(par.mfx) * 1000;
+    }
+
+    sps.pic_width_in_luma_samples  = (uint16_t)bs_sps.pic_width_in_luma_samples;
+    sps.pic_height_in_luma_samples = (uint16_t)bs_sps.pic_height_in_luma_samples;
+
+    sps.seq_fields.bits.chroma_format_idc                   = bs_sps.chroma_format_idc;
+    sps.seq_fields.bits.separate_colour_plane_flag          = bs_sps.separate_colour_plane_flag;
+    sps.seq_fields.bits.bit_depth_luma_minus8               = bs_sps.bit_depth_luma_minus8;
+    sps.seq_fields.bits.bit_depth_chroma_minus8             = bs_sps.bit_depth_chroma_minus8;
+    sps.seq_fields.bits.scaling_list_enabled_flag           = bs_sps.scaling_list_enabled_flag;
+    sps.seq_fields.bits.strong_intra_smoothing_enabled_flag = bs_sps.strong_intra_smoothing_enabled_flag;
+    sps.seq_fields.bits.amp_enabled_flag                    = bs_sps.amp_enabled_flag;
+    sps.seq_fields.bits.sample_adaptive_offset_enabled_flag = bs_sps.sample_adaptive_offset_enabled_flag;
+    sps.seq_fields.bits.pcm_enabled_flag                    = bs_sps.pcm_enabled_flag;
+    sps.seq_fields.bits.pcm_loop_filter_disabled_flag       = 1;//bs_sps.pcm_loop_filter_disabled_flag;
+    sps.seq_fields.bits.sps_temporal_mvp_enabled_flag       = bs_sps.temporal_mvp_enabled_flag;
+
+    sps.log2_min_luma_coding_block_size_minus3 = (mfxU8)bs_sps.log2_min_luma_coding_block_size_minus3;
+
+    sps.log2_diff_max_min_luma_coding_block_size   = (mfxU8)bs_sps.log2_diff_max_min_luma_coding_block_size;
+    sps.log2_min_transform_block_size_minus2       = (mfxU8)bs_sps.log2_min_transform_block_size_minus2;
+    sps.log2_diff_max_min_transform_block_size     = (mfxU8)bs_sps.log2_diff_max_min_transform_block_size;
+    sps.max_transform_hierarchy_depth_inter        = (mfxU8)bs_sps.max_transform_hierarchy_depth_inter;
+    sps.max_transform_hierarchy_depth_intra        = (mfxU8)bs_sps.max_transform_hierarchy_depth_intra;
+    sps.pcm_sample_bit_depth_luma_minus1           = (mfxU8)bs_sps.pcm_sample_bit_depth_luma_minus1;
+    sps.pcm_sample_bit_depth_chroma_minus1         = (mfxU8)bs_sps.pcm_sample_bit_depth_chroma_minus1;
+    sps.log2_min_pcm_luma_coding_block_size_minus3 = (mfxU8)bs_sps.log2_min_pcm_luma_coding_block_size_minus3;
+    sps.log2_max_pcm_luma_coding_block_size_minus3 = (mfxU8)(bs_sps.log2_min_pcm_luma_coding_block_size_minus3
+        + bs_sps.log2_diff_max_min_pcm_luma_coding_block_size);
+
+    sps.vui_parameters_present_flag                             = bs_sps.vui_parameters_present_flag;
+    sps.vui_fields.bits.aspect_ratio_info_present_flag          = bs_sps.vui.aspect_ratio_info_present_flag;
+    sps.vui_fields.bits.neutral_chroma_indication_flag          = bs_sps.vui.neutral_chroma_indication_flag;
+    sps.vui_fields.bits.field_seq_flag                          = bs_sps.vui.field_seq_flag;
+    sps.vui_fields.bits.vui_timing_info_present_flag            = bs_sps.vui.timing_info_present_flag;
+    sps.vui_fields.bits.bitstream_restriction_flag              = bs_sps.vui.bitstream_restriction_flag;
+    sps.vui_fields.bits.tiles_fixed_structure_flag              = bs_sps.vui.tiles_fixed_structure_flag;
+    sps.vui_fields.bits.motion_vectors_over_pic_boundaries_flag = bs_sps.vui.motion_vectors_over_pic_boundaries_flag;
+    sps.vui_fields.bits.restricted_ref_pic_lists_flag           = bs_sps.vui.restricted_ref_pic_lists_flag;
+    sps.vui_fields.bits.log2_max_mv_length_horizontal           = bs_sps.vui.log2_max_mv_length_horizontal;
+    sps.vui_fields.bits.log2_max_mv_length_vertical             = bs_sps.vui.log2_max_mv_length_vertical;
+
+
+    sps.aspect_ratio_idc             = bs_sps.vui.aspect_ratio_idc;
+    sps.sar_width                    = bs_sps.vui.sar_width;
+    sps.sar_height                   = bs_sps.vui.sar_height;
+    sps.vui_num_units_in_tick        = bs_sps.vui.num_units_in_tick;
+    sps.vui_time_scale               = bs_sps.vui.time_scale;
+    sps.min_spatial_segmentation_idc = bs_sps.vui.min_spatial_segmentation_idc;
+    sps.max_bytes_per_pic_denom      = bs_sps.vui.max_bytes_per_pic_denom;
+    sps.max_bits_per_min_cu_denom    = bs_sps.vui.max_bits_per_min_cu_denom;
+}
+
+void InitPPS(
+    const ExtBuffer::Param<mfxVideoParam>& /*par*/
+    , const PPS& bs_pps
+    , VAEncPictureParameterBufferHEVC & pps)
+{
+    pps = {};
+
+    std::for_each(
+        std::begin(pps.reference_frames)
+        , std::end(pps.reference_frames)
+        , [](decltype(*std::begin(pps.reference_frames)) ref) { ref.picture_id = VA_INVALID_ID; });
+
+    pps.last_picture            = 0;
+    pps.pic_init_qp             = (mfxU8)(bs_pps.init_qp_minus26 + 26);
+    pps.diff_cu_qp_delta_depth  = (mfxU8)bs_pps.diff_cu_qp_delta_depth;
+    pps.pps_cb_qp_offset        = (mfxU8)bs_pps.cb_qp_offset;
+    pps.pps_cr_qp_offset        = (mfxU8)bs_pps.cr_qp_offset;
+    pps.num_tile_columns_minus1 = (mfxU8)bs_pps.num_tile_columns_minus1;
+    pps.num_tile_rows_minus1    = (mfxU8)bs_pps.num_tile_rows_minus1;
+
+    auto NumTileDdiToVa = [](mfxU16 n) { return (uint8_t)std::max<int>(0, n - 1); };
+
+    std::transform(
+        bs_pps.column_width
+        , bs_pps.column_width + pps.num_tile_columns_minus1 + 1u
+        , pps.column_width_minus1
+        , NumTileDdiToVa);
+    std::transform(
+        bs_pps.row_height
+        , bs_pps.row_height + pps.num_tile_rows_minus1 + 1u
+        , pps.row_height_minus1
+        , NumTileDdiToVa);
+
+    pps.log2_parallel_merge_level_minus2     = (mfxU8)bs_pps.log2_parallel_merge_level_minus2;
+    pps.ctu_max_bitsize_allowed              = 0;
+    pps.num_ref_idx_l0_default_active_minus1 = (mfxU8)bs_pps.num_ref_idx_l0_default_active_minus1;
+    pps.num_ref_idx_l1_default_active_minus1 = (mfxU8)bs_pps.num_ref_idx_l1_default_active_minus1;
+    pps.slice_pic_parameter_set_id           = 0;
+
+    pps.pic_fields.bits.dependent_slice_segments_enabled_flag      = bs_pps.dependent_slice_segments_enabled_flag;
+    pps.pic_fields.bits.sign_data_hiding_enabled_flag              = bs_pps.sign_data_hiding_enabled_flag;
+    pps.pic_fields.bits.constrained_intra_pred_flag                = bs_pps.constrained_intra_pred_flag;
+    pps.pic_fields.bits.transform_skip_enabled_flag                = bs_pps.transform_skip_enabled_flag;
+    pps.pic_fields.bits.cu_qp_delta_enabled_flag                   = bs_pps.cu_qp_delta_enabled_flag;
+    pps.pic_fields.bits.weighted_pred_flag                         = bs_pps.weighted_pred_flag;
+    pps.pic_fields.bits.weighted_bipred_flag                       = bs_pps.weighted_bipred_flag;
+    pps.pic_fields.bits.transquant_bypass_enabled_flag             = bs_pps.transquant_bypass_enabled_flag;
+    pps.pic_fields.bits.tiles_enabled_flag                         = bs_pps.tiles_enabled_flag;
+    pps.pic_fields.bits.entropy_coding_sync_enabled_flag           = bs_pps.entropy_coding_sync_enabled_flag;
+    pps.pic_fields.bits.loop_filter_across_tiles_enabled_flag      = bs_pps.loop_filter_across_tiles_enabled_flag;
+    pps.pic_fields.bits.pps_loop_filter_across_slices_enabled_flag = bs_pps.loop_filter_across_slices_enabled_flag;
+    pps.pic_fields.bits.scaling_list_data_present_flag             = bs_pps.scaling_list_data_present_flag;
+    pps.pic_fields.bits.screen_content_flag                        = 0;
+    pps.pic_fields.bits.enable_gpu_weighted_prediction             = 0;
+    pps.pic_fields.bits.no_output_of_prior_pics_flag               = 0;
+}
+
+void InitSSH(
+    const ExtBuffer::Param<mfxVideoParam>& /*par*/
+    , Glob::SliceInfo::TRef sinfo
+    , std::vector<VAEncSliceParameterBufferHEVC> & slices)
+{
+    slices.resize(sinfo.size());
+    std::transform(sinfo.begin(), sinfo.end(), slices.begin()
+        , [](const SliceInfo& si)
+    {
+        VAEncSliceParameterBufferHEVC s = {};
+        s.slice_segment_address = si.SegmentAddress;
+        s.num_ctu_in_slice = si.NumLCU;
+        return s;
+    });
+
+    if (!slices.empty())
+        slices.rbegin()->slice_fields.bits.last_slice_of_pic_flag = 1;
+}
+
+void AddVaMiscHRD(
+    const Glob::VideoParam::TRef& par
+    , std::list<std::vector<mfxU8>>& buf)
+{
+    auto& hrd = AddVaMisc<VAEncMiscParameterHRD>(VAEncMiscParameterTypeHRD, buf);
+
+    uint32_t bNeedBufParam =
+        par.mfx.RateControlMethod != MFX_RATECONTROL_CQP
+        && par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ;
+
+    hrd.initial_buffer_fullness = bNeedBufParam * InitialDelayInKB(par.mfx) * 8000;
+    hrd.buffer_size             = bNeedBufParam * BufferSizeInKB(par.mfx) * 8000;
+}
+
+void AddVaMiscRC(
+    const Glob::VideoParam::TRef& par
+    , const Glob::PPS::TRef& bs_pps
+    , std::list<std::vector<mfxU8>>& buf
+    , bool bResetBRC = false)
+{
+    auto& rc = AddVaMisc<VAEncMiscParameterRateControl>(VAEncMiscParameterTypeRateControl, buf);
+
+    uint32_t bNeedRateParam =
+            par.mfx.RateControlMethod != MFX_RATECONTROL_CQP
+        && par.mfx.RateControlMethod != MFX_RATECONTROL_ICQ
+        && par.mfx.RateControlMethod != MFX_RATECONTROL_LA_EXT;
+
+    rc.bits_per_second = bNeedRateParam * MaxKbps(par.mfx) * 1000;
+
+    if (rc.bits_per_second)
+        rc.target_percentage = uint32_t(100.0 * (mfxF64)TargetKbps(par.mfx) / (mfxF64)MaxKbps(par.mfx));
+
+    rc.rc_flags.bits.reset = bNeedRateParam && bResetBRC;
+
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+
+#ifdef PARALLEL_BRC_support
+    rc.rc_flags.bits.enable_parallel_brc =
+        bNeedRateParam
+        && (par.AsyncDepth > 1)
+        && (par.mfx.GopRefDist > 1)
+        && (par.mfx.GopRefDist <= 8)
+        && (CO2.BRefType == MFX_B_REF_PYRAMID);
+#endif //PARALLEL_BRC_support
+
+    rc.ICQ_quality_factor = uint32_t((par.mfx.RateControlMethod == MFX_RATECONTROL_ICQ) * par.mfx.ICQQuality);
+    rc.initial_qp = bs_pps.init_qp_minus26 + 26;
+
+    //  MBBRC control
+    // Control VA_RC_MB 0: default, 1: enable, 2: disable, other: reserved
+    rc.rc_flags.bits.mb_rate_control = IsOn(CO2.MBBRC) + IsOff(CO2.MBBRC) * 2;
+
+#ifdef MFX_ENABLE_QVBR
+    const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+
+    rc.quality_factor = uint32_t((par.mfx.RateControlMethod == MFX_RATECONTROL_QVBR) * CO3.QVBRQuality);
+#endif
+}
+
+void AddVaMiscPBRC(
+    const Glob::VideoParam::TRef& par
+    , std::list<std::vector<mfxU8>>& buf)
+{
+#ifdef PARALLEL_BRC_support
+    auto& pbrc = AddVaMisc<VAEncMiscParameterParallelRateControl>(
+        VAEncMiscParameterTypeParallelBRC, buf);
+    const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par);
+
+    if (CO2.BRefType != MFX_B_REF_PYRAMID)
+    {
+        pbrc.num_b_in_gop[0] = par.mfx.GopRefDist - 1;
+        pbrc.num_b_in_gop[1] = 0;
+        pbrc.num_b_in_gop[2] = 0;
+
+        return;
+    }
+
+    if (par.mfx.GopRefDist <= 8)
+    {
+        static uint32_t B[9] = { 0,0,1,1,1,1,1,1,1 };
+        static uint32_t B1[9] = { 0,0,0,1,2,2,2,2,2 };
+        static uint32_t B2[9] = { 0,0,0,0,0,1,2,3,4 };
+
+        mfxI32 numBpyr = par.mfx.GopPicSize / par.mfx.GopRefDist;
+        mfxI32 lastBpyrW = par.mfx.GopPicSize%par.mfx.GopRefDist;
+
+        pbrc.num_b_in_gop[0] = numBpyr * B[par.mfx.GopRefDist] + B[lastBpyrW];;
+        pbrc.num_b_in_gop[1] = numBpyr * B1[par.mfx.GopRefDist] + B1[lastBpyrW];
+        pbrc.num_b_in_gop[2] = numBpyr * B2[par.mfx.GopRefDist] + B2[lastBpyrW];
+
+        return;
+    }
+
+    pbrc.num_b_in_gop[0] = 0;
+    pbrc.num_b_in_gop[1] = 0;
+    pbrc.num_b_in_gop[2] = 0;
+#else
+    std::ignore = par;
+    std::ignore = buf;
+#endif //PARALLEL_BRC_support
+}
+
+void AddVaMiscFR(
+    const Glob::VideoParam::TRef& par
+    , std::list<std::vector<mfxU8>>& buf)
+{
+    auto& fr = AddVaMisc<VAEncMiscParameterFrameRate>(VAEncMiscParameterTypeFrameRate, buf);
+
+    PackMfxFrameRate(par.mfx.FrameInfo.FrameRateExtN, par.mfx.FrameInfo.FrameRateExtD, fr.framerate);
+}
+
+void AddVaMiscTU(
+    const Glob::VideoParam::TRef& par
+    , std::list<std::vector<mfxU8>>& buf)
+{
+    auto& tu = AddVaMisc<VAEncMiscParameterBufferQualityLevel>(VAEncMiscParameterTypeQualityLevel, buf);
+
+    tu.quality_level = par.mfx.TargetUsage;
+}
+
+void AddVaMiscQualityParams(
+    const Glob::VideoParam::TRef& par
+    , std::list<std::vector<mfxU8>>& buf)
+{
+    const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+    auto& quality_param = AddVaMisc<VAEncMiscParameterEncQuality>(VAEncMiscParameterTypeEncQuality, buf);
+
+    quality_param.PanicModeDisable = IsOff(CO3.BRCPanicMode);
+}
+
+void CUQPMap::Init (mfxU32 picWidthInLumaSamples, mfxU32 picHeightInLumaSamples)
+{
+    //16x32 only: driver limitation
+    m_width        = (picWidthInLumaSamples  + 31) / 32;
+    m_height       = (picHeightInLumaSamples + 31) / 32;
+    m_pitch        = mfx::align2_value(m_width, 64);
+    m_h_aligned    = mfx::align2_value(m_height, 4);
+    m_block_width  = 32;
+    m_block_height = 32;
+    m_buffer.resize(m_pitch * m_h_aligned);
+    std::fill(m_buffer.begin(), m_buffer.end(), mfxI8(0));
+}
+
+static bool FillCUQPDataVA(
+    const Task::Common::TRef & task
+    , const Glob::VideoParam::TRef &par
+    , CUQPMap& cuqpMap)
+{
+    const mfxExtMBQP* mbqp = ExtBuffer::Get(task.ctrl);
+
+    bool bInitialized =
+        cuqpMap.m_width
+        && cuqpMap.m_height
+        && cuqpMap.m_block_width
+        && cuqpMap.m_block_height;
+
+    if (!bInitialized)
+        return false;
+
+    const mfxExtHEVCParam & HEVCParam = ExtBuffer::Get(par);
+
+    mfxU32 drBlkW = cuqpMap.m_block_width;  // block size of driver
+    mfxU32 drBlkH = cuqpMap.m_block_height;  // block size of driver
+    mfxU16 inBlkSize = 16;                    //mbqp->BlockSize ? mbqp->BlockSize : 16;  //input block size
+
+    mfxU32 inputW = CeilDiv(HEVCParam.PicWidthInLumaSamples, inBlkSize);
+    mfxU32 inputH = CeilDiv(HEVCParam.PicHeightInLumaSamples, inBlkSize);
+
+    bool bInvalid = !mbqp->QP || (mbqp->NumQPAlloc < inputW * inputH);
+    if (bInvalid)
+        return false;
+
+    for (mfxU32 i = 0; i < cuqpMap.m_height; i++)
+    {
+        for (mfxU32 j = 0; j < cuqpMap.m_width; j++)
+        {
+            mfxU32 y = i * drBlkH / inBlkSize;
+            mfxU32 x = j * drBlkW / inBlkSize;
+
+            y = (y < inputH) ? y : inputH;
+            x = (x < inputW) ? x : inputW;
+
+            cuqpMap.m_buffer[i * cuqpMap.m_pitch + j] = mbqp->QP[y * inputW + x];
+        }
+    }
+
+    return true;
+}
+
+void VAPacker::InitAlloc(const FeatureBlocks& /*blocks*/, TPushIA Push)
+{
+    Push(BLK_Init
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        auto& core = Glob::VideoCore::Get(strg);
+
+        const auto& par     = Glob::VideoParam::Get(strg);
+        const auto& bs_sps  = Glob::SPS::Get(strg);
+        const auto& bs_pps  = Glob::PPS::Get(strg);
+        
+        InitSPS(par, bs_sps, m_sps);
+        InitPPS(par, bs_pps, m_pps);
+        InitSSH(par, Glob::SliceInfo::Get(strg), m_slices);
+
+        AddVaMiscHRD(par, m_vaPerSeqMiscData);
+        AddVaMiscRC(par, bs_pps, m_vaPerSeqMiscData);
+        AddVaMiscPBRC(par, m_vaPerSeqMiscData);
+        AddVaMiscFR(par, m_vaPerSeqMiscData);
+        AddVaMiscTU(par, m_vaPerSeqMiscData);
+        AddVaMiscQualityParams(par, m_vaPerSeqMiscData);
+
+        auto& vaInitPar = Tmp::DDI_InitParam::GetOrConstruct(local);
+
+        std::for_each(m_vaPerSeqMiscData.begin(), m_vaPerSeqMiscData.end()
+            , [&](decltype(*m_vaPerSeqMiscData.begin()) data)
+        {
+            DDIExecParam par = {};
+            par.Function = VAEncMiscParameterBufferType;
+            par.In.pData = data.data();
+            par.In.Size  = (mfxU32)data.size();
+            par.In.Num   = 1;
+
+            vaInitPar.push_back(par);
+        });
+
+        const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par);
+
+        if (IsOn(CO3.EnableMBQP))
+        {
+            const mfxExtHEVCParam& HEVCPar = ExtBuffer::Get(par);
+            m_qpMap.Init(HEVCPar.PicWidthInLumaSamples, HEVCPar.PicHeightInLumaSamples);
+        }
+
+        auto MidToVA = [&core](mfxMemId mid)
+        {
+            VASurfaceID *pSurface = nullptr;
+            mfxStatus sts = core.GetFrameHDL(mid, (mfxHDL*)&pSurface);
+            ThrowIf(!!sts, sts);
+            return *pSurface;
+        };
+        auto& recResponse = Glob::AllocRec::Get(strg).Response();
+        auto& bsResponse = Glob::AllocBS::Get(strg).Response();
+
+        m_rec.resize(recResponse.NumFrameActual, VA_INVALID_SURFACE);
+        m_bs.resize(bsResponse.NumFrameActual, VA_INVALID_SURFACE);
+
+        mfxStatus sts = Catch(
+            MFX_ERR_NONE
+            , std::transform<mfxMemId*, VASurfaceID*, std::function<VASurfaceID(mfxMemId)>>
+            , recResponse.mids
+            , recResponse.mids + recResponse.NumFrameActual
+            , m_rec.data()
+            , MidToVA);
+        MFX_CHECK_STS(sts);
+
+        sts = Catch(
+            MFX_ERR_NONE
+            , std::transform<mfxMemId*, VASurfaceID*, std::function<VASurfaceID(mfxMemId)>>
+            , bsResponse.mids
+            , bsResponse.mids + bsResponse.NumFrameActual
+            , m_bs.data()
+            , MidToVA);
+        MFX_CHECK_STS(sts);
+
+        auto& resources = Glob::DDI_Resources::GetOrConstruct(strg);
+        DDIExecParam xPar = {};
+        xPar.Function = MFX_FOURCC_NV12;
+        xPar.Resource.pData = m_rec.data();
+        xPar.Resource.Size = sizeof(VASurfaceID);
+        xPar.Resource.Num = mfxU32(m_rec.size());
+        resources.push_back(xPar);
+        xPar.Function = MFX_FOURCC_P8;
+        xPar.Resource.pData = m_bs.data();
+        xPar.Resource.Size = sizeof(VABufferID);
+        xPar.Resource.Num = mfxU32(m_bs.size());
+        resources.push_back(xPar);
+
+        m_feedback.resize(Glob::AllocBS::Get(strg).Response().NumFrameActual);
+
+        Glob::DDI_SubmitParam::GetOrConstruct(strg);
+        auto& fb = Glob::DDI_Feedback::GetOrConstruct(strg);
+        fb.Out.pData = &m_feedbackTmp;
+        fb.Out.Size = sizeof(VACodedBufferSegment);
+        fb.Out.Num = 1;
+        fb.Get = [this](mfxU32 id) -> void*
+        {
+            if (!FeedbackReady(id))
+                return nullptr;
+            return &m_feedback.at(FeedbackIDWrap(id));
+        };
+        fb.Update = [this](mfxU32 id)
+        {
+            MFX_CHECK(!FeedbackReady(id), MFX_ERR_UNDEFINED_BEHAVIOR);
+            m_feedback[FeedbackIDWrap(id)] = m_feedbackTmp;
+            m_feedbackTmp = {};
+            FeedbackReady(id) = true;
+            return MFX_ERR_NONE;
+        };
+
+        auto& cc = CC::GetOrConstruct(strg);
+        cc.ReadFeedback.Push([](
+                CallChains::TReadFeedback::TExt
+                , const StorageR& global
+                , StorageW& s_task
+                , const VACodedBufferSegment& fb)
+        {
+            auto& bsInfo = Glob::AllocBS::Get(global).Info();
+
+            MFX_CHECK(!(fb.status & VA_CODED_BUF_STATUS_BAD_BITSTREAM), MFX_ERR_GPU_HANG);
+            MFX_CHECK(fb.buf && fb.size, MFX_ERR_DEVICE_FAILED);
+            MFX_CHECK(mfxU32(bsInfo.Width * bsInfo.Height) >= fb.size, MFX_ERR_DEVICE_FAILED);
+
+            Task::Common::Get(s_task).BsDataLength = fb.size;
+
+            return MFX_ERR_NONE;
+        });
+        cc.FillCUQPData.Push([](
+            CallChains::TFillCUQPData::TExt
+            , const StorageR& global
+            , const StorageR& s_task
+            , CUQPMap& qpmap)
+        {
+            auto& task = Task::Common::Get(s_task);
+            return task.bCUQPMap && FillCUQPDataVA(task, Glob::VideoParam::Get(global), qpmap);
+        });
+        cc.AddPerPicMiscData[VAEncMiscParameterTypeSkipFrame].Push([this](
+            CallChains::TAddMiscData::TExt
+            , const StorageR&
+            , const StorageR& s_task
+            , std::list<std::vector<mfxU8>>& data)
+        {
+            if (Task::Common::Get(s_task).SkipCMD & SKIPCMD_NeedNumSkipAdding)
+            {
+                auto& sf = AddVaMisc<VAEncMiscParameterSkipFrame>(VAEncMiscParameterTypeSkipFrame, data);
+                sf.num_skip_frames  = uint8_t(m_numSkipFrames);
+                sf.size_skip_frames = m_sizeSkipFrames;
+                sf.skip_frame_flag  = !!m_numSkipFrames;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void VAPacker::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
+{
+    Push(BLK_Reset
+        , [this](StorageRW& strg, StorageRW& local) -> mfxStatus
+    {
+        const auto& par = Glob::VideoParam::Get(strg);
+        const auto& bs_sps = Glob::SPS::Get(strg);
+        const auto& bs_pps = Glob::PPS::Get(strg);
+
+        InitSPS(par, bs_sps, m_sps);
+        InitPPS(par, bs_pps, m_pps);
+        InitSSH(par, Glob::SliceInfo::Get(strg), m_slices);
+
+        m_vaPerSeqMiscData.clear();
+
+        AddVaMiscHRD(par, m_vaPerSeqMiscData);
+        AddVaMiscRC(par, bs_pps, m_vaPerSeqMiscData, !!(Glob::ResetHint::Get(strg).Flags & RF_BRC_RESET));
+        AddVaMiscPBRC(par, m_vaPerSeqMiscData);
+        AddVaMiscFR(par, m_vaPerSeqMiscData);
+        AddVaMiscTU(par, m_vaPerSeqMiscData);
+        AddVaMiscQualityParams(par, m_vaPerSeqMiscData);
+
+        auto& vaInitPar = Tmp::DDI_InitParam::GetOrConstruct(local);
+        vaInitPar.clear();
+
+        std::for_each(m_vaPerSeqMiscData.begin(), m_vaPerSeqMiscData.end()
+            , [&](decltype(*m_vaPerSeqMiscData.begin()) data)
+        {
+            DDIExecParam par = {};
+            par.Function = VAEncMiscParameterBufferType;
+            par.In.pData = data.data();
+            par.In.Size = (mfxU32)data.size();
+            par.In.Num = 1;
+
+            vaInitPar.push_back(par);
+        });
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void UpdatePPS(
+    const TaskCommonPar & task
+    , const Slice & sh
+    , const std::vector<VASurfaceID> & rec
+    , VAEncPictureParameterBufferHEVC & pps)
+{
+    pps.pic_fields.bits.idr_pic_flag       = !!(task.FrameType & MFX_FRAMETYPE_IDR);
+    pps.pic_fields.bits.coding_type        = task.CodingType;
+    pps.pic_fields.bits.reference_pic_flag = !!(task.FrameType & MFX_FRAMETYPE_REF);
+
+    pps.collocated_ref_pic_index = 0xff;
+    if (sh.temporal_mvp_enabled_flag)
+        pps.collocated_ref_pic_index = task.RefPicList[!sh.collocated_from_l0_flag][sh.collocated_ref_idx];
+
+    pps.decoded_curr_pic.picture_id     = rec.at(task.Rec.Idx);
+    pps.decoded_curr_pic.pic_order_cnt  = task.POC;
+    pps.decoded_curr_pic.flags          = 0;
+
+    auto pDpbBegin = task.DPB.Active;
+    auto pDpbEnd   = task.DPB.Active + Size(task.DPB.Active);
+    auto pDpbValidEnd = std::find_if(pDpbBegin, pDpbEnd
+        , [](decltype(*pDpbBegin) ref) { return ref.Rec.Idx == IDX_INVALID; });
+
+    std::transform(pDpbBegin, pDpbValidEnd, pps.reference_frames
+        , [&](decltype(*pDpbBegin) ref)
+    {
+        VAPictureHEVC vaRef  = {};
+        vaRef.picture_id     = rec.at(ref.Rec.Idx);
+        vaRef.pic_order_cnt  = ref.POC;
+        vaRef.flags          = VA_PICTURE_HEVC_LONG_TERM_REFERENCE * !!ref.isLTR;
+        return vaRef;
+    });
+
+    VAPictureHEVC vaRefInvalid = {};
+    vaRefInvalid.picture_id = VA_INVALID_SURFACE;
+    vaRefInvalid.flags      = VA_PICTURE_HEVC_INVALID;
+
+    std::fill(
+        pps.reference_frames + (pDpbValidEnd - pDpbBegin)
+        , pps.reference_frames + Size(pps.reference_frames)
+        , vaRefInvalid);
+}
+
+void UpdateSlices(
+    const TaskCommonPar & task
+    , const Slice & sh
+    , const VAEncPictureParameterBufferHEVC & pps
+    , std::vector<VAEncSliceParameterBufferHEVC> & slices)
+{
+    std::for_each(slices.begin(), slices.end()
+        , [&](VAEncSliceParameterBufferHEVC& slice)
+    {
+        slice.slice_type                 = sh.type;
+        slice.slice_pic_parameter_set_id = pps.slice_pic_parameter_set_id;
+
+        if (slice.slice_type != 2)
+        {
+            slice.num_ref_idx_l0_active_minus1 = task.NumRefActive[0] - 1;
+
+            if (slice.slice_type == 0)
+                slice.num_ref_idx_l1_active_minus1 = task.NumRefActive[1] - 1;
+            else
+                slice.num_ref_idx_l1_active_minus1 = 0;
+
+        }
+        else
+            slice.num_ref_idx_l0_active_minus1 = slice.num_ref_idx_l1_active_minus1 = 0;
+
+
+        VAPictureHEVC vaRefInvalid = {};
+        vaRefInvalid.picture_id = VA_INVALID_SURFACE;
+        vaRefInvalid.flags      = VA_PICTURE_HEVC_INVALID;
+
+        auto GetRef = [&](mfxU8 idx)
+        {
+            if (idx < Size(pps.reference_frames))
+                return pps.reference_frames[idx];
+            return vaRefInvalid;
+        };
+
+        std::fill(slice.ref_pic_list0, slice.ref_pic_list0 + Size(slice.ref_pic_list0), vaRefInvalid);
+        std::fill(slice.ref_pic_list1, slice.ref_pic_list1 + Size(slice.ref_pic_list1), vaRefInvalid);
+
+        std::transform(
+            task.RefPicList[0]
+            , task.RefPicList[0] + task.NumRefActive[0]
+            , slice.ref_pic_list0
+            , GetRef);
+        std::transform(
+            task.RefPicList[1]
+            , task.RefPicList[1] + task.NumRefActive[1]
+            , slice.ref_pic_list1
+            , GetRef);
+
+        slice.max_num_merge_cand     = 5 - sh.five_minus_max_num_merge_cand;
+        slice.slice_qp_delta         = sh.slice_qp_delta;
+        slice.slice_cb_qp_offset     = sh.slice_cb_qp_offset;
+        slice.slice_cr_qp_offset     = sh.slice_cr_qp_offset;
+        slice.slice_beta_offset_div2 = sh.beta_offset_div2;
+        slice.slice_tc_offset_div2   = sh.tc_offset_div2;
+
+        slice.slice_fields.bits.dependent_slice_segment_flag          = sh.dependent_slice_segment_flag;
+        slice.slice_fields.bits.slice_temporal_mvp_enabled_flag       = sh.temporal_mvp_enabled_flag;
+        slice.slice_fields.bits.slice_sao_luma_flag                   = sh.sao_luma_flag;
+        slice.slice_fields.bits.slice_sao_chroma_flag                 = sh.sao_chroma_flag;
+        slice.slice_fields.bits.num_ref_idx_active_override_flag =
+                slice.num_ref_idx_l0_active_minus1 != pps.num_ref_idx_l0_default_active_minus1 ||
+                slice.num_ref_idx_l1_active_minus1 != pps.num_ref_idx_l1_default_active_minus1;
+        slice.slice_fields.bits.mvd_l1_zero_flag                      = sh.mvd_l1_zero_flag;
+        slice.slice_fields.bits.cabac_init_flag                       = sh.cabac_init_flag;
+        slice.slice_fields.bits.slice_deblocking_filter_disabled_flag = sh.deblocking_filter_disabled_flag;
+        slice.slice_fields.bits.collocated_from_l0_flag               = sh.collocated_from_l0_flag;
+    });
+}
+
+bool AddPackedHeaderIf(
+    bool cond
+    , const PackedData pd
+    , std::list<VAEncPackedHeaderParameterBuffer>& vaPhs
+    , std::list<DDIExecParam>& par
+    , uint32_t type = VAEncPackedHeaderRawData)
+{
+    if (!cond)
+        return false;
+
+    VAEncPackedHeaderParameterBuffer vaPh = {};
+    vaPh.type                = type;
+    vaPh.bit_length          = pd.BitLen;
+    vaPh.has_emulation_bytes = pd.bHasEP;
+    vaPhs.push_back(vaPh);
+
+    DDIExecParam xPar;
+    xPar.Function = VAEncPackedHeaderParameterBufferType;
+    xPar.In.pData = &vaPhs.back();
+    xPar.In.Size  = sizeof(VAEncPackedHeaderParameterBuffer);
+    xPar.In.Num   = 1;
+    par.push_back(xPar);
+
+    xPar.Function = VAEncPackedHeaderDataBufferType;
+    xPar.In.pData = pd.pData;
+    xPar.In.Size  = pd.BitLen / 8;
+    xPar.In.Num   = 1;
+    par.push_back(xPar);
+
+    return true;
+}
+
+void VAPacker::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
+{
+    Push(BLK_SubmitTask
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& task      = Task::Common::Get(s_task);
+        bool  bSkipCurr =
+            !(task.SkipCMD & SKIPCMD_NeedDriverCall)
+            && (task.SkipCMD & SKIPCMD_NeedCurrentFrameSkipping);
+
+        m_numSkipFrames  += !!(task.SkipCMD & SKIPCMD_NeedNumSkipAdding) * task.ctrl.SkipFrame;
+        m_numSkipFrames  += bSkipCurr;
+        m_sizeSkipFrames += bSkipCurr * task.BsDataLength;
+
+        MFX_CHECK(task.SkipCMD & SKIPCMD_NeedDriverCall, MFX_ERR_NONE);
+
+        auto& sh = Task::SSH::Get(s_task);
+        auto& ph = Glob::PackedHeaders::Get(global);
+
+        if (task.RepackHeaders & INSERT_PPS)
+        {
+            InitPPS(Glob::VideoParam::Get(global), Glob::PPS::Get(global), m_pps);
+        }
+
+        UpdatePPS(task, sh, m_rec, m_pps);
+        UpdateSlices(task, sh, m_pps, m_slices);
+
+        MFX_CHECK(task.BS.Idx < m_bs.size(), MFX_ERR_UNKNOWN);
+        m_pps.coded_buf = m_bs.at(task.BS.Idx);
+
+        auto& cc  = CC::Get(global);
+        auto& par = Glob::DDI_SubmitParam::Get(global);
+        par.clear();
+
+        auto AddBuffer = [&](VABufferType type, void* pData, mfxU32 size, mfxU32 num = 1)
+        {
+            DDIExecParam xPar = {};
+            xPar.Function = type;
+            xPar.In.pData = pData;
+            xPar.In.Size  = size;
+            xPar.In.Num   = num;
+            par.push_back(xPar);
+        };
+        auto AddMiscBuffer = [&](std::vector<mfxU8>& misc)
+        {
+            AddBuffer(VAEncMiscParameterBufferType, misc.data(), (mfxU32)misc.size());
+        };
+        
+        AddBuffer(VAEncSequenceParameterBufferType, &m_sps, sizeof(m_sps));
+        AddBuffer(VAEncPictureParameterBufferType, &m_pps, sizeof(m_pps));
+
+        std::for_each(m_slices.begin(), m_slices.end()
+            , [&](VAEncSliceParameterBufferHEVC& s)
+        {
+            AddBuffer(VAEncSliceParameterBufferType, &s, sizeof(s));
+        });
+
+        if (cc.FillCUQPData(global, s_task, m_qpMap))
+        {
+            AddBuffer(
+                VAEncQPBufferType
+                , m_qpMap.m_buffer.data()
+                , m_qpMap.m_pitch
+                , m_qpMap.m_h_aligned);
+        }
+
+        m_vaPerPicMiscData.clear();
+        m_vaPackedHeaders.clear();
+
+        AddPackedHeaderIf(!!(task.InsertHeaders & INSERT_AUD)
+            , ph.AUD[mfx::clamp<mfxU8>(task.CodingType, 1, 3) - 1], m_vaPackedHeaders, par);
+
+        AddPackedHeaderIf(!!(task.InsertHeaders & INSERT_VPS)
+            , ph.VPS, m_vaPackedHeaders, par, VAEncPackedHeaderHEVC_VPS);
+
+        AddPackedHeaderIf(!!(task.InsertHeaders & INSERT_SPS)
+            , ph.SPS, m_vaPackedHeaders, par, VAEncPackedHeaderHEVC_SPS);
+
+        AddPackedHeaderIf(!!(task.InsertHeaders & INSERT_PPS)
+            , ph.PPS, m_vaPackedHeaders, par, VAEncPackedHeaderHEVC_PPS);
+
+        AddPackedHeaderIf((!!(task.InsertHeaders & INSERT_SEI) || task.ctrl.NumPayload) && ph.PrefixSEI.BitLen
+            , ph.PrefixSEI, m_vaPackedHeaders, par/*, VAEncPackedHeaderHEVC_SEI*/);
+
+        std::for_each(
+            ph.SSH.begin()
+            , ph.SSH.begin() + std::min<size_t>(m_slices.size(), ph.SSH.size())
+            , [&](PackedData& pd)
+        {
+            AddPackedHeaderIf(true, pd, m_vaPackedHeaders, par, VAEncPackedHeaderHEVC_Slice);
+        });
+
+        for (auto& AddMisc : cc.AddPerPicMiscData)
+        {
+            if (AddMisc.second(global, s_task, m_vaPerPicMiscData))
+                AddMiscBuffer(m_vaPerPicMiscData.back());
+        }
+
+        m_numSkipFrames  = 0;
+        m_sizeSkipFrames = 0;
+
+        return MFX_ERR_NONE;
+    });
+}
+
+void VAPacker::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
+{
+    Push(BLK_QueryTask
+        , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        MFX_CHECK(!Glob::DDI_Feedback::Get(global).bNotReady, MFX_TASK_BUSY);
+
+        auto& task = Task::Common::Get(s_task);
+
+        if (!(task.SkipCMD & SKIPCMD_NeedDriverCall))
+            return MFX_ERR_NONE;
+
+        MFX_CHECK(FeedbackReady(task.StatusReportId), MFX_TASK_BUSY);
+
+        auto& fb    = m_feedback.at(FeedbackIDWrap(task.StatusReportId));
+        auto& rtErr = Glob::RTErr::Get(global);
+
+        auto sts = CC::Get(global).ReadFeedback(global, s_task, fb);
+        SetIf(rtErr, sts < MFX_ERR_NONE, sts);
+
+        FeedbackReady(task.StatusReportId) = false;
+
+        return sts;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_packer_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_va_packer_lin.h
@@ -1,0 +1,143 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#include "hevcehw_base.h"
+
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11_data.h"
+#include "hevcehw_g11_iddi_packer.h"
+#include "va/va.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+using namespace HEVCEHW::Gen11;
+
+template<class T>
+T& AddVaMisc(
+    VAEncMiscParameterType type
+    , std::list<std::vector<mfxU8>>& buf)
+{
+    const size_t szH = sizeof(VAEncMiscParameterBuffer);
+    const size_t szB = sizeof(T);
+    buf.push_back(std::vector<mfxU8>(szH + szB, 0));
+    auto pMisc = (VAEncMiscParameterBuffer*)buf.back().data();
+    pMisc->type = type;
+    return *(T*)(buf.back().data() + szH);
+}
+
+class CUQPMap
+{
+public:
+    mfxU32                            m_width;
+    mfxU32                            m_height;
+    mfxU32                            m_pitch;
+    mfxU32                            m_h_aligned;
+
+    mfxU32                            m_block_width;
+    mfxU32                            m_block_height;
+    std::vector<mfxI8>                m_buffer;
+
+    CUQPMap() :
+        m_width(0),
+        m_height(0),
+        m_pitch(0),
+        m_h_aligned(0),
+        m_block_width(0),
+        m_block_height(0) {}
+
+    void Init(mfxU32 picWidthInLumaSamples, mfxU32 picHeightInLumaSamples);
+};
+
+class VAPacker
+    : public virtual FeatureBase
+    , protected IDDIPacker
+{
+public:
+    VAPacker(mfxU32 FeatureId)
+        : FeatureBase(FeatureId)
+        , IDDIPacker(FeatureId)
+    {
+        SetTraceName("G11_VAPacker");
+    }
+
+    struct CallChains
+        : Storable
+    {
+        using TReadFeedback = CallChain<mfxStatus
+            , const StorageR& //glob
+            , StorageW& //task
+            , const VACodedBufferSegment&>;
+        TReadFeedback ReadFeedback;
+
+        using TFillCUQPData = CallChain<bool
+            , const StorageR& //glob
+            , const StorageR& //task
+            , CUQPMap&>;
+        TFillCUQPData FillCUQPData;
+
+        using TAddMiscData = CallChain<bool
+            , const StorageR& //glob
+            , const StorageR& //task
+            , std::list<std::vector<mfxU8>>&>;
+        std::map<VAEncMiscParameterType, TAddMiscData> AddPerPicMiscData;
+    };
+
+    using CC = StorageVar<Gen11::Glob::ReservedKey0, CallChains>;
+
+protected:
+    virtual void Query1WithCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+    virtual void InitAlloc(const FeatureBlocks& blocks, TPushIA Push) override;
+    virtual void SubmitTask(const FeatureBlocks& blocks, TPushST Push) override;
+    virtual void QueryTask(const FeatureBlocks& blocks, TPushQT Push) override;
+    virtual void ResetState(const FeatureBlocks& blocks, TPushRS Push) override;
+
+
+    inline mfxU32 FeedbackIDWrap(mfxU32 id) { return (id % m_feedback.size()); }
+    inline bool& FeedbackReady(mfxU32 id) { return m_fbReady[FeedbackIDWrap(id)]; }
+
+    VAEncSequenceParameterBufferHEVC            m_sps;
+    VAEncPictureParameterBufferHEVC             m_pps;
+    std::vector<VAEncSliceParameterBufferHEVC>  m_slices;
+    std::vector<VASurfaceID>                    m_rec;
+    std::vector<VABufferID>                     m_bs;
+    std::vector<VACodedBufferSegment>           m_feedback;
+    VACodedBufferSegment                        m_feedbackTmp = {};
+    std::map<mfxU32, bool>                      m_fbReady;
+    std::list<std::vector<mfxU8>>               m_vaPerSeqMiscData;
+    std::list<std::vector<mfxU8>>               m_vaPerPicMiscData;
+    std::list<VAEncPackedHeaderParameterBuffer> m_vaPackedHeaders;
+    CUQPMap                                     m_qpMap;
+    mfxU32                                      m_numSkipFrames = 0;
+    mfxU32                                      m_sizeSkipFrames = 0;
+};
+
+} //Gen11
+} //Linux
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_weighted_prediction_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_weighted_prediction_lin.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11_weighted_prediction_lin.h"
+#include "hevcehw_g11_va_packer_lin.h"
+#include "va/va.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen11;
+
+void Linux::Gen11::WeightPred::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) 
+{
+    Push(BLK_PatchDDITask
+            , [this](StorageW& global, StorageW& s_task) -> mfxStatus
+    {
+        auto& esSlice = Task::SSH::Get(s_task);
+        auto& ddiPar  = Glob::DDI_SubmitParam::Get(global);
+        auto  itPPS   = std::find_if(std::begin(ddiPar), std::end(ddiPar)
+            , [](DDIExecParam& ep) { return (ep.Function == VAEncPictureParameterBufferType); });
+
+        MFX_CHECK(itPPS != std::end(ddiPar) && itPPS->In.pData, MFX_ERR_UNKNOWN);
+
+        auto& ddiPPS    = *(VAEncPictureParameterBufferHEVC*)itPPS->In.pData;
+        bool bNeedPWT   = (esSlice.type != 2
+            && (ddiPPS.pic_fields.bits.weighted_bipred_flag || ddiPPS.pic_fields.bits.weighted_pred_flag));
+        MFX_CHECK(bNeedPWT, MFX_ERR_NONE);
+
+        auto SetPWT = [&](VAEncSliceParameterBufferHEVC& slice)
+        {
+            const mfxU16 Y = 0, Cb = 1, Cr = 2, Weight = 0, Offset = 1;
+
+            slice.luma_log2_weight_denom         = (mfxU8)esSlice.luma_log2_weight_denom;
+            slice.delta_chroma_log2_weight_denom = (mfxI8)(esSlice.chroma_log2_weight_denom - slice.luma_log2_weight_denom);
+
+            mfxI16 wY = (1 << slice.luma_log2_weight_denom);
+            mfxI16 wC = (1 << esSlice.chroma_log2_weight_denom);
+
+            for (mfxU16 i = 0; i < 15; i++)
+            {
+                slice.luma_offset_l0[i]            = (mfxI8)esSlice.pwt[0][i][Y][Offset];
+                slice.delta_luma_weight_l0[i]      = (mfxI8)(esSlice.pwt[0][i][Y][Weight] - wY);
+                slice.chroma_offset_l0[i][0]       = (mfxI8)esSlice.pwt[0][i][Cb][Offset];
+                slice.chroma_offset_l0[i][1]       = (mfxI8)esSlice.pwt[0][i][Cr][Offset];
+                slice.delta_chroma_weight_l0[i][0] = (mfxI8)(esSlice.pwt[0][i][Cb][Weight] - wC);
+                slice.delta_chroma_weight_l0[i][1] = (mfxI8)(esSlice.pwt[0][i][Cr][Weight] - wC);
+                slice.luma_offset_l1[i]            = (mfxI8)esSlice.pwt[1][i][Y][Offset];
+                slice.delta_luma_weight_l1[i]      = (mfxI8)(esSlice.pwt[1][i][Y][Weight] - wY);
+                slice.chroma_offset_l1[i][0]       = (mfxI8)esSlice.pwt[1][i][Cb][Offset];
+                slice.chroma_offset_l1[i][1]       = (mfxI8)esSlice.pwt[1][i][Cr][Offset];
+                slice.delta_chroma_weight_l1[i][0] = (mfxI8)(esSlice.pwt[1][i][Cb][Weight] - wC);
+                slice.delta_chroma_weight_l1[i][1] = (mfxI8)(esSlice.pwt[1][i][Cr][Weight] - wC);
+            }
+        };
+
+        std::for_each(std::begin(ddiPar), std::end(ddiPar)
+            , [&](DDIExecParam& ep)
+        {
+            if (ep.Function != VAEncSliceParameterBufferType)
+                return;
+
+            auto pBegin = (VAEncSliceParameterBufferHEVC*)ep.In.pData;
+            auto pEnd   = pBegin + (std::max<mfxU32>(ep.In.Num, 1) * !!pBegin);
+
+            assert(ep.In.Size == sizeof(VAEncSliceParameterBufferHEVC));
+
+            std::for_each(pBegin, pEnd, SetPWT);
+        });
+
+        return MFX_ERR_NONE;
+    });
+}
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_weighted_prediction_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g11/hevcehw_g11_weighted_prediction_lin.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION) && defined (MFX_VA_LINUX)
+#include "hevcehw_g11_weighted_prediction.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen11
+{
+    class WeightPred
+        : public HEVCEHW::Gen11::WeightPred
+    {
+    public:
+        WeightPred(mfxU32 FeatureId)
+            : HEVCEHW::Gen11::WeightPred(FeatureId)
+        {}
+
+    protected:
+
+        void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
+    };
+
+} //Gen11Win
+} //Linux
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_caps_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_caps_lin.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_base.h"
+#include "hevcehw_g12_caps.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen12
+{
+class Caps
+    : public HEVCEHW::Gen12::Caps
+{
+public:
+    Caps(mfxU32 FeatureId)
+        : HEVCEHW::Gen12::Caps(FeatureId)
+    {}
+
+protected:
+    virtual void SetSpecificCaps(HEVCEHW::Gen11::EncodeCapsHevc& caps) override
+    {
+        caps.CodingLimitSet             = 1;
+        caps.Color420Only               = 0;
+        caps.SliceIPBOnly               = 1;
+        caps.NoMinorMVs                 = 1;
+        caps.RawReconRefToggle          = 1;
+        caps.NoInterlacedField          = 1;
+        caps.ParallelBRC                = 1;
+        caps.MaxEncodedBitDepth         = 2;
+        caps.MaxPicWidth                = 16384;
+        caps.MaxPicHeight               = 16384;
+        caps.MaxNumOfROI                = 16;
+        caps.ROIDeltaQPSupport          = 1;
+        caps.BlockSize                  = 1;
+        caps.SliceLevelReportSupport    = 1;
+        caps.FrameSizeToleranceSupport  = 1;
+        caps.NumScalablePipesMinus1     = 1;
+        caps.NoWeightedPred             = 0;
+        caps.LumaWeightedPred           = 1;
+        caps.ChromaWeightedPred         = 0;
+        caps.MaxNum_WeightedPredL0      = 4;
+        caps.MaxNum_WeightedPredL1      = 2;
+        caps.HRDConformanceSupport      = 1;
+        caps.TileSupport                = 1;
+        caps.YUV422ReconSupport         = 1;
+        caps.IntraRefreshBlockUnitSize  = 2;
+    }
+};
+
+} //Gen12
+} //Linux
+} //namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_lin.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g12_lin.h"
+#if (MFX_VERSION >= 1031)
+#include "hevcehw_g12_rext_lin.h"
+#endif
+#include "hevcehw_g12_caps_lin.h"
+#include "hevcehw_g12_sao.h"
+#include "hevcehw_g11_legacy.h"
+#include "hevcehw_g11_iddi_packer.h"
+#include "hevcehw_g11_iddi.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen12
+{
+using namespace HEVCEHW::Gen12;
+
+MFXVideoENCODEH265_HW::MFXVideoENCODEH265_HW(
+    VideoCORE& core
+    , mfxStatus& status
+    , eFeatureMode mode)
+    : TBaseGen(core, status, mode)
+{
+    TFeatureList newFeatures;
+
+#if (MFX_VERSION >= 1031)
+    newFeatures.emplace_back(new RExt(FEATURE_REXT));
+#endif
+    newFeatures.emplace_back(new Caps(FEATURE_CAPS));
+    newFeatures.emplace_back(new SAO(FEATURE_SAO));
+
+    InternalInitFeatures(status, mode, newFeatures);
+}
+
+void MFXVideoENCODEH265_HW::InternalInitFeatures(
+    mfxStatus& status
+    , eFeatureMode mode
+    , TFeatureList& newFeatures)
+{
+    status = MFX_ERR_UNKNOWN;
+
+    for (auto& pFeature : newFeatures)
+        pFeature->Init(mode, *this);
+
+    TBaseGen::m_features.splice(TBaseGen::m_features.end(), newFeatures);
+
+    if (mode & (QUERY1 | QUERY_IO_SURF | INIT))
+    {
+        auto& qnc = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1NoCaps>::Get(*this);
+
+        FeatureBlocks::Reorder(
+            qnc
+            , { HEVCEHW::Gen11::FEATURE_LEGACY, HEVCEHW::Gen11::Legacy::BLK_SetLowPowerDefault }
+            , { FEATURE_CAPS, Caps::BLK_SetDefaultsCallChain });
+
+        auto& qwc = FeatureBlocks::BQ<FeatureBlocks::BQ_Query1WithCaps>::Get(*this);
+#if (MFX_VERSION >= 1031)
+        FeatureBlocks::Reorder(
+            qwc
+            , { HEVCEHW::Gen11::FEATURE_DDI_PACKER, HEVCEHW::Gen11::IDDIPacker::BLK_HardcodeCaps }
+            , { FEATURE_REXT, RExt::BLK_HardcodeCaps });
+#endif
+        FeatureBlocks::Reorder(
+            qwc
+            , { HEVCEHW::Gen11::FEATURE_DDI_PACKER, HEVCEHW::Gen11::IDDIPacker::BLK_HardcodeCaps }
+            , { FEATURE_CAPS, Caps::BLK_HardcodeCaps });
+    }
+
+    status = MFX_ERR_NONE;
+}
+
+} //namespace Linux
+} //namespace Gen12
+} //namespace HEVCEHW
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_lin.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX)
+
+#include "hevcehw_g11_lin.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen12
+{
+    class MFXVideoENCODEH265_HW
+        : public Linux::Gen11::MFXVideoENCODEH265_HW
+    {
+    public:
+        using TBaseGen = Linux::Gen11::MFXVideoENCODEH265_HW;
+    
+        MFXVideoENCODEH265_HW(
+            VideoCORE& core
+            , mfxStatus& status
+            , eFeatureMode mode = eFeatureMode::INIT);
+
+    protected:
+        using TFeatureList = HEVCEHW::Gen11::MFXVideoENCODEH265_HW::TFeatureList;
+
+        void InternalInitFeatures(
+            mfxStatus& status
+            , eFeatureMode mode
+            , TFeatureList& newFeatures);
+    };
+
+} //Gen12
+} //namespace Linux
+}// namespace HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_rext_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_rext_lin.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX) && (MFX_VERSION >= 1031)
+
+#include "hevcehw_g12_rext_lin.h"
+#include "va/va.h"
+
+using namespace HEVCEHW;
+using namespace HEVCEHW::Gen12;
+using namespace HEVCEHW::Linux;
+
+void Linux::Gen12::RExt::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
+{
+    Push(BLK_SetGUID
+        , [this](const mfxVideoParam&, mfxVideoParam& par, StorageRW& strg) -> mfxStatus
+    {
+        //don't change GUID in Reset
+        MFX_CHECK(!strg.Contains(Glob::RealState::Key), MFX_ERR_NONE);
+
+        auto& g2va = Glob::GuidToVa::GetOrConstruct(strg);
+        g2va[DXVA2_Intel_Encode_HEVC_Main12]     = { VAProfileHEVCMain12,     VAEntrypointEncSlice };
+        g2va[DXVA2_Intel_Encode_HEVC_Main422_12] = { VAProfileHEVCMain422_12, VAEntrypointEncSlice };
+        g2va[DXVA2_Intel_Encode_HEVC_Main444_12] = { VAProfileHEVCMain444_12, VAEntrypointEncSlice };
+
+        return SetGuid(par, strg);
+    });
+}
+
+
+#endif //defined(MFX_ENABLE_H265_VIDEO_ENCODE)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_rext_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_rext_lin.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#if defined(MFX_ENABLE_H265_VIDEO_ENCODE) && defined (MFX_VA_LINUX) && (MFX_VERSION >= 1031)
+
+#include "hevcehw_g12_rext.h"
+
+namespace HEVCEHW
+{
+namespace Linux
+{
+namespace Gen12
+{
+class RExt
+    : public HEVCEHW::Gen12::RExt
+{
+public:
+
+    RExt(mfxU32 FeatureId)
+        : HEVCEHW::Gen12::RExt(FeatureId)
+    {}
+
+protected:
+    virtual void Query1NoCaps(const FeatureBlocks& blocks, TPushQ1 Push) override;
+};
+
+} //Linux
+} //Gen12
+} //HEVCEHW
+
+#endif

--- a/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_base.h
+++ b/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_base.h
@@ -1,0 +1,222 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+#include "mfx_feature_blocks_utils.h"
+
+#include <list>
+#include <map>
+#include <exception>
+#include <functional>
+
+namespace MfxFeatureBlocks
+{
+
+enum eFeatureMode
+{
+      QUERY0        = (1 << 0)
+    , QUERY1        = (1 << 1)
+    , QUERY_IO_SURF = (1 << 2)
+    , INIT          = (1 << 3)
+    , RUNTIME       = (1 << 4)
+};
+
+enum eReorderLoc
+{
+    PLACE_BEFORE
+    , PLACE_AFTER
+};
+
+struct ParamSupport
+{
+    std::list<std::function<void(const mfxVideoParam*, mfxVideoParam*)>>
+        m_mvpCopySupported;
+    std::map<mfxU32, std::list<std::function<void(const mfxExtBuffer*, mfxExtBuffer*)>>>
+        m_ebCopySupported
+        , m_ebCopyPtrs;
+};
+
+struct ParamInheritance //for Reset
+{
+    std::list<std::function<void(const mfxVideoParam*, mfxVideoParam*)>>
+        m_mvpInheritDefault;
+    std::map<mfxU32, std::list<std::function<void(const mfxVideoParam&, const mfxExtBuffer*, const mfxVideoParam&, mfxExtBuffer*)>>>
+        m_ebInheritDefault;
+};
+
+struct ID
+{
+    mfxU32 FeatureID;
+    mfxU32 BlockID;
+
+    bool operator==(const ID other) const
+    {
+        return
+            FeatureID == other.FeatureID
+            && BlockID == other.BlockID;
+    }
+
+    bool operator<(const ID other) const
+    {
+        if (FeatureID < other.FeatureID)
+            return true;
+        return BlockID < other.BlockID;
+    }
+};
+
+template<class TBlockTracer>
+class FeatureBlocksCommon
+    : public ParamSupport
+    , public ParamInheritance
+{
+public:
+    using ID = MfxFeatureBlocks::ID;
+
+    virtual ~FeatureBlocksCommon() {}
+
+    template<class T>
+    struct Block : ID
+    {
+        typedef T TCall;
+
+        Block(
+            const ID id
+            , TCall&& call
+            , const char* fName = nullptr
+            , const char* bName = nullptr)
+            : ID(id)
+            , m_featureName(fName)
+            , m_blockName(bName)
+            , m_call(std::move(call))
+        {}
+
+        template<class... TArg>
+        typename TCall::result_type Call(TArg&& ...arg) const
+        {
+            TBlockTracer tr(*this, m_featureName, m_blockName);
+            return m_call(std::forward<TArg>(arg)...);
+        }
+
+        const char* m_featureName;
+        const char* m_blockName;
+        TCall m_call;
+    };
+
+    template<class T>
+    static typename std::conditional<std::is_const<T>::value
+            , typename T::const_iterator, typename T::iterator>::type
+    Find(T& queue, const ID id)
+    {
+        return std::find_if(
+            queue.begin()
+            , queue.end()
+            , [id](const ID x) {
+            return (x == id);
+        });
+    }
+
+    template<class T>
+    static typename std::conditional<std::is_const<T>::value
+        , typename T::const_iterator, typename T::iterator>::type
+    Get(T& queue, const ID id)
+    {
+        auto it = Find(queue, id);
+        if (it == queue.end())
+            throw std::logic_error("Block not found");
+        return it;
+    }
+
+    template<class T>
+    void Reorder(T& queue, const ID _where, const ID _first, eReorderLoc loc = PLACE_BEFORE)
+    {
+        auto itWhere = Get(queue, _where);
+        if (loc == PLACE_AFTER)
+            itWhere++;
+        queue.splice(itWhere, queue, Get(queue, _first));
+    }
+
+    mfxU32 Init(mfxU32 FeatureID, mfxU32 mode)
+    {
+        mfxU32 prevMode = m_initialized[FeatureID];
+        m_initialized[FeatureID] |= mode;
+        return prevMode;
+    }
+
+    virtual const char* GetFeatureName(mfxU32 /*featureID*/) { return nullptr; }
+    virtual const char* GetBlockName(ID /*id*/) { return nullptr; }
+
+    std::map<mfxU32, mfxU32> m_initialized; //FeatureID -> FeatureMode
+};
+
+class IBlockTracer
+{
+public:
+    IBlockTracer(
+        ID /*id*/
+        , const char* /*fName = nullptr*/
+        , const char* /*bName = nullptr*/)
+    {}
+    virtual ~IBlockTracer()
+    {}
+};
+
+template<class TFeatureBlocks>
+class FeatureBaseCommon
+{
+public:
+    FeatureBaseCommon() = delete;
+    virtual ~FeatureBaseCommon() {}
+
+    virtual void Init(
+        mfxU32 mode/*eFeatureMode*/
+        , TFeatureBlocks& blocks) = 0;
+
+    mfxU32 GetID() const { return m_id; }
+
+protected:
+    virtual void SetSupported(ParamSupport& /*par*/) {}
+    virtual void SetInherited(ParamInheritance& /*par*/) {}
+
+    FeatureBaseCommon(mfxU32 id)
+        : m_id(id)
+    {}
+
+    template<class T, class TFeatureBase>
+    using TPfnInitQueue = void (TFeatureBase::*)(const TFeatureBlocks&, T);
+
+    template<mfxU32 ABR, class T, class TFeatureBase>
+    bool InitQueue(
+        TPfnInitQueue<T, TFeatureBase> pfnFunc
+        , TFeatureBlocks& blocks)
+    {
+        (dynamic_cast<TFeatureBase&>(*this).*pfnFunc)(blocks
+            , [&](mfxU32 blkId, typename TFeatureBlocks::template BQ<ABR>::TCall&& call)
+        {
+            blocks.template Push<ABR>(ID{ m_id, blkId }, std::move(call));
+        });
+        return true;
+    }
+    
+    mfxU32 m_id;
+};
+
+}; //namespace MfxFeatureBlocks

--- a/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_decl_blocks.h
+++ b/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_decl_blocks.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if !defined(DECL_BLOCK_LIST) || !defined(DECL_FEATURE_NAME)
+    #error "Invalid usage of " __FILE__ ": DECL_BLOCK_LIST and DECL_FEATURE_NAME must be defined"
+#endif
+
+    enum eBlockId
+    {
+        __FIRST_MINUS1 = -1
+    #define DECL_BLOCK(NAME) , BLK_##NAME
+        DECL_BLOCK_LIST
+    #undef DECL_BLOCK
+        , NUM_BLOCKS
+    };
+
+#if !defined DECL_BLOCK_CLEANUP_DISABLE
+    #undef DECL_BLOCK_LIST
+    #undef DECL_FEATURE_NAME
+#endif
+

--- a/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_init_macros.h
+++ b/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_init_macros.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#define MFX_FEATURE_BLOCKS_DECLARE_BQ_UTILS_IN_FEATURE_BLOCK \
+template<class T> void Push(T& queue, const ID id, typename T::value_type::TCall&& call) \
+{                                                                           \
+    queue.emplace_back(typename T::value_type(id, std::move(call)           \
+        , GetFeatureName(id.FeatureID), GetBlockName(id)));                 \
+}                                                                           \
+template<mfxU32 QID> struct BQ {};                                          \
+template<mfxU32 QID> void Push(const ID id, typename BQ<QID>::TCall&& call) \
+{                                                                           \
+    BQ<QID>::Push(*this, id, std::move(call));                              \
+}
+
+#define MFX_FEATURE_BLOCKS_DECLARE_QUEUES_IN_FEATURE_BLOCK(NAME, ABR, RTYPE, ...)\
+    static const mfxU32 BQ_##NAME = __LINE__;\
+    std::list<Block<std::function<RTYPE(__VA_ARGS__)>>> m_q##NAME;
+
+#define MFX_FEATURE_BLOCKS_DECLARE_QUEUES_EXTERNAL(NAME, ABR, RTYPE, ...)\
+template<> struct FeatureBlocks::BQ <FeatureBlocks::BQ_##NAME>\
+{\
+    typedef std::function<RTYPE(__VA_ARGS__)> TCall;\
+    typedef std::list<FeatureBlocks::Block<TCall>> TQueue;\
+    static TQueue& Get(FeatureBlocks& blk) { return blk.m_q##NAME;}\
+    static const TQueue& Get(const FeatureBlocks& blk) { return blk.m_q##NAME;}\
+    static void Push(FeatureBlocks& blks, const ID id, TCall&& call)\
+    { blks.Push(blks.m_q##NAME, id, std::move(call)); }\
+};
+
+#define MFX_FEATURE_BLOCKS_DECLARE_QUEUES_IN_FEATURE_BASE(NAME, ABR, RTYPE, ...)\
+    static const mfxU32 ABR = FeatureBlocks::BQ_##NAME;\
+    typedef FeatureBlocks::BQ<ABR>::TCall TCall##ABR;\
+    typedef std::function<void(mfxU32 blkId, TCall##ABR&&)> TPush##ABR;\
+    virtual void NAME(const FeatureBlocks&, TPush##ABR) {}

--- a/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_utils.h
+++ b/_studio/mfx_lib/shared/include/feature_blocks/mfx_feature_blocks_utils.h
@@ -1,0 +1,301 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mfx_common.h"
+
+#include "mfxvideo.h"
+#include <memory>
+#include <map>
+#include <list>
+#include <exception>
+#include <functional>
+#include <algorithm>
+#include <assert.h>
+
+namespace MfxFeatureBlocks
+{
+
+struct Storable
+{
+    virtual ~Storable() {}
+};
+
+template<class T>
+class StorableRef
+    : public Storable
+    , public std::reference_wrapper<T>
+{
+public:
+    StorableRef(T& ref)
+        : std::reference_wrapper<T>(ref)
+    {}
+};
+
+template<class T>
+class MakeStorable
+    : public T
+    , public StorableRef<T>
+{
+public:
+    template<class... TArg>
+    MakeStorable(TArg&& ...arg)
+        : T(std::forward<TArg>(arg)...)
+        , StorableRef<T>((T&)*this)
+    {}
+};
+
+template<class T>
+class MakeStorablePtr
+    : public std::unique_ptr<T>
+    , public StorableRef<T>
+{
+public:
+    using std::unique_ptr<T>::get;
+
+    MakeStorablePtr(T* p)
+        : std::unique_ptr<T>(p)
+        , StorableRef<T>((T&)*get())
+    {}
+};
+
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<typename T, typename... Args>
+std::unique_ptr<typename std::conditional<std::is_base_of<Storable, T>::value, T, MakeStorable<T>>::type>
+    make_storable(Args&&... args)
+{
+    return make_unique<typename std::conditional<std::is_base_of<Storable, T>::value, T, MakeStorable<T>>::type>
+        (std::forward<Args>(args)...);
+}
+
+class StorageR
+{
+public:
+    typedef mfxU32 TKey;
+    static const TKey KEY_INVALID = TKey(-1);
+
+    template<class T>
+    const T& Read(TKey key) const
+    {
+        auto it = m_map.find(key);
+        if (it == m_map.end())
+            throw std::logic_error("Requested object was not found in storage");
+        return dynamic_cast<T&>(*it->second);
+    }
+
+    bool Contains(TKey key) const
+    {
+        return (m_map.find(key) != m_map.end());
+    }
+
+    bool Empty() const
+    {
+        return m_map.empty();
+    }
+
+protected:
+    std::map<TKey, std::unique_ptr<Storable>> m_map;
+};
+
+class StorageW : public StorageR
+{
+public:
+    template<class T>
+    T& Write(TKey key) const
+    {
+        auto it = m_map.find(key);
+        if (it == m_map.end())
+            throw std::logic_error("Requested object was not found in storage");
+        return dynamic_cast<T&>(*it->second);
+    }
+};
+
+class StorageRW : public StorageW
+{
+public:
+    bool TryInsert(TKey key, std::unique_ptr<Storable>&& pObj)
+    {
+        return m_map.emplace(key, std::move(pObj)).second;
+    }
+
+    void Insert(TKey key, std::unique_ptr<Storable>&& pObj)
+    {
+        if (!TryInsert(key, std::move(pObj)))
+            throw std::logic_error("Keys must be unique");
+    }
+
+    template<class T, typename std::enable_if<!std::is_base_of<Storable, T>::value, int>::type = 0>
+    void Insert(TKey key, T* pObj)
+    {
+        Insert(key, new MakeStorablePtr<T>(pObj));
+    }
+
+    template<class T, typename = typename std::enable_if<std::is_base_of<Storable, T>::value>::type>
+    void Insert(TKey key, T* pObj)
+    {
+        Insert(key, std::unique_ptr<T>(pObj));
+    }
+
+    void Erase(TKey key)
+    {
+        m_map.erase(key);
+    }
+
+    void Clear()
+    {
+        m_map.clear();
+    }
+};
+
+template<StorageR::TKey K, class T>
+struct StorageVar
+{
+    static const StorageR::TKey Key = K;
+    typedef typename std::conditional<std::is_base_of<Storable, T>::value, T, StorableRef<T>>::type TStore;
+    typedef T TRef;
+
+    static const TRef& Get(const StorageR& s)
+    {
+        return s.Read<TStore>(Key);
+    }
+
+    static TRef& Get(StorageW& s)
+    {
+        return s.Write<TStore>(Key);
+    }
+
+    template<typename... Args>
+    static TRef& GetOrConstruct(StorageRW& s, Args&&... args)
+    {
+        if (!s.Contains(Key))
+            s.Insert(Key, make_storable<TRef>(std::forward<Args>(args)...));
+        return s.Write<TStore>(Key);
+    }
+};
+
+inline mfxStatus GetWorstSts(mfxStatus sts1, mfxStatus sts2)
+{
+    mfxStatus sts_min = std::min<mfxStatus>(sts1, sts2);
+    return sts_min == MFX_ERR_NONE ? std::max<mfxStatus>(sts1, sts2) : sts_min;
+}
+
+template<class T>
+inline void ThrowIf(bool bThrow, T sts)
+{
+    if (bThrow)
+        throw sts;
+}
+
+template<class STS, class T, class... Args>
+inline STS Catch(STS dflt, T func, Args&&... args)
+{
+    try
+    {
+        func(std::forward<Args>(args)...);
+    }
+    catch (STS sts)
+    {
+        return sts;
+    }
+
+    return dflt;
+}
+
+inline bool IgnoreSts(mfxStatus) { return false; }
+
+template<
+    class TBlock
+    , typename std::enable_if<!std::is_same<typename std::remove_reference<TBlock>::type::TCall::result_type, mfxStatus>::value, int>::type = 0
+    , class... TArgs>
+inline mfxStatus CallAndGetMfxSts(TBlock&& blk, TArgs&&... args)
+{
+    blk.Call(std::forward<TArgs>(args)...);
+    return MFX_ERR_NONE;
+}
+
+template<
+    class TBlock
+    , typename = typename std::enable_if<std::is_same<typename std::remove_reference<TBlock>::type::TCall::result_type, mfxStatus>::value>::type
+    , class... TArgs>
+inline mfxStatus CallAndGetMfxSts(TBlock&& blk, TArgs&&... args)
+{
+    return blk.Call(std::forward<TArgs>(args)...);
+}
+
+template <class TPred, class TQ, class... TArgs>
+mfxStatus RunBlocks(TPred stopAtSts, TQ& queue, TArgs&&... args)
+{
+    mfxStatus wrn = MFX_ERR_NONE, sts;
+    using TBlock = typename TQ::value_type;
+    auto RunBlock = [&](const TBlock& blk)
+    {
+        auto sts = CallAndGetMfxSts(blk, std::forward<TArgs>(args)...);
+        ThrowIf(stopAtSts(sts), sts);
+        wrn = GetWorstSts(sts, wrn);
+    };
+
+    try
+    {
+        sts = Catch(
+            MFX_ERR_NONE
+            , std::for_each<decltype(queue.begin()), decltype(RunBlock)>
+            , queue.begin(), queue.end(), RunBlock
+        );
+    }
+    catch (std::exception& ex)
+    {
+        sts = MFX_ERR_UNKNOWN;
+#if defined(_DEBUG)
+        printf("HEVCEHW Exception: %s\n", ex.what());
+        fflush(stdout);
+#endif
+    }
+
+    return GetWorstSts(sts, wrn);
+}
+
+template<class TRV, class... TArg>
+struct CallChain
+    : public std::function<TRV(TArg...)>
+{
+    typedef std::function<TRV(TArg...)> TExt;
+    typedef std::function<TRV(TExt, TArg...)> TInt;
+
+    void Push(TInt newCall)
+    {
+        m_prev.push_front(*this);
+        auto pPrev = &m_prev.front();
+        (TExt&)*this = TExt([=](TArg... args)
+        {
+            return newCall(*pPrev, args...);
+        });
+    }
+
+    std::list<TExt> m_prev;
+};
+
+} //namespace MfxFeatureBlocks
+

--- a/_studio/shared/include/mfx_utils.h
+++ b/_studio/shared/include/mfx_utils.h
@@ -56,6 +56,8 @@ static inline T mfx_print_err(T sts, const char *file, int line, const char *fun
 #define MFX_RETURN(sts)         { return MFX_STS_TRACE(sts); }
 #define MFX_CHECK(EXPR, ERR)    { if (!(EXPR)) MFX_RETURN(ERR); }
 
+#define MFX_CHECK_NO_RET(EXPR, STS, ERR){ if (!(EXPR)) { std::ignore = MFX_STS_TRACE(ERR); STS = ERR; } }
+
 #define MFX_CHECK_STS(sts)              MFX_CHECK(MFX_SUCCEEDED(sts), sts)
 #define MFX_SAFE_CALL(FUNC)             { mfxStatus _sts = FUNC; MFX_CHECK_STS(_sts); }
 #define MFX_CHECK_NULL_PTR1(pointer)    MFX_CHECK(pointer, MFX_ERR_NULL_PTR)

--- a/api/mediasdk_structures/ts_ext_buffers_decl.h
+++ b/api/mediasdk_structures/ts_ext_buffers_decl.h
@@ -18,9 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-
+#if defined(__MFXSTRUCTURES_H__)
 EXTBUF(mfxExtCodingOption                , MFX_EXTBUFF_CODING_OPTION                   )
 EXTBUF(mfxExtCodingOptionSPSPPS          , MFX_EXTBUFF_CODING_OPTION_SPSPPS            )
+EXTBUF(mfxExtCodingOptionVPS             , MFX_EXTBUFF_CODING_OPTION_VPS               )
 EXTBUF(mfxExtVPPDoNotUse                 , MFX_EXTBUFF_VPP_DONOTUSE                    )
 EXTBUF(mfxExtVppAuxData                  , MFX_EXTBUFF_VPP_AUXDATA                     )
 EXTBUF(mfxExtVPPDenoise                  , MFX_EXTBUFF_VPP_DENOISE                     )
@@ -43,17 +44,42 @@ EXTBUF(mfxExtVPPVideoSignalInfo          , MFX_EXTBUFF_VPP_VIDEO_SIGNAL_INFO    
 EXTBUF(mfxExtEncoderROI                  , MFX_EXTBUFF_ENCODER_ROI                     )
 EXTBUF(mfxExtVPPDeinterlacing            , MFX_EXTBUFF_VPP_DEINTERLACING               )
 EXTBUF(mfxExtVP8CodingOption             , MFX_EXTBUFF_VP8_CODING_OPTION               )
-EXTBUF(mfxExtLAControl                   , MFX_EXTBUFF_LOOKAHEAD_CTRL                  )
 EXTBUF(mfxExtVPPFieldProcessing          , MFX_EXTBUFF_VPP_FIELD_PROCESSING            )
 EXTBUF(mfxExtContentLightLevelInfo       , MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO        )
 EXTBUF(mfxExtMasteringDisplayColourVolume, MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME )
 EXTBUF(mfxExtMultiFrameParam             , MFX_EXTBUFF_MULTI_FRAME_PARAM               )
 EXTBUF(mfxExtMultiFrameControl           , MFX_EXTBUFF_MULTI_FRAME_CONTROL             )
+EXTBUF(mfxExtColorConversion             , MFX_EXTBUFF_VPP_COLOR_CONVERSION            )
+EXTBUF(mfxExtAVCRefLists                 , MFX_EXTBUFF_AVC_REFLISTS                    )
+EXTBUF(mfxExtCodingOption3               , MFX_EXTBUFF_CODING_OPTION3                  )
+EXTBUF(mfxExtMBQP                        , MFX_EXTBUFF_MBQP                            )
+EXTBUF(mfxExtMBForceIntra                , MFX_EXTBUFF_MB_FORCE_INTRA                  )
+EXTBUF(mfxExtChromaLocInfo               , MFX_EXTBUFF_CHROMA_LOC_INFO                 )
+EXTBUF(mfxExtDecodedFrameInfo            , MFX_EXTBUFF_DECODED_FRAME_INFO              )
+EXTBUF(mfxExtDecodeErrorReport           , MFX_EXTBUFF_DECODE_ERROR_REPORT             )
+EXTBUF(mfxExtVPPRotation                 , MFX_EXTBUFF_VPP_ROTATION                    )
+EXTBUF(mfxExtVPPMirroring                , MFX_EXTBUFF_VPP_MIRRORING                   )
+EXTBUF(mfxExtMVCSeqDesc                  , MFX_EXTBUFF_MVC_SEQ_DESC                    )
+EXTBUF(mfxExtMBDisableSkipMap            , MFX_EXTBUFF_MB_DISABLE_SKIP_MAP             )
+EXTBUF(mfxExtDirtyRect                   , MFX_EXTBUFF_DIRTY_RECTANGLES                )
+EXTBUF(mfxExtMoveRect                    , MFX_EXTBUFF_MOVING_RECTANGLES               )
+EXTBUF(mfxExtHEVCParam                   , MFX_EXTBUFF_HEVC_PARAM                      )
+EXTBUF(mfxExtHEVCTiles                   , MFX_EXTBUFF_HEVC_TILES                      )
+EXTBUF(mfxExtPredWeightTable             , MFX_EXTBUFF_PRED_WEIGHT_TABLE               )
+EXTBUF(mfxExtEncodedUnitsInfo            , MFX_EXTBUFF_ENCODED_UNITS_INFO              )
 #if (MFX_VERSION >= 1026)
 EXTBUF(mfxExtVppMctf                     , MFX_EXTBUFF_VPP_MCTF                        )
+EXTBUF(mfxExtVP9Segmentation             , MFX_EXTBUFF_VP9_SEGMENTATION                )
+EXTBUF(mfxExtVP9TemporalLayers           , MFX_EXTBUFF_VP9_TEMPORAL_LAYERS             )
+EXTBUF(mfxExtVP9Param                    , MFX_EXTBUFF_VP9_PARAM                       )
 #endif
-EXTBUF(mfxExtColorConversion             , MFX_EXTBUFF_VPP_COLOR_CONVERSION            )
-// FEI
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+EXTBUF(mfxExtAVCScalingMatrix            , MFX_EXTBUFF_AVC_SCALING_MATRIX              )
+EXTBUF(mfxExtDPB                         , MFX_EXTBUFF_DPB                             )
+#endif
+#endif //defined(__MFXSTRUCTURES_H__)
+
+#if defined(__MFXFEI_H__)
 EXTBUF(mfxExtFeiParam               , MFX_EXTBUFF_FEI_PARAM                 )
 EXTBUF(mfxExtFeiSPS                 , MFX_EXTBUFF_FEI_SPS                   )
 EXTBUF(mfxExtFeiPPS                 , MFX_EXTBUFF_FEI_PPS                   )
@@ -77,8 +103,9 @@ EXTBUF(mfxExtFeiHevcEncMVPredictors , MFX_EXTBUFF_HEVCFEI_ENC_MV_PRED       )
 EXTBUF(mfxExtFeiHevcEncQP           , MFX_EXTBUFF_HEVCFEI_ENC_QP            )
 EXTBUF(mfxExtFeiHevcEncCtuCtrl      , MFX_EXTBUFF_HEVCFEI_ENC_CTU_CTRL      )
 #endif
-// end of FEI
-// Camera
+#endif //defined(__MFXFEI_H__)
+
+#if defined(__MFXCAMERA_H__)
 EXTBUF(mfxExtCamTotalColorControl   , MFX_EXTBUF_CAM_TOTAL_COLOR_CONTROL     )
 EXTBUF(mfxExtCamCscYuvRgb           , MFX_EXTBUF_CAM_CSC_YUV_RGB             )
 EXTBUF(mfxExtCamGammaCorrection     , MFX_EXTBUF_CAM_GAMMA_CORRECTION        )
@@ -90,50 +117,27 @@ EXTBUF(mfxExtCamBayerDenoise        , MFX_EXTBUF_CAM_BAYER_DENOISE           )
 EXTBUF(mfxExtCamColorCorrection3x3  , MFX_EXTBUF_CAM_COLOR_CORRECTION_3X3    )
 EXTBUF(mfxExtCamPadding             , MFX_EXTBUF_CAM_PADDING                 )
 EXTBUF(mfxExtCamPipeControl         , MFX_EXTBUF_CAM_PIPECONTROL             )
-// end of Camera
-EXTBUF(mfxExtAVCRefLists            , MFX_EXTBUFF_AVC_REFLISTS               )
-EXTBUF(mfxExtCodingOption3          , MFX_EXTBUFF_CODING_OPTION3             )
-EXTBUF(mfxExtMBQP                   , MFX_EXTBUFF_MBQP                       )
-EXTBUF(mfxExtMBForceIntra           , MFX_EXTBUFF_MB_FORCE_INTRA             )
+#endif //defined(__MFXCAMERA_H__)
 
-EXTBUF(mfxExtChromaLocInfo          , MFX_EXTBUFF_CHROMA_LOC_INFO            )
-EXTBUF(mfxExtDecodedFrameInfo       , MFX_EXTBUFF_DECODED_FRAME_INFO         )
-EXTBUF(mfxExtDecodeErrorReport      , MFX_EXTBUFF_DECODE_ERROR_REPORT        )
-
+#if defined(__MFXCOMMON_H__)
 // Threading API
 EXTBUF(mfxExtThreadsParam           , MFX_EXTBUFF_THREADS_PARAM)
+#endif //defined(__MFXCOMMON_H__)
 
-EXTBUF(mfxExtVPPRotation            , MFX_EXTBUFF_VPP_ROTATION)
-EXTBUF(mfxExtVPPMirroring           , MFX_EXTBUFF_VPP_MIRRORING)
-EXTBUF(mfxExtMVCSeqDesc             , MFX_EXTBUFF_MVC_SEQ_DESC              )
-//EXTBUF(mfxExtMVCTargetViews         , MFX_EXTBUFF_MVC_TARGET_VIEWS          )
-//EXTBUF(mfxExtJPEGQuantTables        , MFX_EXTBUFF_JPEG_QT                   )
-//EXTBUF(mfxExtJPEGHuffmanTables      , MFX_EXTBUFF_JPEG_HUFFMAN              )
-EXTBUF(mfxExtMBDisableSkipMap       , MFX_EXTBUFF_MB_DISABLE_SKIP_MAP)
-
+#if defined(__MFXSC_H__)
 //Screen capture
 EXTBUF(mfxExtScreenCaptureParam     , MFX_EXTBUFF_SCREEN_CAPTURE_PARAM      )
-EXTBUF(mfxExtDirtyRect              , MFX_EXTBUFF_DIRTY_RECTANGLES          )
-EXTBUF(mfxExtMoveRect               , MFX_EXTBUFF_MOVING_RECTANGLES         )
+#endif //defined(__MFXSC_H__)
 
+#if defined(__MFXVP9_H__)
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
 EXTBUF(mfxExtVP9DecodedFrameInfo    , MFX_EXTBUFF_VP9_DECODED_FRAME_INFO    )
 #endif
-
-#if (MFX_VERSION >= 1026)
-EXTBUF(mfxExtVP9Segmentation        , MFX_EXTBUFF_VP9_SEGMENTATION          )
-EXTBUF(mfxExtVP9TemporalLayers      , MFX_EXTBUFF_VP9_TEMPORAL_LAYERS       )
-EXTBUF(mfxExtVP9Param               , MFX_EXTBUFF_VP9_PARAM                 )
-#endif
-
-EXTBUF(mfxExtHEVCParam              , MFX_EXTBUFF_HEVC_PARAM                )
-EXTBUF(mfxExtPredWeightTable        , MFX_EXTBUFF_PRED_WEIGHT_TABLE         )
+#endif //defined(__MFXVP9_H__)
 
 #if defined(__MFXBRC_H__)
 EXTBUF(mfxExtBRC, MFX_EXTBUFF_BRC)
 #endif // defined(__MFXBRC_H__)
-
-EXTBUF(mfxExtEncodedUnitsInfo       , MFX_EXTBUFF_ENCODED_UNITS_INFO        )
 
 #if defined(__MFXPCP_H__)
 #if (MFX_VERSION >= 1030)
@@ -144,3 +148,8 @@ EXTBUF(mfxExtCencParam              , MFX_EXTBUFF_CENC_PARAM                )
 #if defined(__MFXSCD_H__)
 EXTBUF(mfxExtSCD, MFX_EXTBUFF_SCD)
 #endif // defined(__MFXSCD_H__)
+
+#ifdef __MFXLA_H__
+EXTBUF(mfxExtLAControl                   , MFX_EXTBUFF_LOOKAHEAD_CTRL )
+EXTBUF(mfxExtLAFrameStatistics           , MFX_EXTBUFF_LOOKAHEAD_STAT )
+#endif //__MFXLA_H__


### PR DESCRIPTION
Refactored code-path is disabled by default.
Defines to enable (see libmfxsw_encode.cpp, hevcehw_disp.cpp):
MFX_ENABLE_HEVCEHW_REFACTORING
MFX_ENABLE_HEVCEHW_REFACTORING_LIN_SKL
MFX_ENABLE_HEVCEHW_REFACTORING_LIN_ICL
MFX_ENABLE_HEVCEHW_REFACTORING_LIN_TGL
