### PR TITLE
[AVCe] VA may return multiple values in VAConfigAttribEncSliceStructure

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_vaapi.cpp
@@ -886,7 +886,6 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
         VAConfigAttribMaxPictureWidth,
         VAConfigAttribEncParallelRateControl,
         VAConfigAttribEncMaxRefFrames,
-        VAConfigAttribEncSliceStructure,
         VAConfigAttribEncROI,
         VAConfigAttribEncTileSupport
     };

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -90,21 +90,18 @@ VAProfile ConvertProfileTypeMFX2VAAPI(mfxU32 type)
 
 } // VAProfile ConvertProfileTypeMFX2VAAPI(mfxU8 type)
 
-mfxU8 ConvertSliceStructureVAAPIToMFX(mfxU8 structure)
+static mfxU8 ConvertSliceStructureVAAPIToMFX(mfxU8 structure)
 {
-    switch (structure)
-    {
-        case VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS:
-            return 1;
-        case VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS:
-            return 2;
-        case VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS:
-            return 3;
-        case VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS:
-            return 4;
-        default:
-            return 0;
-    }
+    if (structure & VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS)
+        return 1;
+    else if (structure & VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS)
+        return 2;
+    else if (structure & VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS)
+        return 3;
+    else if (structure & VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS)
+        return 4;
+    else
+        return 0;
 }
 
 mfxStatus SetHRD(

--- a/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
@@ -398,7 +398,6 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(mfxU16 codecProfile)
         VAConfigAttribMaxPictureWidth,
         VAConfigAttribEncSkipFrame,
         VAConfigAttribEncMaxRefFrames,
-        VAConfigAttribEncSliceStructure
     };
 
     std::vector<VAConfigAttrib> attrs;
@@ -432,9 +431,6 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(mfxU16 codecProfile)
 
     if (CheckAttribValue(attrs[idx_map[VAConfigAttribEncMaxRefFrames]].value))
         m_caps.MaxNum_Reference  = attrs[idx_map[VAConfigAttribEncMaxRefFrames]].value;
-
-    if (CheckAttribValue(attrs[idx_map[VAConfigAttribEncSliceStructure]].value))
-        m_caps.SliceStructure  = attrs[idx_map[VAConfigAttribEncSliceStructure]].value;
 
     return MFX_ERR_NONE;
 }


### PR DESCRIPTION
Previously combined values were mapped to 0.

Issue: MDP-61999