### PR TITLE
[hevce] Fix sliding window parameters

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -2553,9 +2553,9 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
                     }
                 }
             }
-            else if (!par.MaxKbps)
+            else
             {
-                changed++;
+                changed += CheckOption(CO3.WinBRCMaxAvgKbps, par.MaxKbps);
             }
         }
         else if (par.TargetKbps && CO3.WinBRCMaxAvgKbps && CO3.WinBRCMaxAvgKbps < par.TargetKbps) // ExtBRC is on

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy_defaults.cpp
@@ -2597,7 +2597,7 @@ public:
         auto   maxKbps = dpar.base.GetMaxKbps(dpar);
 
         changed += pCO3->WinBRCSize && SetIf(pCO3->WinBRCSize, pCO3->WinBRCSize != fps, fps);
-        changed += pCO3->WinBRCMaxAvgKbps && SetIf(pCO3->WinBRCMaxAvgKbps, pCO3->WinBRCMaxAvgKbps != maxKbps, maxKbps);
+        changed += SetIf(pCO3->WinBRCMaxAvgKbps, pCO3->WinBRCMaxAvgKbps != maxKbps, maxKbps);
 
         MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
         return MFX_ERR_NONE;


### PR DESCRIPTION
Max bitrate for sliding window is equal to max kbps by default