### PR TITLE
[HEVCe] Fix IntraRefresh with multiref issue

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy.cpp
@@ -2733,7 +2733,19 @@ void Legacy::InitDPB(
         task.POC > task.PrevRAP
         && prevTask.POC <= prevTask.PrevRAP;
 
-    if (b1stTrail)
+    if ((task.IRState.refrType && !task.IRState.firstFrameInCycle) // IntRefCycle
+        || (!task.IRState.refrType && prevTask.IRState.refrType)) // First frame after IntRefCycle
+    {
+        Remove(task.DPB.Active, 0, MAX_DPB_SIZE);
+
+        for (mfxU8 i = 0; !isDpbEnd(prevTask.DPB.After, i); i++)
+        {
+            const DpbFrame& ref = prevTask.DPB.After[i]; // initial POC = -1
+            if (ref.POC > task.DPB.Active[0].POC) // disable multiref within IntraRefCycle and next frame
+                task.DPB.Active[0] = ref;
+        }
+    }
+    else if (b1stTrail)
     {
         Remove(task.DPB.Active, 0, MAX_DPB_SIZE);
 


### PR DESCRIPTION
First frame in Intrarefresh cycle can have more than one references
All other frames in Intrarefresh cycle should have only one reference
First frame after Intrarefresh cycle should have only one reference
Other frames outside IntraRefresh cycle can have more than one reference