### PR TITLE
[hevce] L1 should be sorted in ascending POC order

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -3186,10 +3186,10 @@ void ConstructRPL(
 
             }
 
-            // reorder STRs to POC descending order
-            for (mfxU8 lx = 0; lx < 2; lx++)
-                MFX_SORT_COMMON(RPL[lx], numRefActive[lx],
-                    DPB[RPL[lx][_i]].m_poc < DPB[RPL[lx][_j]].m_poc);
+            // reorder STRs to POC descending order for L0
+            MFX_SORT_COMMON(RPL[0], numRefActive[0], DPB[RPL[0][_i]].m_poc < DPB[RPL[0][_j]].m_poc);
+            // reorder STRs to POC asscending order for L1
+            MFX_SORT_COMMON(RPL[1], numRefActive[1], DPB[RPL[1][_i]].m_poc > DPB[RPL[1][_j]].m_poc);
 
             if (nLTR)
             {

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1251,10 +1251,6 @@ public:
             bGT |= bEQ && Closer(a, b);
             return bGT;
         };
-        auto POCGreater = [](const DpbFrame* a, const DpbFrame* b) { return a->POC > b->POC; };
-        bool bNoQPOffset = (par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_CQP && IsOff(CO3.EnableQPOffset));
-        bool bIsSCC = par.mvp.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC; // use default ref list order for SCC
-        bool bUseDefaultOrder = bIsSCC || bNoQPOffset;
 
         if (L0.empty())
         {
@@ -1274,11 +1270,17 @@ public:
         L0.resize(l0);
         L1.resize(l1);
 
+        bool bNoQPOffset = (par.mvp.mfx.RateControlMethod == MFX_RATECONTROL_CQP && IsOff(CO3.EnableQPOffset));
+        bool bIsSCC = par.mvp.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC; // use default ref list order for SCC
+        bool bUseDefaultOrder = bIsSCC || bNoQPOffset;
         if (bUseDefaultOrder)
         {
-            L0.sort(POCGreater);
+            auto POCDescending = [](const DpbFrame* a, const DpbFrame* b) { return a->POC > b->POC; };
+            L0.sort(POCDescending);
         }
-        L1.sort(POCGreater);
+
+        auto POCAscending = [](const DpbFrame* a, const DpbFrame* b) { return a->POC < b->POC; };
+        L1.sort(POCAscending);
 
         std::transform(L0.begin(), L0.end(), RPL[0]
             , [&](const DpbFrame* x) { return mfxU8(x - dpbBegin); });


### PR DESCRIPTION
Smaller POC is closer to current frame