### PR TITLE
[API] Adding Scaling Interpolation Method

### DIFF
--- a/_studio/mfx_lib/vpp/include/mfx_vpp_utils.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -94,6 +94,7 @@ mfxStatus GetPipelineList(
 mfxStatus CheckFrameInfo(mfxFrameInfo* info, mfxU32 request, eMFXHWType platform);
 
 mfxStatus CheckCropParam( mfxFrameInfo* info );
+mfxStatus CheckScalingParam(mfxExtBuffer* pScalingExtBuffer);
 
 mfxStatus CompareFrameInfo(mfxFrameInfo* info1, mfxFrameInfo* info2);
 

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -140,6 +140,9 @@ static void MemSetZero4mfxExecuteParams (mfxExecuteParams *pMfxExecuteParams )
     pMfxExecuteParams->iFieldProcessingMode = 0;
     pMfxExecuteParams->rotation = 0;
     pMfxExecuteParams->scalingMode = MFX_SCALING_MODE_DEFAULT;
+#if (MFX_VERSION >= 1033)
+    pMfxExecuteParams->interpolationMethod = MFX_INTERPOLATION_DEFAULT;
+#endif
 #if (MFX_VERSION >= 1025)
     pMfxExecuteParams->chromaSiting = MFX_CHROMA_SITING_UNKNOWN;
 #endif
@@ -2027,6 +2030,9 @@ mfxStatus VideoVPPHW::GetVideoParams(mfxVideoParam *par) const
             mfxExtVPPScaling *bufSc = reinterpret_cast<mfxExtVPPScaling *>(par->ExtParam[i]);
             MFX_CHECK_NULL_PTR1(bufSc);
             bufSc->ScalingMode = m_executeParams.scalingMode;
+#if (MFX_VERSION >= 1033)
+            bufSc->InterpolationMethod = m_executeParams.interpolationMethod;
+#endif            
         }
 #if (MFX_VERSION >= 1025)
         else if (MFX_EXTBUFF_VPP_COLOR_CONVERSION == bufferId)
