### PR TITLE
[HEVCe] Clapping of input QP

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -2180,9 +2180,12 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP)
     {
-        changed += CheckRangeDflt(par.mfx.QPI, minQP, maxQP, 0);
-        changed += CheckRangeDflt(par.mfx.QPP, minQP, maxQP, 0);
-        changed += CheckRangeDflt(par.mfx.QPB, minQP, maxQP, 0);
+        if (par.mfx.QPI)
+            changed += CheckRange(par.mfx.QPI, minQP, maxQP);
+        if (par.mfx.QPP)
+            changed += CheckRange(par.mfx.QPP, minQP, maxQP);
+        if (par.mfx.QPB)
+            changed += CheckRange(par.mfx.QPB, minQP, maxQP);
     }
 
     if (par.BufferSizeInKB != 0)

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
@@ -4160,11 +4160,11 @@ mfxStatus Legacy::CheckBRC(
 
     if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP)
     {
-        changed += CheckMinOrClip<mfxU16>(par.mfx.QPI, minQP);
+        changed += par.mfx.QPI && CheckMinOrClip<mfxU16>(par.mfx.QPI, minQP);
         changed += CheckMaxOrClip<mfxU16>(par.mfx.QPI, maxQP);
-        changed += CheckMinOrClip<mfxU16>(par.mfx.QPP, minQP);
+        changed += par.mfx.QPP && CheckMinOrClip<mfxU16>(par.mfx.QPP, minQP);
         changed += CheckMaxOrClip<mfxU16>(par.mfx.QPP, maxQP);
-        changed += CheckMinOrClip<mfxU16>(par.mfx.QPB, minQP);
+        changed += par.mfx.QPB && CheckMinOrClip<mfxU16>(par.mfx.QPB, minQP);
         changed += CheckMaxOrClip<mfxU16>(par.mfx.QPB, maxQP);
 
         changed += !par.mfx.QPI && (par.mfx.QPP || par.mfx.QPB);


### PR DESCRIPTION
If QP supplied is out of range it is clapped to the supported range now
instead of dropping to the default value