### PR TITLE
[hevce r] Fix reset on Linux

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_va_packer_lin.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_va_packer_lin.cpp
@@ -534,7 +534,6 @@ void VAPacker::ResetState(const FeatureBlocks& /*blocks*/, TPushRS Push)
         AddVaMiscQualityParams(par, m_vaPerSeqMiscData);
 
         auto& vaInitPar = Tmp::DDI_InitParam::GetOrConstruct(local);
-        vaInitPar.clear();
 
         std::transform(
             m_vaPerSeqMiscData.begin()


### PR DESCRIPTION
vaInitPar contains buffer data. Pushed buffs in blocks before VAPacker Reset were erased.