### PR TITLE
sample_encode: Fix V4L2

### DIFF
--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -291,11 +291,11 @@ public:
 
     void SetNumView(mfxU32 numViews) { m_nNumView = numViews; }
     virtual void  PrintInfo();
-
+#if defined (ENABLE_V4L2_SUPPORT)
     void InitV4L2Pipeline(sInputParams *pParams);
     mfxStatus CaptureStartV4L2Pipeline();
     void CaptureStopV4L2Pipeline();
-
+#endif
     static void InsertIDR(mfxEncodeCtrl & ctrl, bool forceIDR);
 
     virtual mfxStatus OpenRoundingOffsetFile(sInputParams *pInParams);


### PR DESCRIPTION
Camera capture linear, but driver expected tiled memory with yuy2,uyvy
formats. When passed VA_SURFACE_ATTRIB_MEM_TYPE_VA with custom buffer,
driver sets memory to non-tiled.

Fixes:#1874

Signed-off-by: Anton Grishin <anton.grishin@intel.com>