### PR TITLE
[hevce] fix recon format for specific cases

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -2598,6 +2598,22 @@ bool Legacy::GetRecInfo(
         return false;
     }
 
+    if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV420) && CO3.TargetBitDepthLuma == 8)
+    {
+        rec.FourCC = MFX_FOURCC_NV12;
+    }
+    else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 8)
+    {
+        rec.FourCC = MFX_FOURCC_AYUV;
+    }
+    else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV420) && CO3.TargetBitDepthLuma == 10)
+    {
+        rec.FourCC = MFX_FOURCC_P010;
+    }
+    else if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV444) && CO3.TargetBitDepthLuma == 10)
+    {
+        rec.FourCC = MFX_FOURCC_Y410;
+    }
     rec.ChromaFormat   = CO3.TargetChromaFormatPlus1 - 1;
     rec.BitDepthLuma   = CO3.TargetBitDepthLuma;
     rec.BitDepthChroma = CO3.TargetBitDepthChroma;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
@@ -59,7 +59,11 @@ void RExt::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
         auto& rec = pRI->Info;
 
         rec = par.mfx.FrameInfo;
-        
+
+        if (CO3.TargetChromaFormatPlus1 == (1 + MFX_CHROMAFORMAT_YUV420) && CO3.TargetBitDepthLuma == 10)
+        {
+            rec.FourCC = MFX_FOURCC_P010;
+        }
         rec.ChromaFormat   = CO3.TargetChromaFormatPlus1 - 1;
         rec.BitDepthLuma   = CO3.TargetBitDepthLuma;
         rec.BitDepthChroma = CO3.TargetBitDepthChroma;


### PR DESCRIPTION
Fix recons format for specific cases when input format differs
from the output. For example, for HEVCe VDENC
Y210 format is supported as input while the output is P010