### PR TITLE
[hevce] allow SAO with WP

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_sao.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_sao.h
@@ -62,12 +62,7 @@ protected:
                 mfxExtHEVCParam* pHEVC = ExtBuffer::Get(par);
                 MFX_CHECK(pHEVC, MFX_ERR_NONE);
 
-                mfxExtCodingOption3* pCO3 = ExtBuffer::Get(par);
-
-                bool bNoSAO =
-                    (pCO3 && pCO3->WeightedPred == MFX_WEIGHTED_PRED_EXPLICIT)
-                    || (pCO3 && pCO3->WeightedBiPred == MFX_WEIGHTED_PRED_EXPLICIT)
-                    || defPar.base.GetLCUSize(defPar) == 16;
+                bool bNoSAO = defPar.base.GetLCUSize(defPar) == 16;
 
                 bool bChanged = CheckOrZero<mfxU16>(
                     pHEVC->SampleAdaptiveOffset


### PR DESCRIPTION
Removed obsolete rule to disable SAO when WeightedPrediction is enabled