### PR TITLE
[HEVCe R] Disallow IOPattern=0 at QueryIOSurf

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
@@ -826,6 +826,21 @@ void Legacy::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
 
 void Legacy::QueryIOSurf(const FeatureBlocks& blocks, TPushQIS Push)
 {
+    Push(BLK_CheckIOPattern
+        , [](const mfxVideoParam& par, mfxFrameAllocRequest&, StorageRW&) -> mfxStatus
+    {
+        bool check_result = Check<mfxU16
+            , MFX_IOPATTERN_IN_VIDEO_MEMORY
+            , MFX_IOPATTERN_IN_SYSTEM_MEMORY
+            , MFX_IOPATTERN_IN_OPAQUE_MEMORY
+            >
+            (par.IOPattern);
+
+        MFX_CHECK(!check_result, MFX_ERR_INVALID_VIDEO_PARAM);
+
+        return MFX_ERR_NONE;
+    });
+    
     Push(BLK_CheckVideoParam
         , [&blocks](const mfxVideoParam& par, mfxFrameAllocRequest&, StorageRW& strg) -> mfxStatus
     {


### PR DESCRIPTION
Legacy have same behavior.
Note! Query/Init allow IOPattern=0! (same behavior for Legacy & refactored)

Signed-off-by: Andrey Larionov <andrey.larionov@intel.com>