### PR TITLE
core: Use external allocator for find FEI ENC / PAK reconstructs

### DIFF
--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -614,7 +614,7 @@ VAAPIVideoCORE::AllocFrames(
             // external allocator
             if (m_bSetExtFrameAlloc &&
                 request->Info.FourCC != MFX_FOURCC_P8 &&
-                (request->Type & MFX_MEMTYPE_EXTERNAL_FRAME))
+                (request->Type & (MFX_MEMTYPE_EXTERNAL_FRAME | MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK)))
             {
                 // make 'fake' Alloc call to retrieve memId's of surfaces already allocated by app.
                 sts = (*m_FrameAllocator.frameAllocator.Alloc)(m_FrameAllocator.frameAllocator.pthis, &temp_request, response);


### PR DESCRIPTION
FEI ENC/PAK uses external allocator to retrieve memId's of surfaces
which already allocated by app

Test: few different scenarios via sample_encode/sample_decode/smt/sample_fei 

fixes: 7eb0c0b (core: Use default allocator for allocate internal resources")