### PR TITLE
[h264e] Fix AVBR MVC encoding

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
@@ -305,12 +305,11 @@ typedef struct tagENCODE_CAPS
             UINT    LLCStreamingBufferSupport     : 1;
             UINT    DDRStreamingBufferSupport     : 1;
             UINT    LowDelayBRCSupport            : 1; // eFrameSizeTolerance_ExtremelyLow (Low delay) supported
-            UINT    AVBRBRCSupport                : 1;
             UINT    MaxNumDeltaQPMinus1           : 4;
             UINT    TCBRCSupport                  : 1;
             UINT    HRDConformanceSupport         : 1;
             UINT    PollingModeSupport            : 1;
-            UINT                                  : 4;
+            UINT                                  : 5;
         };
         UINT      CodingLimits2;
     };
@@ -326,6 +325,7 @@ struct MFX_ENCODE_CAPS
     bool CQPSupport;
     bool CBRSupport;
     bool VBRSupport;
+    bool AVBRSupport;
 };
 
 // this enumeration is used to define the block size for intra prediction. they

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3941,7 +3941,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
     }
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_AVBR &&
-        hwCaps.ddi_caps.AVBRBRCSupport == 0)
+        hwCaps.AVBRSupport == 0)
     {
         par.mfx.RateControlMethod = 0;
         unsupported = true;
@@ -7617,8 +7617,7 @@ void MfxVideoParam::SyncVideoToCalculableParam()
             calcParam.mvcPerViewPar.bufferSizeInKB   = calcParam.bufferSizeInKB / extMvc->NumView;
             if (mfx.RateControlMethod != MFX_RATECONTROL_CQP
                 && mfx.RateControlMethod != MFX_RATECONTROL_ICQ
-                && mfx.RateControlMethod != MFX_RATECONTROL_LA_ICQ
-                && mfx.RateControlMethod != MFX_RATECONTROL_AVBR)
+                && mfx.RateControlMethod != MFX_RATECONTROL_LA_ICQ)
             {
                 calcParam.mvcPerViewPar.initialDelayInKB = calcParam.initialDelayInKB / extMvc->NumView;
                 calcParam.mvcPerViewPar.targetKbps       = calcParam.targetKbps / extMvc->NumView;

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1508,7 +1508,7 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
         (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_QVBR) ? 1 : 0;
 #endif
 #if VA_CHECK_VERSION(1,3,0)
-    m_caps.ddi_caps.AVBRBRCSupport =
+    m_caps.AVBRSupport =
         (attrs[idx_map[VAConfigAttribRateControl]].value & VA_RC_AVBR) ? 1 : 0;
 #endif
     m_caps.ddi_caps.TrelisQuantization =


### PR DESCRIPTION
1) In 0e04f56 for MFX_RATECONTROL_AVBR mvcPerViewPar.(target|max)Kbps etc
were erroneously set to zero.
2) Move AVBRSupport to other (CQP|CBR|VBR)Support.

Issue: MDP-60700