### PR TITLE
[h264e] VA may return multiple values in VAConfigAttribEncSliceStructure

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -1205,7 +1205,7 @@ mfxStatus ImplementationAvc::Init(mfxVideoParam * par)
     // init slice divider
     bool fieldCoding = (m_video.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE) == 0;
     m_sliceDivider = MakeSliceDivider(
-        (m_caps.ddi_caps.SliceLevelRateCtrl) ? 4 : m_caps.ddi_caps.SliceStructure,
+        (m_caps.ddi_caps.SliceLevelRateCtrl) ? SliceDividerType::ARBITRARY_MB_SLICE : SliceDividerType(m_caps.ddi_caps.SliceStructure),
         extOpt2.NumMbPerSlice,
         extOpt3.NumSliceP,
         m_video.mfx.FrameInfo.Width / 16,
@@ -1410,7 +1410,7 @@ mfxStatus ImplementationAvc::Reset(mfxVideoParam *par)
     {
         bool fieldCoding = (newPar.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE) == 0;
         m_sliceDivider = MakeSliceDivider(
-            (m_caps.ddi_caps.SliceLevelRateCtrl) ? 4 : m_caps.ddi_caps.SliceStructure,
+            (m_caps.ddi_caps.SliceLevelRateCtrl) ? SliceDividerType::ARBITRARY_MB_SLICE : SliceDividerType(m_caps.ddi_caps.SliceStructure),
             extOpt2New.NumMbPerSlice,
             extOpt3New.NumSliceP,
             newPar.mfx.FrameInfo.Width / 16,

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw_utils_new.cpp
@@ -1797,7 +1797,7 @@ IntraRefreshState MfxHwH264Encode::GetIntraRefreshState(
             // reset divider on I frames
             bool fieldCoding = (video.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE) == 0;
             divider = MakeSliceDivider(
-                (caps.ddi_caps.SliceLevelRateCtrl) ? 4 : caps.ddi_caps.SliceStructure,
+                (caps.ddi_caps.SliceLevelRateCtrl) ? SliceDividerType::ARBITRARY_MB_SLICE : SliceDividerType(caps.ddi_caps.SliceStructure),
                 extOpt2Init.NumMbPerSlice,
                 extOpt3Init.NumSliceP,
                 video.mfx.FrameInfo.Width / 16,
@@ -1824,7 +1824,7 @@ IntraRefreshState MfxHwH264Encode::GetIntraRefreshState(
             {
                 bool fieldCoding = (video.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE) == 0;
                 divider = MakeSliceDivider(
-                    (caps.ddi_caps.SliceLevelRateCtrl) ? 4 : caps.ddi_caps.SliceStructure,
+                    (caps.ddi_caps.SliceLevelRateCtrl) ? SliceDividerType::ARBITRARY_MB_SLICE : SliceDividerType(caps.ddi_caps.SliceStructure),
                     extOpt2Init.NumMbPerSlice,
                     extOpt3Init.NumSliceP,
                     video.mfx.FrameInfo.Width / 16,

--- a/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_enc_common_hw.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -942,6 +942,15 @@ namespace MfxHwH264Encode
 
     ENCODE_FRAME_SIZE_TOLERANCE ConvertLowDelayBRCMfx2Ddi(mfxU16 type, bool bTCBRC);
 
+    enum class SliceDividerType
+    {
+        ONESLICE            = 0, // Once slice for the whole frame
+        ROW2ROW             = 1, // Slices are power of 2 number of rows, all slices the same
+        ROWSLICE            = 2, // Slices are any number of rows, all slices the same
+        ARBITRARY_ROW_SLICE = 3, // Slices are any number of rows, slices can be different
+        ARBITRARY_MB_SLICE  = 4, // Slices are any number of MBs, slices can be different
+    };
+
     struct MfxMemId
     {
     public:
@@ -1169,9 +1178,9 @@ namespace MfxHwH264Encode
     };
 
 
-    struct SliceDividerBluRay : SliceDivider
+    struct SliceDividerArbitraryRowSlice : SliceDivider
     {
-        SliceDividerBluRay(
+        SliceDividerArbitraryRowSlice(
             mfxU32 numSlice,
             mfxU32 widthInMbs,
             mfxU32 heightInMbs);
@@ -1180,9 +1189,9 @@ namespace MfxHwH264Encode
     };
 
 
-    struct SliceDividerSnb : SliceDivider
+    struct SliceDividerRow2Row : SliceDivider
     {
-        SliceDividerSnb(
+        SliceDividerRow2Row(
             mfxU32 numSlice,
             mfxU32 widthInMbs,
             mfxU32 heightInMbs);
@@ -1193,9 +1202,9 @@ namespace MfxHwH264Encode
     };
 
 
-    struct SliceDividerHsw : SliceDivider
+    struct SliceDividerRowSlice : SliceDivider
     {
-        SliceDividerHsw(
+        SliceDividerRowSlice(
             mfxU32 numSlice,
             mfxU32 widthInMbs,
             mfxU32 heightInMbs);
@@ -1231,7 +1240,7 @@ namespace MfxHwH264Encode
         static bool Next(SliceDividerState & state);
     };
     SliceDivider MakeSliceDivider(
-        mfxU32  sliceHwCaps,
+        SliceDividerType sliceHwCaps,
         mfxU32  sliceSizeInMbs,
         mfxU32  numSlice,
         mfxU32  widthInMbs,


### PR DESCRIPTION
1) Previously combined values leads to creation of single slice.
2) enum is used instead of magic numbers.

Issue: MDP-61999