@@ -5613,6 +5619,9 @@ mfxStatus ConfigureExecuteParams(
                         {
                             mfxExtVPPScaling *extScaling = (mfxExtVPPScaling*) videoParam.ExtParam[i];
                             executeParams.scalingMode = extScaling->ScalingMode;
+#if (MFX_VERSION >= 1033)
+                            executeParams.interpolationMethod = extScaling->InterpolationMethod;
+#endif
                         }
                     }
                 }

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_internal.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_internal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -344,7 +344,7 @@ bool IsCompositionMode(mfxVideoParam* pParam)
 
 mfxStatus ExtendedQuery(VideoCORE * core, mfxU32 filterName, mfxExtBuffer* pHint)
 {
-    mfxStatus sts;
+    mfxStatus sts = MFX_ERR_NONE;
     /* Lets find out VA type (Linux, Win or Android) and platform type */
     /* It can be different behaviour for Linux and IVB, Linux and HSW*/
     bool bLinuxAndIVB_HSW_BDW = false;
@@ -403,6 +403,10 @@ mfxStatus ExtendedQuery(VideoCORE * core, mfxU32 filterName, mfxExtBuffer* pHint
         {
             sts = MFX_ERR_NONE;
         }
+    }
+    else if (MFX_EXTBUFF_VPP_SCALING == filterName)
+    {
+        sts = CheckScalingParam(pHint);
     }
     else // ignore
     {

--- a/_studio/shared/include/mfx_vpp_interface.h
+++ b/_studio/shared/include/mfx_vpp_interface.h
@@ -291,6 +291,9 @@ namespace MfxHwVideoProcessing
                ,iFieldProcessingMode(0)
                ,rotation(0)
                ,scalingMode(MFX_SCALING_MODE_DEFAULT)
+#if (MFX_VERSION >= 1033)
+               ,interpolationMethod(MFX_INTERPOLATION_DEFAULT)
+#endif
 #if (MFX_VERSION >= 1025)
                ,chromaSiting(MFX_CHROMA_SITING_UNKNOWN)
 #endif
@@ -420,6 +423,10 @@ namespace MfxHwVideoProcessing
         int         rotation;
 
         mfxU16      scalingMode;
+
+#if (MFX_VERSION >= 1033)
+        mfxU16      interpolationMethod;
+#endif
 
         mfxU16      chromaSiting;
 

--- a/api/include/mfxdefs.h
+++ b/api/include/mfxdefs.h
@@ -21,7 +21,7 @@
 #define __MFXDEFS_H__
 
 #define MFX_VERSION_MAJOR 1
-#define MFX_VERSION_MINOR 32
+#define MFX_VERSION_MINOR 33
 
 // MFX_VERSION_NEXT is always +1 from last public release
 // may be enforced by MFX_VERSION_USE_LATEST define

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -1992,12 +1992,27 @@ enum {
     MFX_SCALING_MODE_QUALITY    = 2
 };
 
+#if (MFX_VERSION >= 1033)
+/* Interpolation Method */
+enum {
+    MFX_INTERPOLATION_DEFAULT                = 0,
+    MFX_INTERPOLATION_NEAREST_NEIGHBOR       = 1,
+    MFX_INTERPOLATION_BILINEAR               = 2,
+    MFX_INTERPOLATION_ADVANCED               = 3
+};
+#endif
+
 MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 ScalingMode;
+#if (MFX_VERSION >= 1033)
+    mfxU16 InterpolationMethod;
+    mfxU16 reserved[10];
+#else
     mfxU16 reserved[11];
+#endif
 } mfxExtVPPScaling;
 MFX_PACK_END()
 

--- a/doc/header-template.md
+++ b/doc/header-template.md
@@ -1,7 +1,7 @@
 ![](./pic/intel_logo.png)
 <br><br><br>
 #**Title**
-Media SDK API Version 1.32
+Media SDK API Version 1.33
 
 <div style="page-break-before:always" />
 

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -1,7 +1,7 @@
 ![](./pic/intel_logo.png)
 <br><br><br>
 # **Media SDK Developer Reference**
-## Media SDK API Version 1.32
+## Media SDK API Version 1.33
 
 <div style="page-break-before:always" />
 
@@ -6934,11 +6934,20 @@ enum {
     MFX_SCALING_MODE_QUALITY    = 2
 };
 
+/* Interpolation Method */
+enum {
+    MFX_INTERPOLATION_DEFAULT                = 0,
+    MFX_INTERPOLATION_NEAREST_NEIGHBOR       = 1,
+    MFX_INTERPOLATION_BILINEAR               = 2,
+    MFX_INTERPOLATION_ADVANCED               = 3
+};
+
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 ScalingMode;
-    mfxU16 reserved[11];
+    mfxU16 InterpolationMethod;
+    mfxU16 reserved[10];
 } mfxExtVPPScaling;
 ```
 
@@ -6946,14 +6955,23 @@ typedef struct {
 
 The `mfxExtVPPScaling` structure configures the **VPP** Scaling filter algorithm.
 
+The interpolation method supports `MFX_INTERPOLATION_NEAREST_NEIGHBOR`, `MFX_INTERPOLATION_BILINEAR`,  `MFX_INTERPOLATION_DEFAULT` and `MFX_INTERPOLATION_ADVANCED`.
+`MFX_INTERPOLATION_NEAREST_NEIGHBOR` and `MFX_INTERPOLATION_BILINEAR` are well known algorithm, `MFX_INTERPOLATION_ADVANCED` is a proprietary implementation.
+
+Not all combinations of `ScalingMode` and `InterpolationMethod` are supported in the SDK. The application has to use query function to determine if a combination is supported.
+
 **Members**
 
 | | |
 --- | ---
 `Header.BufferId` | Must be [MFX_EXTBUFF_VPP_SCALING](#ExtendedBufferID)
 `ScalingMode` | Scaling mode
+`InterpolationMethod` | Interpolation Method
+
 
 **Change History**
+
+The SDK API 1.33 adds InterpolationMethod fields.
 
 This structure is available since SDK API 1.19.
 


### PR DESCRIPTION
Adding 4 interpolation method definition and implementation: Default, Nearest Neighborhood, Bilinear and Advanced. Provide the flexiblity to API user.