### PR TITLE
[hevcd] Fix slice header buffer size for large entry point offset count

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
@@ -1173,6 +1173,10 @@ typedef struct {
   int32_t      delta_weight; // for HW decoder
 } wpScalingParam;
 
+#define DEFAULT_MAX_ENETRY_POINT_NUM 512
+#define DEFAULT_MAX_PREVENTION_BYTES 300
+#define DEAFULT_MAX_SLICE_HEADER_SIZE 512
+
 // Slice header structure, corresponding to the HEVC bitstream definition.
 struct H265SliceHeader
 {

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_va_supplier.h
@@ -75,8 +75,7 @@ private:
         return *this;
     }
 
-    // Assume we have max 300 bytes prevention, 1760(440 x 4) bytes for entrypoint offsets, 800 bytes for other slice header
-    const int SliceHeaderSize = 2860;
+    const int SliceHeaderSize = DEFAULT_MAX_ENETRY_POINT_NUM * 4 + DEFAULT_MAX_PREVENTION_BYTES + DEAFULT_MAX_SLICE_HEADER_SIZE;
 };
 
 // this template class added to apply big surface pool workaround depends on platform

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1941,11 +1941,12 @@ H265Slice *TaskSupplier_H265::DecodeSliceHeader(UMC::MediaDataEx *nalUnit)
             NumOfMaxEntryPoints = PicHeightInCtbsY * (pps->num_tile_columns);
 
         //reallocate memory for slice header
-        if (NumOfMaxEntryPoints > 512)
+        if (NumOfMaxEntryPoints > DEFAULT_MAX_ENETRY_POINT_NUM)
         {
             //offset_len_minus1[0-31], assume maximum 31[4 bytes]
-            int newsize = 1024 + NumOfMaxEntryPoints * 4 + DEFAULT_NU_TAIL_SIZE;
+            int newsize = 2048 + NumOfMaxEntryPoints * 4 + DEFAULT_NU_TAIL_SIZE;
             pSlice->m_source.Allocate(newsize);
+            nalUnit->SetDataSize(newsize);
 
             //swap buffer again, since buffer is small at first time
             removed_offsets.clear();


### PR DESCRIPTION
When reallocate slice header buffer because large entry point offset,
1. Enlarge the base size for slice header.
2. Make the data size matched between nalUnit and slice->m_source.
3. User macro definition calculation instead of "2860" and "512" hard code.

Issue: MDP-62068
Test: hevcd_func

Change-Id: I754ab9f263c18b9e2f350e22f3764c435b0453e4
Signed-off-by: Yan Wang <yan.wang@linux.intel.com>