### PR TITLE
[hevce] remove usage of extddi buffer for LCUSize

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h265/include/mfx_h265_encode_hw_utils.h
@@ -554,7 +554,6 @@ namespace ExtBuffer
         MFX_COPY_FIELD(NumActiveRefBL0);
         MFX_COPY_FIELD(NumActiveRefBL1);
         MFX_COPY_FIELD(NumActiveRefP);
-        MFX_COPY_FIELD(LCUSize);
         MFX_COPY_FIELD(QpAdjust);
     }
     inline void  CopySupportedParams(mfxExtEncoderCapability& buf_dst, mfxExtEncoderCapability& buf_src)

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_par.cpp
@@ -1300,7 +1300,6 @@ void InheritDefaultValues(
 
     mfxExtCodingOptionDDI const* extOptDDIInit = &parInit.m_ext.DDI;
     mfxExtCodingOptionDDI      * extOptDDIReset = &parReset.m_ext.DDI;
-    InheritOption(extOptDDIInit->LCUSize, extOptDDIReset->LCUSize);
 #if (MFX_VERSION >= 1025)
     if (parInit.mfx.TargetUsage != parReset.mfx.TargetUsage)
     {   // NumActiveRefs depends on TU
@@ -1577,17 +1576,6 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
 
     changed += CheckTriStateOption(par.mfx.LowPower);
 
-#if (MFX_VERSION >= 1025)
-    if (par.m_ext.DDI.LCUSize != 0)
-    {
-        if (CheckLCUSize(caps.ddi_caps.LCUSizeSupported, par.m_ext.DDI.LCUSize))
-        {
-            par.LCUSize = par.m_ext.DDI.LCUSize;
-        }
-        else
-            invalid++;
-    }
-
 #if (MFX_VERSION >= 1026)
     if (par.m_ext.HEVCParam.LCUSize != 0)
     {
@@ -1598,15 +1586,7 @@ mfxStatus CheckVideoParam(MfxVideoParam& par, MFX_ENCODE_CAPS_HEVC const & caps,
         else
             invalid++;
     }
-
-    // HEVCParam.LCUSize have a priority.
-    if ((par.m_ext.DDI.LCUSize != 0) &&  (par.m_ext.DDI.LCUSize != par.m_ext.HEVCParam.LCUSize))
-    {
-        par.m_ext.DDI.LCUSize = 0;
-        changed++;
-    }
 #endif // MFX_VERSION >= 1026
-#endif // MFX_VERSION >= 1025
     if (!par.LCUSize)
         par.LCUSize = GetDefaultLCUSize(par, caps.ddi_caps); //  that a local copy of actual value;
 
@@ -2703,7 +2683,6 @@ void SetDefaults(
 #if MFX_VERSION >= 1026
     par.m_ext.HEVCParam.LCUSize = (mfxU16)par.LCUSize; // typecast is safe since value must be valid 8,16,32,64
 #endif
-    par.m_ext.DDI.LCUSize = (mfxU16)par.LCUSize;
 
     if (par.mfx.CodecLevel)
     {

--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -892,9 +892,7 @@ mfxStatus MfxVideoParam::GetExtBuffers(mfxVideoParam& par, bool query)
     ExtBuffer::Set(par, m_ext.CO3);
     ExtBuffer::Set(par, m_ext.ResetOpt);
 
-    if (ExtBuffer::Set(par, m_ext.DDI))
-    {
-    }
+    ExtBuffer::Set(par, m_ext.DDI);
     ExtBuffer::Set(par, m_ext.AVCTL);
     ExtBuffer::Set(par, m_ext.ROI);
     ExtBuffer::Set(par, m_ext.VSI);

--- a/_studio/shared/include/mfx_ext_buffers.h
+++ b/_studio/shared/include/mfx_ext_buffers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -90,7 +90,7 @@ typedef struct {
     mfxU16 RegressionWindow;        //
     mfxU16 LookAheadDependency;     // LookAheadDependency < LookAhead
     mfxU16 Hme;                     // tri-state
-    mfxU16 LCUSize;                 // 32 or 64 - overrides default value of Largest Coding Unit
+    mfxU16 reserved4;               //
     mfxU16 WriteIVFHeaders;         // tri-state
     mfxU16 RefreshFrameContext;
     mfxU16 ChangeFrameContextIdxForTS;


### PR DESCRIPTION
LCUSize is removed from mfxExtCodingOptionDDI buffer since
it was moved to mfxExtHEVCParam (official API)
