### PR TITLE
[h264e] Pass BRC reset flag to driver

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
@@ -293,6 +293,7 @@ namespace MfxHwH264Encode
         mfxU32 m_skipMode;
         bool m_isENCPAK;
 
+        bool                           m_isBrcResetRequired;
         VAEncMiscParameterRateControl  m_vaBrcPar;
         VAEncMiscParameterFrameRate    m_vaFrameRate;
 


### PR DESCRIPTION
rc_flags.bits.reset is used inside vaRenderPicture(), but it's value was
lost on VAEncMiscParameterBufferType buffer's recreation.

Issue: MDP-61317