### PR TITLE
sample_decode: Add one more surface in rendering mode

### DIFF
--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -1181,8 +1181,10 @@ mfxStatus CDecodingPipeline::AllocFrames()
         // The number of surfaces shared by vpp input and decode output
         nSurfNum = Request.NumFrameSuggested + VppRequest[0].NumFrameSuggested - m_mfxVideoParams.AsyncDepth + 1;
 
-        // The number of surfaces for vpp output
-        nVppSurfNum = VppRequest[1].NumFrameSuggested;
+        // The number of surfaces for vpp output.
+        // Need to add one more surface in render mode if AsyncDepth == 1
+        nVppSurfNum = VppRequest[1].NumFrameSuggested +
+                      (m_eWorkMode == MODE_RENDERING ? m_mfxVideoParams.AsyncDepth == 1 : 0);
 
         // prepare allocation request
         Request.NumFrameSuggested = Request.NumFrameMin = nSurfNum;


### PR DESCRIPTION
Need to add one more surface in rendering mode for correct "async 1"
behavior

Fixes: #1655