### PR TITLE
[mpeg2e] Add CodecProfile/Level checking in Query

### DIFF
--- a/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/mpeg2/src/mfx_mpeg2_encode_utils_hw.cpp
@@ -822,6 +822,15 @@ namespace MPEG2EncoderHW
                 out->mfx.CodecLevel = MFX_LEVEL_UNKNOWN;
                 bWarning = true;
             }
+            if (CorrectProfileLevelMpeg2(out->mfx.CodecProfile, out->mfx.CodecLevel,
+                out->mfx.FrameInfo.Width, out->mfx.FrameInfo.Height,
+                CalculateUMCFramerate(out->mfx.FrameInfo.FrameRateExtN, out->mfx.FrameInfo.FrameRateExtD),
+                out->mfx.RateControlMethod == MFX_RATECONTROL_CQP ? 0 : (mfxU32)(out->mfx.TargetKbps * out->mfx.BRCParamMultiplier * BRC_BITS_IN_KBIT),
+                out->mfx.GopRefDist))
+            {
+                bWarning = true;
+            }
+
             if (bAVBR_WA)
             {
                 bWarning = AVBR_via_CBR(out) ? true : bWarning;


### PR DESCRIPTION
Added missed CodecProfile/Level checking in Query.
It failed before if CodecProfile and CodecLevel were inconsistent.