### PR TITLE
refactored hevce: fix ROI priority mode support

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_roi.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_roi.h
@@ -58,6 +58,11 @@ protected:
     virtual void SetDefaults(const FeatureBlocks& /*blocks*/, TPushSD Push) override;
     virtual void InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push) override;
 
+    mfxStatus CheckAndFixROI(
+        ENCODE_CAPS_HEVC const & caps
+        , mfxVideoParam const & par
+        , mfxExtEncoderROI& roi);
+
     bool m_bViaCuQp = false;
 };
 


### PR DESCRIPTION
ROI priority mode is supported on platforms with corresponding caps
Otherwise it should be converted to delta QP mode