### PR TITLE
[hevce][hevce r] Fix checks for dirty rectangle

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1085,6 +1085,8 @@ mfxStatus CheckAndFixDirtyRect(ENCODE_CAPS_HEVC const & caps, MfxVideoParam cons
     {
         // check that rectangle dimensions don't conflict with each other and don't exceed frame size
         RectData *rect = (RectData *)&(DirtyRect->Rect[i]);
+        // Dirty rectangle (0, 0, 0, 0) is a valid dirty rectangle and means that frame is not changed.
+        if (rect->Left==0 && rect->Right==0 && rect->Top==0 && rect->Bottom==0) continue;
 
         rsts = CheckAndFixRect(rect, par, caps);
 

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_dirty_rect.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_dirty_rect.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -74,10 +74,12 @@ mfxStatus CheckAndFixDirtyRect(
 
     auto IsInvalidRect = [](const DirtyRect::RectData& rect)
     {
+        // Dirty rectangle (0, 0, 0, 0) is a valid dirty rectangle and means that frame is not changed.
+        if (rect.Left==0 && rect.Right==0 && rect.Top==0 && rect.Bottom==0) return false;
         return ((rect.Left >= rect.Right) || (rect.Top >= rect.Bottom));
     };
     mfxU16 numValidRect = mfxU16(std::remove_if(dr.Rect, dr.Rect + dr.NumRect, IsInvalidRect) - dr.Rect);
-    changed += CheckMinOrClip(dr.NumRect, numValidRect);
+    changed += CheckMaxOrClip(dr.NumRect, numValidRect);
 
     if (changed)
         sts = MFX_WRN_INCOMPATIBLE_VIDEO_PARAM;


### PR DESCRIPTION
1. (0,0,0,0) is valid, that frame is not changed;
2. fixed 'changed' when invalid dirty rects are removed from the list in refactored code