### PR TITLE
[jpege] Improve caps usage

### DIFF
--- a/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_vaapi.h
+++ b/_studio/mfx_lib/encode_hw/mjpeg/include/mfx_mjpeg_encode_vaapi.h
@@ -101,6 +101,7 @@ namespace MfxHwMJpegEncode
         VideoCORE       * m_core;
         mfxU32            m_width;
         mfxU32            m_height;
+        JpegEncCaps       m_caps;
         VADisplay         m_vaDisplay;
         VAContextID       m_vaContextEncode;
         VAConfigID        m_vaConfig;

--- a/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/mjpeg/src/mfx_mjpeg_encode_hw_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -35,11 +35,6 @@ mfxStatus MfxHwMJpegEncode::QueryHwCaps(VideoCORE * core, JpegEncCaps & hwCaps)
 {
     MFX_CHECK_NULL_PTR1(core);
 
-    // Should be replaced with once quering capabs as other encoders do
-    // remove this when driver starts returning actual encode caps
-    hwCaps.MaxPicWidth      = 4096;
-    hwCaps.MaxPicHeight     = 4096;
-
     if (core->GetVAType() == MFX_HW_VAAPI && core->GetHWType() < MFX_HW_CHT)
         return MFX_ERR_UNSUPPORTED;
 
@@ -48,6 +43,8 @@ mfxStatus MfxHwMJpegEncode::QueryHwCaps(VideoCORE * core, JpegEncCaps & hwCaps)
     if (ddi.get() == 0)
         return MFX_ERR_NULL_PTR;
 
+    // the device is created just to query caps,
+    // so width/height are insignificant
     mfxStatus sts = ddi->CreateAuxilliaryDevice(core, 640, 480, true);
     MFX_CHECK_STS(sts);
 


### PR DESCRIPTION
1) Cache jpege caps, not ask them at every EncodeFrameAsync.
2) Request some encoding limitation from driver, not use hardcoded values.