### PR TITLE
[HEVCe] Remove hardcode of resolution's caps

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -148,8 +148,6 @@ mfxStatus HardcodeCaps(MFX_ENCODE_CAPS_HEVC& caps, VideoCORE* core, MfxVideoPara
         caps.ddi_caps.LumaWeightedPred = 1; // = 0 now
         caps.ddi_caps.ChromaWeightedPred = 0; // = 0 now
         caps.ddi_caps.MaxEncodedBitDepth = 2;  // = 1 now (8/10b only)
-        caps.ddi_caps.MaxPicWidth = 16384;  // = 8192 now
-        caps.ddi_caps.MaxPicHeight = 16384;  // = 8192 now
         caps.ddi_caps.MaxNumOfROI = 16;  // = 0 now
         caps.ddi_caps.ROIDeltaQPSupport = 1;  // = 0 now
         caps.ddi_caps.BlockSize = 1;  // = 0 now (set to 16x16 like in Win)

--- a/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_caps_lin.h
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_caps_lin.h
@@ -51,8 +51,6 @@ protected:
         caps.NoInterlacedField          = 1;
         caps.ParallelBRC                = 1;
         caps.MaxEncodedBitDepth         = 2;
-        caps.MaxPicWidth                = 16384;
-        caps.MaxPicHeight               = 16384;
         caps.MaxNumOfROI                = 16;
         caps.ROIDeltaQPSupport          = 1;
         caps.BlockSize                  = 1;


### PR DESCRIPTION
Remove MaxPicWidth and MaxPicHeight from HardcodeCaps()
The first step in avoiding of hardcoding caps.