### PR TITLE
[HEVCe]: Move setting some caps to HardcodeCaps()

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -94,7 +94,7 @@ mfxStatus HardcodeCaps(MFX_ENCODE_CAPS_HEVC& caps, VideoCORE* core, MfxVideoPara
         caps.ddi_caps.YUV444ReconSupport = 1;
     if (!caps.ddi_caps.Color420Only && !(caps.ddi_caps.YUV422ReconSupport))   // VPG: caps are not correct now
         caps.ddi_caps.YUV422ReconSupport = 1;
-#if (MFX_VERSION >= 1025)
+
     eMFXHWType platform = core->GetHWType();
 
     if (platform < MFX_HW_CNL)
@@ -127,7 +127,6 @@ mfxStatus HardcodeCaps(MFX_ENCODE_CAPS_HEVC& caps, VideoCORE* core, MfxVideoPara
         //caps.SliceLevelWeightedPred;
     }
 #endif //defined(MFX_ENABLE_HEVCE_WEIGHTED_PREDICTION)
-#else
     if (!caps.ddi_caps.LCUSizeSupported)
         caps.ddi_caps.LCUSizeSupported = 2;
     caps.ddi_caps.BlockSize = 2; // 32x32
@@ -160,9 +159,19 @@ mfxStatus HardcodeCaps(MFX_ENCODE_CAPS_HEVC& caps, VideoCORE* core, MfxVideoPara
         caps.ddi_caps.MaxNum_WeightedPredL1 = 2; // = 0 now
         caps.ddi_caps.TileSupport = 1;
         caps.ddi_caps.IntraRefreshBlockUnitSize = 2;
+
+        caps.ddi_caps.MaxNumDeltaQP = 0;
+        caps.ddi_caps.DirtyRectSupport = 1;
+        caps.ddi_caps.RGBEncodingSupport = 0;
+        caps.ddi_caps.MaxNumOfDirtyRect = 4;
+
+        caps.ddi_caps.UserMaxFrameSizeSupport = 1;
+        caps.ddi_caps.MbQpDataSupport = 1;
+        caps.ddi_caps.TUSupport = 73;
+        caps.ddi_caps.SliceStructure = 4;
+        caps.ddi_caps.SliceByteSizeCtrl = 1; ///It means that GPU may further split the slice region that slice control data specifies into finer slice segments based on slice size upper limit (MaxSliceSize).
     }
     (void)core;
-#endif
 
     return sts;
 }

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -938,10 +938,7 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
 
     m_caps.ddi_caps.RollingIntraRefresh =
             (attrs[idx_map[VAConfigAttribEncIntraRefresh]].value & (~VA_ATTRIB_NOT_SUPPORTED)) ? 1 : 0 ;
-    m_caps.ddi_caps.UserMaxFrameSizeSupport = 1;
     m_caps.ddi_caps.MBBRCSupport            = attrs[ idx_map[VAConfigAttribRateControl] ].value & VA_RC_MB ? 1 : 0;
-    m_caps.ddi_caps.MbQpDataSupport         = 1;
-    m_caps.ddi_caps.TUSupport               = 73;
 
 #if VA_CHECK_VERSION(1,2,0)
     if(attrs[idx_map[VAConfigAttribRTFormat]].value & VA_RT_FORMAT_YUV420_12)
@@ -975,10 +972,6 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     MFX_CHECK(attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value >= m_height, MFX_ERR_UNSUPPORTED);
     m_caps.ddi_caps.MaxPicWidth  = attrs[ idx_map[VAConfigAttribMaxPictureWidth] ].value;
     m_caps.ddi_caps.MaxPicHeight = attrs[ idx_map[VAConfigAttribMaxPictureHeight] ].value;
-
-
-    m_caps.ddi_caps.SliceStructure = 4;
-    m_caps.ddi_caps.SliceByteSizeCtrl = 1; //It means that GPU may further split the slice region that slice control data specifies into finer slice segments based on slice size upper limit (MaxSliceSize).
 
     if (attrs[ idx_map[VAConfigAttribEncMaxRefFrames] ].value != VA_ATTRIB_NOT_SUPPORTED)
     {
@@ -1015,7 +1008,8 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     m_caps.ddi_caps.IntraRefreshBlockUnitSize = 2;
     m_caps.ddi_caps.TileSupport = (attrs[idx_map[VAConfigAttribEncTileSupport]].value == 1);
 
-    m_caps.PSliceSupport = IsOn(par.mfx.LowPower) ? 0 : 1;
+    sts = HardcodeCaps(m_caps, core, par);
+    MFX_CHECK_STS(sts);
 
     return MFX_ERR_NONE;
 }


### PR DESCRIPTION
Usage of HardcodeCaps is a temporal solution.
It will be removed when all driver caps issues are resolved