### PR TITLE
sample: fix chroma size for Y410 and Y416

### DIFF
--- a/samples/sample_common/src/sample_utils.cpp
+++ b/samples/sample_common/src/sample_utils.cpp
@@ -926,6 +926,8 @@ mfxStatus GetChromaSize(const mfxFrameInfo & pInfo, mfxU32 & ChromaW, mfxU32 & C
     case MFX_FOURCC_AYUV:
     case MFX_FOURCC_YUY2:
     case MFX_FOURCC_A2RGB10:
+    case MFX_FOURCC_Y410:
+    case MFX_FOURCC_Y416:
     {
         if (pInfo.CropH > 0 && pInfo.CropW > 0)
         {


### PR DESCRIPTION
Without this patch, GetChromaSize() returns MFX_ERR_UNSUPPORTED for Y410
and Y416 frames, and sample_decode fails to write Y410 and Y416 frames
for VAProfileHEVCMain444_10 and VAProfileHEVCMain444_12 videos

example:

sample_decode  h265 -i input.10b.444.hevc -o output.yuv

[ERROR], sts=MFX_ERR_UNKNOWN(-1), RunDecoding, Unexpected error!!