### PR TITLE
Fix HEVC SCC IntraBlockCopy case failure

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_slice_decoding.cpp
@@ -298,13 +298,19 @@ int H265Slice::getNumRpsCurrTempList() const
   if (GetSliceHeader()->slice_type != I_SLICE)
   {
       const ReferencePictureSet *rps = getRPS();
+      bool intra_block_copy_flag = (GetPicParam()->pps_curr_pic_ref_enabled_flag != 0);
 
-      for(uint32_t i=0;i < rps->getNumberOfNegativePictures() + rps->getNumberOfPositivePictures() + rps->getNumberOfLongtermPictures();i++)
+      for (uint32_t i=0;i < rps->getNumberOfNegativePictures() + rps->getNumberOfPositivePictures() + rps->getNumberOfLongtermPictures();i++)
       {
-        if(rps->getUsed(i))
-        {
+          if (rps->getUsed(i))
+          {
+              numRpsCurrTempList++;
+          }
+      }
+
+      if (intra_block_copy_flag)
+      {
           numRpsCurrTempList++;
-        }
       }
   }
 


### PR DESCRIPTION
Increase numRpsCurrTempList when pps_intra_block_copy_flag is true.

Issue: MDP-60807
Test: mfx_player.exe -i:hevc ScreenExtendedMain444_10_L41_00_IntraBlockCopy_192x200_r4446.hevc
-o ScreenExtendedMain444_10_L41_00_IntraBlockCopy_192x200_r4446_MediaSDK_dx11.yuv -hw -d3d -n 2 -f 30

Change-Id: Ia0bf7e4d667a311c24c7f488f4eecc3bf464b84e