### PR TITLE
[VPP][MCTF] Fast path feature enabled for ICL

### DIFF
--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
@@ -1510,6 +1510,14 @@ public:
 
     CM_RT_API virtual INT EnqueueWithHints(CmTask* pTask, CmEvent* & pEvent, UINT hints = 0) = 0;
     CM_RT_API virtual INT EnqueueVebox(CmVebox* pVebox, CmEvent* & pEvent) = 0;
+
+    CM_RT_API virtual INT EnqueueFast(CmTask *task,
+                              CmEvent *&event,
+                              const CmThreadSpace *threadSpace = nullptr) = 0;
+    CM_RT_API virtual INT DestroyEventFast(CmEvent *&event) = 0;
+    CM_RT_API virtual INT EnqueueWithGroupFast(CmTask *task,
+                                  CmEvent *&event,
+                                  const CmThreadGroupSpace *threadGroupSpace = nullptr) = 0;
 };
 
 class CmDevice;

--- a/_studio/mfx_lib/mctf_package/mctf/include/mctf_common.h
+++ b/_studio/mfx_lib/mctf_package/mctf/include/mctf_common.h
@@ -359,6 +359,8 @@ private:
     t_MCTF_LOAD     pMCTF_LOAD_func;
     t_MCTF_SPDEN    pMCTF_SpDen_func;
 
+    eMFXHWType
+        mctf_HWType;
     CmDevice
         * device;
     CmQueue
@@ -623,6 +625,11 @@ private:
     );
     mfxU8  SetOverlapOp();
     mfxU8  SetOverlapOp_half();
+    mfxI32 MCTF_Enqueue(
+        CmTask* taskInt,
+        CmEvent* & eInt,
+        const CmThreadSpace* tSInt = 0
+    );    
     mfxI32 MCTF_RUN_TASK_NA(
         CmKernel * kernel,
         bool       reset,


### PR DESCRIPTION
MCTF hangs when is used in ICL with Opensource
driver, this is because Fast Path for enqueue
was not implemented. Now Fast path is available
in opensrouce driver but it needs to be called
implicitly for ICL platform. This fix determines
based on the platform what type of enqueue function
to use, EnqueueFast for Gen11 and Enqueue for all
others.

Issue: https://hsdes.intel.com/resource/2207632605
Test: manual on SKL and ICL