### PR TITLE
[DISP]: Change the API version verification

### DIFF
--- a/api/mfx_dispatch/windows/src/main.cpp
+++ b/api/mfx_dispatch/windows/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2019 Intel Corporation
+// Copyright (c) 2012-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -899,7 +899,7 @@ mfxStatus MFXJoinSession(mfxSession session, mfxSession child_session)
     MFX_DISP_HANDLE *pChildHandle = (MFX_DISP_HANDLE *)child_session;
 
     // get the function's address and make a call
-    if ((pHandle) && (pChildHandle) && (pHandle->apiVersion == pChildHandle->apiVersion))
+    if ((pHandle) && (pChildHandle) && (pHandle->actualApiVersion == pChildHandle->actualApiVersion))
     {
         /* check whether it is audio session or video */
         int tableIndex = eMFXJoinSession;


### PR DESCRIPTION
Change the API version verification condition in MFXJoinSession
function from the desired version of the library implementation
to loaded SDK implementation version.