### PR TITLE
[h264e] Enable QPOffset by default

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@
 #define MFX_ARRAY_SIZE(ARR) (sizeof(ARR)/sizeof(ARR[0]))
 const int MFX_MAX_DIRTY_RECT_COUNT = MFX_ARRAY_SIZE(mfxExtDirtyRect::Rect);
 const int MFX_MAX_MOVE_RECT_COUNT = MFX_ARRAY_SIZE(mfxExtMoveRect::Rect);
+const int DEFAULT_PPYR_INTERVAL = 3;
 
 
 namespace MfxHwH264Encode
@@ -291,9 +292,17 @@ namespace MfxHwH264Encode
         mfxExtCodingOptionDDI const * extDdi,
         mfxU8                         frameType);
 
-    mfxU8 GetQpValue(
+    mfxU8 GetPFrameLevel(
+        mfxU32 i,
+        mfxU32 num);
+
+    mfxU8 PLayer(
         MfxVideoParam const & par,
-        mfxEncodeCtrl const & ctrl,
+        mfxU32                order);
+
+    mfxU8 GetQpValue(
+        DdiTask const &       task,
+        MfxVideoParam const & par,
         mfxU32                frameType);
 
     PairU16 GetPicStruct(

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
@@ -2315,8 +2315,8 @@ void MfxHwH264Encode::ConfigureTask(
         task.m_nalRefIdc[sfid] = task.m_reference[sfid] ? 2 : 0;
     }
 
-    task.m_cqpValue[0] = GetQpValue(video, task.m_ctrl, task.m_type[0]);
-    task.m_cqpValue[1] = GetQpValue(video, task.m_ctrl, task.m_type[1]);
+    task.m_cqpValue[0] = GetQpValue(task, video, task.m_type[0]);
+    task.m_cqpValue[1] = GetQpValue(task, video, task.m_type[1]);
 
     task.m_statusReportNumber[0] = 2 * task.m_encOrder;
     task.m_statusReportNumber[1] = 2 * task.m_encOrder + 1;

--- a/_studio/mfx_lib/fei/h264_common/fei_common.cpp
+++ b/_studio/mfx_lib/fei/h264_common/fei_common.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -172,8 +172,8 @@ void MfxH264FEIcommon::ConfigureTaskFEI(
         task.m_nalRefIdc[sfid] = task.m_reference[sfid] ? 2 : 0;
     }
 
-    task.m_cqpValue[0] = GetQpValue(video, task.m_ctrl, task.m_type[0]);
-    task.m_cqpValue[1] = GetQpValue(video, task.m_ctrl, task.m_type[1]);
+    task.m_cqpValue[0] = GetQpValue(task, video, task.m_type[0]);
+    task.m_cqpValue[1] = GetQpValue(task, video, task.m_type[1]);
 
 #if MFX_VERSION >= 1023
 

--- a/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -606,6 +606,7 @@ namespace MfxHwH264Encode
             mfxU16 widthLa;
             mfxU16 heightLa;
             mfxU32 TCBRCTargetFrameSize;
+            mfxU32 PPyrInterval;
         } calcParam;
     };
 

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -3207,8 +3207,32 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
     if (!CheckTriStateOption(extOpt2->RepeatPPS))               changed = true;
     if (!CheckTriStateOption(extOpt2->UseRawRef))               changed = true;
 
+    if (!CheckTriStateOption(extOpt3->EnableQPOffset))              changed = true;
     if (!CheckTriStateOption(extOpt3->DirectBiasAdjustment))        changed = true;
     if (!CheckTriStateOption(extOpt3->GlobalMotionBiasAdjustment))  changed = true;
