### PR TITLE
[hevce] Fix Linux MBQP

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -317,7 +317,7 @@ struct Task : DpbFrame
     Slice             m_sh                            = {};
 
     mfxU32            m_idxBs                         = IDX_INVALID;
-    mfxU8             m_idxCUQp                       = IDX_INVALID;
+    mfxU32            m_idxCUQp                       = IDX_INVALID;
     bool              m_bCUQPMap                      = false;
 
     mfxU8             m_refPicList[2][MAX_DPB_SIZE]   = {};

--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_vaapi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -179,7 +179,7 @@ mfxStatus SetSkipFrame(
             m_block_width(0),
             m_block_height(0) {}
 
-            void Init(mfxU32 picWidthInLumaSamples, mfxU32 picHeightInLumaSamples);
+        void Init(mfxU32 picWidthInLumaSamples, mfxU32 picHeightInLumaSamples, mfxU32 blockSize); // block width/height = 8 << blockSize
     };
 
     class GUIDhash

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -429,10 +429,12 @@ mfxStatus FillCUQPDataDDI(Task& task, MfxVideoParam &par, VideoCORE& core, mfxFr
         FrameLocker lock(&core, task.m_midCUQp);
         MFX_CHECK(lock.Y, MFX_ERR_LOCK_MEMORY);
 
-        for (mfxU32 i = 0; i < CUQPFrameInfo.Height; i++)
+        for (mfxU32 i = 0; i < CUQPFrameInfo.Height; i++) {
             for (mfxU32 j = 0; j < CUQPFrameInfo.Width; j++)
-                    lock.Y[i * lock.Pitch + j] = mbqp->QP[i*drBlkH/inBlkSize * pitch_MBQP + j*drBlkW/inBlkSize];
-
+                lock.Y[i * lock.Pitch + j] = mbqp->QP[i*drBlkH / inBlkSize * pitch_MBQP + j * drBlkW / inBlkSize];
+            for (mfxU32 j = CUQPFrameInfo.Width; j < lock.Pitch; j++) // hevc averages to LCU size
+                lock.Y[i * lock.Pitch + j] = lock.Y[i * lock.Pitch + CUQPFrameInfo.Width - 1];
+        }
     }
 #ifdef MFX_ENABLE_HEVCE_ROI
     else if (roi)

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_ddi.cpp
@@ -432,7 +432,7 @@ mfxStatus FillCUQPDataDDI(Task& task, MfxVideoParam &par, VideoCORE& core, mfxFr
         for (mfxU32 i = 0; i < CUQPFrameInfo.Height; i++) {
             for (mfxU32 j = 0; j < CUQPFrameInfo.Width; j++)
                 lock.Y[i * lock.Pitch + j] = mbqp->QP[i*drBlkH / inBlkSize * pitch_MBQP + j * drBlkW / inBlkSize];
-            for (mfxU32 j = CUQPFrameInfo.Width; j < lock.Pitch; j++) // hevc averages to LCU size
+            for (mfxU32 j = CUQPFrameInfo.Width; j < lock.Pitch; j++) // Fill all LCU blocks: HW hevc averages QP 
                 lock.Y[i * lock.Pitch + j] = lock.Y[i * lock.Pitch + CUQPFrameInfo.Width - 1];
         }
     }


### PR DESCRIPTION
Now MBQP block size used by HW in cuqpMap can vary according to caps.
Added cuqpMap filling for unaligned LCU, because HW averages LCU blocks to compute per LCU QP.
 (61287).
Manually tested.
Backmerged fixes for windows.