### PR TITLE
[vp9e] Check for tiles group height exceeds picture height fix

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/vp9/include/mfx_vp9_encode_hw_utils.h
@@ -68,12 +68,11 @@ constexpr auto MAX_NUM_TEMP_LAYERS_SUPPORTED = 4;
 constexpr auto MAX_UPSCALE_RATIO = 16;
 constexpr auto MAX_DOWNSCALE_RATIO = 2;
 
+constexpr auto MIN_TILE_HEIGHT = 128;
 constexpr auto MIN_TILE_WIDTH = 256;
 constexpr auto MAX_TILE_WIDTH = 4096;
 constexpr auto MAX_NUM_TILE_ROWS = 4;
 constexpr auto MAX_NUM_TILES = 16;
-
-constexpr auto SB_SIZE = 64;
 
 const mfxU16 segmentSkipMask = 0xf0;
 const mfxU16 segmentRefMask = 0x0f;

--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp
@@ -1505,8 +1505,8 @@ mfxStatus CheckParameters(VP9MfxVideoParam &par, ENCODE_CAPS_VP9 const &caps)
 
     if (rows && height)
     {
-        mfxU16 heightInSBs = static_cast<mfxU16>(CeilDiv(height, SB_SIZE));
-        mfxU16 maxPossibleRows = std::min<mfxU16>(heightInSBs, MAX_NUM_TILE_ROWS);
+        mfxU16 heightInTiles = static_cast<mfxU16>(CeilDiv(height, MIN_TILE_HEIGHT));
+        mfxU16 maxPossibleRows = std::min<mfxU16>(heightInTiles, MAX_NUM_TILE_ROWS);
         if (rows > maxPossibleRows)
         {
             rows = maxPossibleRows;


### PR DESCRIPTION
Using the wrong constant (64 instead 128) led to overstated
acceptable number of tiles (>4)