+
+    if (   IsOn(extOpt3->EnableQPOffset)
+        && (par.mfx.RateControlMethod != MFX_RATECONTROL_CQP
+            || (par.mfx.GopRefDist > 1 && extOpt2->BRefType == MFX_B_REF_OFF)
+            || (par.mfx.GopRefDist == 1 && extOpt3->PRefType == MFX_P_REF_SIMPLE)))
+    {
+        extOpt3->EnableQPOffset = MFX_CODINGOPTION_OFF;
+        changed = true;
+    }
+
+    if (IsOn(extOpt3->EnableQPOffset))
+    {
+        mfxU16 minQP = 1;
+        mfxU16 maxQP = 51;
+        mfxI16 QPX = (par.mfx.GopRefDist == 1) ? par.mfx.QPP : par.mfx.QPB;
+
+        if (QPX)
+        {
+            for (mfxI16 i = 0; i < 8; i++)
+                if (!CheckRange(extOpt3->QPOffset[i], minQP - QPX, maxQP - QPX))
+                    changed = true;
+        }
+    }
 
     if ((isENCPAK || vaType != MFX_HW_VAAPI)
         && (IsOn(extOpt3->DirectBiasAdjustment) || IsOn(extOpt3->GlobalMotionBiasAdjustment)))
@@ -5273,6 +5297,7 @@ void MfxHwH264Encode::InheritDefaultValues(
     }
     InheritOption(extOpt2Init.DisableVUI,      extOpt2Reset.DisableVUI);
     InheritOption(extOpt2Init.SkipFrame,       extOpt2Reset.SkipFrame);
+    InheritOption(extOpt3Init.PRefType,        extOpt3Reset.PRefType);
 
     InheritOption(extOpt2Init.ExtBRC,  extOpt2Reset.ExtBRC);
 
