### PR TITLE
[hevce] fix ROI priority mode support

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -439,7 +439,7 @@ mfxStatus FillCUQPDataDDI(Task& task, MfxVideoParam &par, VideoCORE& core, mfxFr
                     mfxU32 y = i*drBlkH;
                     if (x >= roi->ROI[n].Left  &&  x < roi->ROI[n].Right  && y >= roi->ROI[n].Top && y < roi->ROI[n].Bottom)
                     {
-                        diff = (task.m_roiMode == MFX_ROI_MODE_PRIORITY ? (-1) : 1) * roi->ROI[n].Priority;
+                        diff = roi->ROI[n].DeltaQP;
                         break;
                     }
 

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -3505,15 +3505,15 @@ void ConfigureTask(
     task.m_numRoi = 0;
     if (parRoi && parRoi->NumROI && !par.bROIViaMBQP)
     {
-         for (mfxU16 i = 0; i < parRoi->NumROI; i ++)
+        for (mfxU16 i = 0; i < parRoi->NumROI; i ++)
         {
             task.m_roi[i] = {parRoi->ROI[i].Left,  parRoi->ROI[i].Top,
                              parRoi->ROI[i].Right, parRoi->ROI[i].Bottom,
-                            (mfxI16)((parRoi->ROIMode == MFX_ROI_MODE_PRIORITY ? (-1) : 1) * parRoi->ROI[i].DeltaQP) };
-            task.m_numRoi ++;
+                             parRoi->ROI[i].DeltaQP};
         }
 
-        task.m_roiMode = MFX_ROI_MODE_QP_DELTA;
+        task.m_numRoi = parRoi->NumROI;
+        task.m_roiMode = parRoi->ROIMode;
     }
 
 #else


### PR DESCRIPTION
ROI priority mode is supported on platforms with corresponding caps
Otherwise it should be converted to delta QP mode