### PR TITLE
Adjust includes in some places

### DIFF
--- a/_studio/shared/umc/core/vm/src/vm_sys_info_linux32.c
+++ b/_studio/shared/umc/core/vm/src/vm_sys_info_linux32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2019 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,11 +21,7 @@
 #if defined(LINUX32)
 
 #include "vm_sys_info.h"
-#include <time.h>
-#include <sys/utsname.h>
 #include <unistd.h>
-
-#include <sys/sysinfo.h>
 
 uint32_t vm_sys_info_get_cpu_num(void)
 {

--- a/tutorials/common/common_vaapi.cpp
+++ b/tutorials/common/common_vaapi.cpp
@@ -22,6 +22,7 @@
 #include <drm.h>
 #include <drm_fourcc.h>
 #include <map>
+#include <string>
 
 #include "common_vaapi.h"
 


### PR DESCRIPTION
Upstreaming some fixes from [FreeBSD package](https://www.freshports.org/multimedia/intel-media-sdk):
- libc++ (unlike libstdc++) doesn't bootleg `<string>` via `<map>`
- `sysinfo` code was converted to `sysconf`, making it portable to other Unices