@@ -5784,6 +5809,36 @@ void MfxHwH264Encode::SetDefaults(
     if (extOpt2->RepeatPPS == MFX_CODINGOPTION_UNKNOWN)
         extOpt2->RepeatPPS = MFX_CODINGOPTION_ON;
 
+    mfxExtBRC const & extBRC = GetExtBufferRef(par);
+
+    if (extOpt3->PRefType == MFX_P_REF_DEFAULT)
+    {
+        if (par.mfx.GopRefDist == 1 && ((par.mfx.RateControlMethod == MFX_RATECONTROL_CQP) || (IsExtBrcSceneChangeSupported(par) && !extBRC.pthis)))
+            extOpt3->PRefType = MFX_P_REF_PYRAMID;
+        else if (par.mfx.GopRefDist == 1)
+            extOpt3->PRefType = MFX_P_REF_SIMPLE;
+    }
+
+    if (!extOpt3->EnableQPOffset)
+    {
+        mfxU16 minQP = 1;
+        mfxU16 maxQP = 51;
+        if (par.mfx.RateControlMethod == MFX_RATECONTROL_CQP
+            && (extOpt2->BRefType == MFX_B_REF_PYRAMID || extOpt3->PRefType == MFX_P_REF_PYRAMID))
+        {
+            extOpt3->EnableQPOffset = MFX_CODINGOPTION_ON;
+            mfxI16 QPX = (par.mfx.GopRefDist == 1) ? par.mfx.QPP : par.mfx.QPB;
+
+            for (mfxI16 i = 0; i < 8; i++)
+                extOpt3->QPOffset[i] = mfx::clamp<mfxI16>(i + (par.mfx.GopRefDist > 1), (mfxI16)minQP - QPX, (mfxI16)maxQP - QPX);
+        }
+        else
+            extOpt3->EnableQPOffset = MFX_CODINGOPTION_OFF;
+    }
+
+    if (IsOff(extOpt3->EnableQPOffset))
+        Zero(extOpt3->QPOffset);
+
     if (extOpt2->MinQPI || extOpt2->MinQPP || extOpt2->MinQPB ||
         extOpt2->MaxQPI || extOpt2->MaxQPP || extOpt2->MaxQPB)
     {
@@ -5822,6 +5877,8 @@ void MfxHwH264Encode::SetDefaults(
             par.mfx.NumRefFrame = 1;
         else if ((par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE) == 0)
             par.mfx.NumRefFrame = std::min({std::max(nrfDefault, nrfMinForInterlace), nrfMaxByLevel, nrfMaxByCaps});
+        else if (extOpt3->PRefType == MFX_P_REF_PYRAMID)
+            par.mfx.NumRefFrame = std::max<mfxU16>((mfxU16)par.calcParam.PPyrInterval, extDdi->NumActiveRefP);
         else
             par.mfx.NumRefFrame = std::min({nrfDefault, nrfMaxByLevel, nrfMaxByCaps});
 
@@ -5829,6 +5886,8 @@ void MfxHwH264Encode::SetDefaults(
         {
             par.mfx.NumRefFrame = std::min<mfxU16>(hwCaps.ddi_caps.MaxNum_Reference, par.mfx.NumRefFrame);
         }
+
+        par.calcParam.PPyrInterval = std::min<mfxU32>(par.calcParam.PPyrInterval, par.mfx.NumRefFrame);
     }
 
     if (extOpt->IntraPredBlockSize == MFX_BLOCKSIZE_UNKNOWN)
@@ -5882,7 +5941,6 @@ void MfxHwH264Encode::SetDefaults(
     if (extOpt3->ExtBrcAdaptiveLTR == MFX_CODINGOPTION_UNKNOWN)
     {
         extOpt3->ExtBrcAdaptiveLTR = MFX_CODINGOPTION_OFF;
-        mfxExtBRC const & extBRC = GetExtBufferRef(par);
         // remove check when sample extbrc is same as implicit extbrc
         // currently added for no behaviour change in sample extbrc
         if (IsExtBrcSceneChangeSupported(par) && !extBRC.pthis)
@@ -5893,7 +5951,6 @@ void MfxHwH264Encode::SetDefaults(
         }
     }
 
-    mfxExtBRC const & extBRC = GetExtBufferRef(par);
     if (extOpt2->AdaptiveI == MFX_CODINGOPTION_UNKNOWN)
     {
         if (IsExtBrcSceneChangeSupported(par) && !extBRC.pthis)
@@ -5908,14 +5965,6 @@ void MfxHwH264Encode::SetDefaults(
             extOpt2->AdaptiveB = MFX_CODINGOPTION_ON;
         else
             extOpt2->AdaptiveB = MFX_CODINGOPTION_OFF;
-    }
-
-    if (extOpt3->PRefType == MFX_P_REF_DEFAULT)
-    {
-        if (par.mfx.GopRefDist == 1 && IsExtBrcSceneChangeSupported(par) && !extBRC.pthis)
-            extOpt3->PRefType = MFX_P_REF_PYRAMID;
-        else if (par.mfx.GopRefDist == 1)
-            extOpt3->PRefType = MFX_P_REF_SIMPLE;
     }
 #endif //(MFX_VERSION >= 1026)
 
@@ -7565,6 +7614,8 @@ MfxVideoParam& MfxVideoParam::operator=(mfxVideoParam const & par)
 void MfxVideoParam::SyncVideoToCalculableParam()
 {
     mfxU32 multiplier = std::max<mfxU16>(mfx.BRCParamMultiplier, 1);
+
+    calcParam.PPyrInterval = (mfx.NumRefFrame > 0) ? std::min<mfxU32>(DEFAULT_PPYR_INTERVAL, mfx.NumRefFrame) : DEFAULT_PPYR_INTERVAL;
 
     calcParam.bufferSizeInKB   = mfx.BufferSizeInKB   * multiplier;
     if (IsOn(m_extOpt.VuiNalHrdParameters)


### PR DESCRIPTION
- In CQP mode and GopRefDist 1 case
  PRefType is set to MFX_P_REF_PYRAMID by default.
- EnableQPOffset is on by default, QPOffset is added in CQP mode.