### PR TITLE
fix compile error with -Wreturn-stack-address

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -285,7 +285,7 @@ template<class T> T Reorder(
 
     if (!brefs.empty())
     {
-        return brefs[BPyrReorder(brefs,par.isField())];
+        return std::move(brefs[BPyrReorder(brefs,par.isField())]);
     }
 
     if (b0 != end)


### PR DESCRIPTION
we met this error with clang version 10.0.4. 

to address below error met on Android building process:
address of stack memory associated with local variable 'brefs'
returned [-Werror,-Wreturn-stack-address]

Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>