### PR TITLE
[HEVCe] Fix MBQP averaging on frame borders

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/linux/g9/hevcehw_g9_va_packer_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/g9/hevcehw_g9_va_packer_lin.cpp
@@ -392,9 +392,9 @@ static bool FillCUQPDataVA(
     if (bInvalid)
         return false;
 
-    for (mfxU32 i = 0; i < cuqpMap.m_height; i++)
+    for (mfxU32 i = 0; i < cuqpMap.m_h_aligned; i++)
     {
-        for (mfxU32 j = 0; j < cuqpMap.m_width; j++)
+        for (mfxU32 j = 0; j < cuqpMap.m_pitch; j++)
         {
             mfxU32 y = i * drBlkH / inBlkSize;
             mfxU32 x = j * drBlkW / inBlkSize;


### PR DESCRIPTION
QP values should be averaged within LCU.
For non LCU aligned resolutions
QP averaging on frame borders was observed.