### PR TITLE
Use CL/cl2.hpp for rotate_opencl_plugin

### DIFF
--- a/samples/sample_plugins/rotate_opencl/include/opencl_filter.h
+++ b/samples/sample_plugins/rotate_opencl/include/opencl_filter.h
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2019, Intel Corporation
+Copyright (c) 2005-2020, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -21,7 +21,18 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 
 #include <iostream>
 #include <stdexcept>
-#include <CL/cl.h>
+#if defined(_WIN32) || defined(_WIN64)
+  // There is no cl2.hpp in Intel OpenCL SDK for Windows at least up to 2020.1.396
+  #include <CL/cl.h>
+#else
+  #define CL_HPP_ENABLE_SIZE_T_COMPATIBILITY
+  #define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY
+  #define CL_HPP_ENABLE_EXCEPTIONS
+  #define CL_HPP_CL_1_2_DEFAULT_BUILD
+  #define CL_HPP_MINIMUM_OPENCL_VERSION 120
+  #define CL_HPP_TARGET_OPENCL_VERSION 120
+  #include <CL/cl2.hpp>
+#endif
 
 #include "mfxvideo++.h"
 #include "logger.h"

--- a/samples/sample_plugins/rotate_opencl/src/sample_opencl_plugin.cpp
+++ b/samples/sample_plugins/rotate_opencl/src/sample_opencl_plugin.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************\
-Copyright (c) 2005-2019, Intel Corporation
+Copyright (c) 2005-2020, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -646,10 +646,10 @@ void OpenCLRotator180Context::CreateBuffers(const cl::size_t<3> &Y_size,
 
 void OpenCLRotator180Context::SetKernelArgs()
 {
-    m_kernelY .setArg(0, m_InY());
-    m_kernelY .setArg(1, m_OutY());
-    m_kernelUV.setArg(0, m_InUV());
-    m_kernelUV.setArg(1, m_OutUV());
+    m_kernelY .setArg(0, m_InY);
+    m_kernelY .setArg(1, m_OutY);
+    m_kernelUV.setArg(0, m_InUV);
+    m_kernelUV.setArg(1, m_OutUV);
 }
 
 void OpenCLRotator180Context::Rotate(size_t width, size_t height,


### PR DESCRIPTION
Since [v2.0.12](https://github.com/KhronosGroup/OpenCL-CLHPP/tree/v2.0.12/include/CL) KronosGroup removed outdated cl.h header.
This change introduce minimal compatibility fix. According to https://github.com/intel/compute-runtime/blob/master/README.md
supported OpenCL API version on Apollo Lake and Gemini Lake platforms is 1.2

Fixes #2190