### PR TITLE
[VPP] Fix MFX status for RGB565 and RGBP color formats

### DIFF
--- a/samples/sample_common/src/vaapi_allocator.cpp
+++ b/samples/sample_common/src/vaapi_allocator.cpp
@@ -152,12 +152,16 @@ static mfxStatus GetVAFourcc(mfxU32 fourcc, unsigned int &va_fourcc)
         (VA_FOURCC_YUY2 != va_fourcc) &&
         (VA_FOURCC_ARGB != va_fourcc) &&
         (VA_FOURCC_ABGR != va_fourcc) &&
+        (VA_FOURCC_RGBP != va_fourcc) &&
         (VA_FOURCC_P208 != va_fourcc) &&
         (VA_FOURCC_P010 != va_fourcc) &&
         (VA_FOURCC_YUY2 != va_fourcc) &&
 #if (MFX_VERSION >= 1027)
         (VA_FOURCC_Y210 != va_fourcc) &&
         (VA_FOURCC_Y410 != va_fourcc) &&
+#endif
+#if (MFX_VERSION >= 1028)
+        (VA_FOURCC_RGB565 != va_fourcc) &&
 #endif
 #if (MFX_VERSION >= 1031)
         (VA_FOURCC_P016 != va_fourcc) &&


### PR DESCRIPTION
Fixes: fcca4c ("Reallocate frame (system memory or vaapi surface) for VP9 DRC decoding.")
sample_vpp returns correct status for RGB565->* and NV12->RGBP color conversions.