### PR TITLE
build: do not enforce specific instruction set

### DIFF
--- a/builder/ConfTargets.cmake
+++ b/builder/ConfTargets.cmake
@@ -20,23 +20,7 @@
 
 message( STATUS "Global Configuration of Targets" )
 
-set( T_ARCH "sse4.2" )
-message( STATUS "Target Architecture to compile: ${T_ARCH}" )
-
 append("-std=c++11" CMAKE_CXX_FLAGS)
-
-# SW HEVC decoder & encoder require SSE4.2
-  if (CMAKE_C_COMPILER MATCHES icc)
-    append("-xSSE4.2 -static-intel" CMAKE_C_FLAGS)
-  else()
-    append("-m${T_ARCH}" CMAKE_C_FLAGS)
-  endif()
-
-  if (CMAKE_CXX_COMPILER MATCHES icpc)
-    append("-xSSE4.2 -static-intel" CMAKE_CXX_FLAGS)
-  else()
-    append("-m${T_ARCH}" CMAKE_CXX_FLAGS)
-  endif()
 
 if (ENABLE_TEXTLOG)
   append("-DMFX_TRACE_ENABLE_TEXTLOG" CMAKE_C_FLAGS)


### PR DESCRIPTION
Fixes: #2047

We should not enforce specific instruction set target (-m<inst-set>
option) since end-users might experience crashes with sigill at
least for the following reasons:
1. msdk lib might be probed at runtime even on non-intel CPUs if it
is included into some plugin based framework (like gstreamer)
2. unit tests included into build system might be run on the system
where build had happenned which might be non-intel

So, this change remove msdk global instruction set flags. We still
have few places in the library tight to the particular instruction
set. These are optimization specific algorithms such as ipp, asc
(scene change detection) and memory copy operations. In these cases
we use runtime checks to detect underlying instruction sets. If we
don't support particular one - we are supposed to gracefully fail.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>