### PR TITLE
[hevce] Fix ExtBRC panic

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_ext_brc.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_ext_brc.cpp
@@ -477,6 +477,7 @@ void ExtBRC::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
 
         mfxStatus sts = m_brc.Update(m_brc.pthis, &fp, &fc, &fs);
         MFX_CHECK_STS(sts);
+        task.bSkip = false;
 
         switch (fs.BRCStatus)
         {

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -1759,10 +1759,9 @@ void Legacy::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
         surfSrc.Data.MemId = ref.Rec.Mid;
         surfDst.Data.MemId = task.Raw.Mid;
 
-        FrameLocker lock_dst(core, surfSrc.Data);
-        FrameLocker lock_src(core, surfDst.Data);
-
-        mfxStatus sts = core.CopyFrame(&surfDst, &surfSrc);
+        mfxStatus sts = core.DoFastCopyWrapper(
+            &surfDst, MFX_MEMTYPE_INTERNAL_FRAME | MFX_MEMTYPE_DXVA2_DECODER_TARGET | MFX_MEMTYPE_FROM_ENCODE,
+            &surfSrc, MFX_MEMTYPE_INTERNAL_FRAME | MFX_MEMTYPE_DXVA2_DECODER_TARGET | MFX_MEMTYPE_FROM_ENCODE);
         MFX_CHECK_STS(sts);
 
         allocRec.SetFlag(ref.Rec.Idx, REC_SKIPPED * !!idx);


### PR DESCRIPTION
Cleared bSkip flag to avoid infinite skip
and changed frame copy mode to match
allocation type and legacy mode