### PR TITLE
1.27: fix cm mem copy for icl

### DIFF
--- a/_studio/shared/src/cm_mem_copy.cpp
+++ b/_studio/shared/src/cm_mem_copy.cpp
@@ -2665,8 +2665,10 @@ mfxStatus CmCopyWrapper::InitializeSwapKernels(eMFXHWType hwtype)
 #if (MFX_VERSION >= 1031)
     case MFX_HW_JSL:
     case MFX_HW_EHL:
+#endif
         cmSts = m_pCmDevice->LoadProgram((void*)genx_copy_kernel_gen11lp,sizeof(genx_copy_kernel_gen11lp),m_pCmProgram,"nojitter");
         break;
+#if (MFX_VERSION >= 1031)
     case MFX_HW_TGL_LP:
         cmSts = m_pCmDevice->LoadProgram((void*)genx_copy_kernel_gen12lp,sizeof(genx_copy_kernel_gen12lp),m_pCmProgram,"nojitter");
         break;


### PR DESCRIPTION
Fixes: 9fd26ab ("API 1.31 - JSL")

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>