### PR TITLE
sample_encode: fix BufferSizeInKB initialization

### DIFF
--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -1566,7 +1566,7 @@ void ModifyParamsUsingPresets(sInputParams& params)
     {
         MODIFY_AND_PRINT_PARAM(params.nBitRate, TargetKbps, params.shouldPrintPresets);
         MODIFY_AND_PRINT_PARAM(params.MaxKbps, MaxKbps, params.shouldPrintPresets);
-        presetParams.BufferSizeInKB = params.nBitRate; // Update bitrate to reflect manually set bitrate. BufferSize should be enough for 1 second of video
+        presetParams.BufferSizeInKB = params.nBitRate / 8; // Update bitrate to reflect manually set bitrate. BufferSize should be enough for 1 second of video
         MODIFY_AND_PRINT_PARAM(params.BufferSizeInKB, BufferSizeInKB, params.shouldPrintPresets);
     }
 


### PR DESCRIPTION
By default BufferSizeInKB is wrongly set to 8 sec (since bitrate is in Kilobits not KiloBytes). This fix sets it to 1 sec as intended.