### PR TITLE
allow ROI rectangle top/left/bottom/right to be 0 for query

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_roi.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_roi.cpp
@@ -107,6 +107,10 @@ mfxStatus ROI::CheckAndFixROI(
 
     auto IsInvalidRect = [](const ROI::RectData& rect)
     {
+        if (rect.Top == 0 && rect.Left == 0 && rect.Right == 0 && rect.Bottom == 0)
+        {
+            return false;
+        }
         return ((rect.Left >= rect.Right) || (rect.Top >= rect.Bottom));
     };
     mfxU16 numValidROI = mfxU16(std::remove_if(roi.ROI, roi.ROI + roi.NumROI, IsInvalidRect) - roi.ROI);


### PR DESCRIPTION
It is nature to fill the ROI rect with zero when query the max
supported ROI numbers. Without this change, the query does not
work for such case.