### PR TITLE
[hevce] Fix reported frame order

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1095,7 +1095,7 @@ void SetEncFrameInfo(MfxVideoParam &m_vpar,
     if (encFrameInfo && taskForQuery)
     {
         encFrameInfo->QP = taskForQuery->m_avgQP;
-        encFrameInfo->FrameOrder = taskForQuery->m_fo;
+        encFrameInfo->FrameOrder = (taskForQuery->m_surf->Data.FrameOrder == mfxU32(-1)) ? taskForQuery->m_fo : taskForQuery->m_surf->Data.FrameOrder;
         encFrameInfo->PicStruct = taskForQuery->m_surf->Info.PicStruct;
         if (IsOn(m_vpar.m_ext.CO2.EnableMAD))
             encFrameInfo->MAD = taskForQuery->m_MAD;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_encoded_frame_info.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_encoded_frame_info.cpp
@@ -104,7 +104,7 @@ void EncodedFrameInfo::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
         std::transform(task.RefPicList[0], task.RefPicList[0] + task.NumRefActive[0], pInfo->UsedRefListL0, GetUsedRef);
         std::transform(task.RefPicList[1], task.RefPicList[1] + task.NumRefActive[1], pInfo->UsedRefListL1, GetUsedRef);
 
-        pInfo->FrameOrder   = task.DisplayOrder;
+        pInfo->FrameOrder   = (task.pSurfIn->Data.FrameOrder == mfxU32(-1)) ? task.DisplayOrder : task.pSurfIn->Data.FrameOrder;
         pInfo->LongTermIdx  = mfxU16(MFX_LONGTERM_IDX_NO_IDX * !task.isLTR);
         pInfo->PicStruct    = PicStructTable[bFields][task.bBottomField];
         pInfo->QP           = 0;


### PR DESCRIPTION
m_frameorder is set to 0 after Reset.
User applications cannot match the encoded frame to the bitstream
during encode using mfxExtAVCEncodedFrameInfo.FrameOrder.