### PR TITLE
[HEVCe] Changed behavior for sps.QpAdjustment

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -3074,7 +3074,7 @@ void SetDefaults(
         par.m_ext.HEVCParam.SampleAdaptiveOffset = isSAOSupported(par) ? (MFX_SAO_ENABLE_LUMA | MFX_SAO_ENABLE_CHROMA) : MFX_SAO_DISABLE;
 
     if (!par.m_ext.DDI.QpAdjust)
-        par.m_ext.DDI.QpAdjust = (par.mfx.TargetUsage < MFX_TARGETUSAGE_6) ? (mfxU16)MFX_CODINGOPTION_ON : (mfxU16)MFX_CODINGOPTION_OFF;
+        par.m_ext.DDI.QpAdjust = MFX_CODINGOPTION_OFF;
 #endif // MFX_VERSION >= 1026
 
     if (CO3.EnableMBQP == 0)


### PR DESCRIPTION
Changed behavior for sps.QpAdjustment:
default is off for all TUs (does not depends on VME or VDENC)