### PR TITLE
[sample_decode] VP8, VP9 reading were fixed (backmerge)

### DIFF
--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -899,6 +899,7 @@ class CIVFFrameReader : public CSmplBitstreamReader
 {
 public:
     CIVFFrameReader();
+    virtual void      Reset();
     virtual mfxStatus Init(const msdk_char *strFileName);
     virtual mfxStatus ReadNextFrame(mfxBitstream *pBS);
 
@@ -928,6 +929,7 @@ protected:
         mfxU32 num_frames;
         mfxU32 unused;
     }m_hdr;
+    mfxStatus ReadHeader();
 };
 
 // writes bitstream to duplicate-file & supports joining


### PR DESCRIPTION
Issue:MDP-62025
Test:manual

Win validations get MFX_ERR_NOT_ENOUGH_BUFFER for VP8 and VP9 codecs. Next frame data was read wrong (read head again)