### PR TITLE
vp9d: fix 8K regression

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -199,12 +199,12 @@ namespace MFX_VPX_Utility
             if (!p_in->mfx.FrameInfo.ChromaFormat && !(!p_in->mfx.FrameInfo.FourCC && !p_in->mfx.FrameInfo.ChromaFormat))
                 sts = MFX_ERR_UNSUPPORTED;
 
-            if (p_in->mfx.FrameInfo.Width % 16 == 0 && p_in->mfx.FrameInfo.Width <= GetMaxWidth(codecId))
+            if (p_in->mfx.FrameInfo.Width % 16 == 0)
                 p_out->mfx.FrameInfo.Width = p_in->mfx.FrameInfo.Width;
             else
                 sts = MFX_ERR_UNSUPPORTED;
 
-            if (p_in->mfx.FrameInfo.Height % 16 == 0 && p_in->mfx.FrameInfo.Height <= GetMaxHeight(codecId))
+            if (p_in->mfx.FrameInfo.Height % 16 == 0)
                 p_out->mfx.FrameInfo.Height = p_in->mfx.FrameInfo.Height;
             else
                 sts = MFX_ERR_UNSUPPORTED;


### PR DESCRIPTION
commit dc8ed84 removed the resolution limitation for vp9 decoder,
however commit 444ecb4 added this limitation back, which results in
regression with 8K decoding