### PR TITLE
[vpx] correct buffer size in copy operation

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -67,8 +67,7 @@ namespace MFX_VPX_Utility
 
         if (p_in == p_out)
         {
-            mfxVideoParam in1;
-            MFX_INTERNAL_CPY(&in1, p_in, sizeof(mfxVideoParam));
+            mfxVideoParam in1 = *p_in;
             return Query(core, &in1, p_out, codecId, type);
         }
 
@@ -264,20 +263,21 @@ namespace MFX_VPX_Utility
 
             if (opaque_in && opaque_out)
             {
+                MFX_CHECK(opaque_out->In.Surfaces && opaque_in->In.Surfaces, MFX_ERR_UNDEFINED_BEHAVIOR);
                 opaque_out->In.Type = opaque_in->In.Type;
                 opaque_out->In.NumSurface = opaque_in->In.NumSurface;
-                MFX_INTERNAL_CPY(opaque_out->In.Surfaces, opaque_in->In.Surfaces, opaque_in->In.NumSurface);
+                if (opaque_in->In.Surfaces != opaque_out->In.Surfaces)
+                    std::copy_n(opaque_in->In.Surfaces, opaque_in->In.NumSurface, opaque_out->In.Surfaces);
 
+                MFX_CHECK(opaque_out->Out.Surfaces && opaque_in->Out.Surfaces, MFX_ERR_UNDEFINED_BEHAVIOR);
                 opaque_out->Out.Type = opaque_in->Out.Type;
                 opaque_out->Out.NumSurface = opaque_in->Out.NumSurface;
-                MFX_INTERNAL_CPY(opaque_out->Out.Surfaces, opaque_in->Out.Surfaces, opaque_in->Out.NumSurface);
+                if (opaque_in->Out.Surfaces != opaque_out->Out.Surfaces)
+                    std::copy_n(opaque_in->Out.Surfaces, opaque_in->Out.NumSurface, opaque_out->Out.Surfaces);
             }
             else
             {
-                if (opaque_out || opaque_in)
-                {
-                    sts = MFX_ERR_UNDEFINED_BEHAVIOR;
-                }
+                MFX_CHECK(!opaque_out && !opaque_in, MFX_ERR_UNDEFINED_BEHAVIOR);
             }
         }
         else
@@ -311,11 +311,6 @@ namespace MFX_VPX_Utility
             else
             {
                 p_out->IOPattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
-            }
-
-            mfxExtOpaqueSurfaceAlloc * opaqueOut = (mfxExtOpaqueSurfaceAlloc *)GetExtBuffer(p_out->ExtParam, p_out->NumExtParam, MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION);
-            if (opaqueOut)
-            {
             }
         }
 


### PR DESCRIPTION
MFX_INTERNAL_CPY uses buffer size in bytes