### PR TITLE
Fix HEVC SCC Main444 10bit VLD profile lookup

### DIFF
--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -106,7 +106,7 @@ VAEntrypoint umc_to_va_entrypoint(uint32_t umc_entrypoint)
     case UMC::VA_VLD | UMC::VA_PROFILE_SCC:
     case UMC::VA_VLD | UMC::VA_PROFILE_SCC  | UMC::VA_PROFILE_10:
     case UMC::VA_VLD | UMC::VA_PROFILE_SCC  | UMC::VA_PROFILE_444:
-    case UMC::VA_VLD | UMC::VA_PROFILE_SCC  | UMC::VA_PROFILE_422:
+    case UMC::VA_VLD | UMC::VA_PROFILE_SCC  | UMC::VA_PROFILE_444 | UMC::VA_PROFILE_10:
 #endif
         va_entrypoint = VAEntrypointVLD;
         break;
@@ -227,8 +227,8 @@ VAProfile get_next_va_profile(uint32_t umc_codec, uint32_t profile)
     case UMC::VA_H265 | UMC::VA_PROFILE_SCC | UMC::VA_PROFILE_10:
         if (profile < 1) va_profile = VAProfileHEVCSccMain10;
         break;
-    case UMC::VA_H265 | UMC::VA_PROFILE_SCC | UMC::VA_PROFILE_422:
     case UMC::VA_H265 | UMC::VA_PROFILE_SCC | UMC::VA_PROFILE_444:
+    case UMC::VA_H265 | UMC::VA_PROFILE_SCC | UMC::VA_PROFILE_444 | UMC::VA_PROFILE_10:
         if (profile < 1) va_profile = VAProfileHEVCSccMain444;
         break;
 #endif


### PR DESCRIPTION
It should also use VAProfileHEVCSccMain444 for HEVC Main444
10bit decoding.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>