### PR TITLE
1) fix small buffer for 16k wpp stream;  2)  clear vector when re-allocate buffer

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/platform/umc_h265_va_packer_vaapi_g12.hpp
+++ b/_studio/shared/umc/codec/h265_dec/include/platform/umc_h265_va_packer_vaapi_g12.hpp
@@ -165,7 +165,7 @@ namespace UMC_HEVC_DECODER
                     sp->entry_offset_to_subset_array   = p.first;
                 }
 
-                if (last_slice)
+                if (last_slice && pps->tiles_enabled_flag)
                     PackSubsets(slice->GetCurrentFrame());
                 return sp_base;
             }

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
@@ -74,6 +74,9 @@ private:
     {
         return *this;
     }
+
+    // Assume we have max 300 bytes prevention, 1760(440 x 4) bytes for entrypoint offsets, 800 bytes for other slice header
+    const int SliceHeaderSize = 2860;
 };
 
 // this template class added to apply big surface pool workaround depends on platform

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1942,13 +1942,12 @@ H265Slice *TaskSupplier_H265::DecodeSliceHeader(UMC::MediaDataEx *nalUnit)
         //reallocate memory for slice header
         if (NumOfMaxEntryPoints > 512)
         {
-            vm_string_printf(VM_STRING("Re-allocate buffer for slice header!\n"));
-
             //offset_len_minus1[0-31], assume maximum 31[4 bytes]
             int newsize = 1024 + NumOfMaxEntryPoints * 4 + DEFAULT_NU_TAIL_SIZE;
             pSlice->m_source.Allocate(newsize);
 
             //swap buffer again, since buffer is small at first time
+            removed_offsets.clear();
             memCopy.SetData(nalUnit);
             swapper->SwapMemory(&pSlice->m_source, &memCopy, &removed_offsets);
         }

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_supplier.cpp
@@ -174,7 +174,7 @@ UMC::Status VATaskSupplier::AllocateFrameData(H265DecoderFrame * pFrame, mfxSize
 H265Slice * VATaskSupplier::DecodeSliceHeader(UMC::MediaDataEx *nalUnit)
 {
     size_t dataSize = nalUnit->GetDataSize();
-    nalUnit->SetDataSize(std::min<size_t>(2560, dataSize));
+    nalUnit->SetDataSize(std::min<size_t>(SliceHeaderSize, dataSize));
 
     H265Slice * slice = TaskSupplier_H265::DecodeSliceHeader(nalUnit);
 


### PR DESCRIPTION
There two changes are all cherry-picked from internal branch.
1) For 16k wpp stream,  it has up to 300 bytes' prevention, so increase 300 bytes here. Meanwhile, 300 bytes is the  biggest size we met till now.