### PR TITLE
[hevce] Fix NumRefActive

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g9/hevcehw_g9_legacy_defaults.cpp
@@ -2669,7 +2669,7 @@ public:
         MFX_CHECK(pCO3, MFX_ERR_NONE);
 
         mfxU16 maxDPB = par.mfx.NumRefFrame + 1;
-        SetIf(maxDPB, !maxDPB, defPar.base.GetMaxDPB, defPar);
+        SetIf(maxDPB, !par.mfx.NumRefFrame, defPar.base.GetMaxDPB, defPar);
 
         mfxU16 maxForward = std::min<mfxU16>(defPar.caps.MaxNum_Reference0, maxDPB - 1);
         mfxU16 maxBackward = std::min<mfxU16>(defPar.caps.MaxNum_Reference1, maxDPB - 1);


### PR DESCRIPTION
ExtCO3.NumRefActive values were discarded
because when NumRefFrame is not set maxDBP
became like 0.
Now maxDBP is set to default in this case.
[62088]
Test: manual check logs and encoded stream