### PR TITLE
[build] Drop mfx_enc_common.cpp from mfx_common

### DIFF
--- a/_studio/mfx_lib/CMakeLists.txt
+++ b/_studio/mfx_lib/CMakeLists.txt
@@ -43,7 +43,6 @@ foreach( prefix ${MSDK_LIB_ROOT}/shared/src )
     ${prefix}/mfx_brc_common.cpp
     ${prefix}/mfx_common_decode_int.cpp
     ${prefix}/mfx_common_int.cpp
-    ${prefix}/mfx_enc_common.cpp
     ${prefix}/mfx_critical_error_handler.cpp
     ${prefix}/mfx_vpx_dec_common.cpp
   )
@@ -55,6 +54,7 @@ append_property( mfx_common COMPILE_FLAGS " -DMFX_RT" )
 
 foreach( prefix ${MSDK_LIB_ROOT}/shared/src )
   list( APPEND sources
+    ${prefix}/mfx_enc_common.cpp
     ${prefix}/mfx_ddi_enc_dump.cpp
     ${prefix}/mfx_h264_enc_common_hw.cpp
     ${prefix}/mfx_h264_encode_vaapi.cpp


### PR DESCRIPTION
mfx_enc_common.cpp is added to both mfx_common_hw and mfx_common,
but later one missed MFX_VA flag, so mfx_enc_common.cpp is build
without MFX_VA_LINUX, that is incorrect.

Issue: MDP-51482