### PR TITLE
[Core] Check if planes are continuously allocated

### DIFF
--- a/_studio/shared/include/cm_mem_copy.h
+++ b/_studio/shared/include/cm_mem_copy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -137,6 +137,7 @@ public:
     mfxStatus IsCmCopySupported(mfxFrameSurface1 *pSurface, mfxSize roi);
 
     static bool CanUseCmCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
+    static bool CheckSurfaceContinuouslyAllocated(const mfxFrameSurface1 &surf);
     static bool isSinglePlainFormat(mfxU32 format);
     static bool isNeedSwapping(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
     static bool isNeedShift(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);


### PR DESCRIPTION
This check disables CM usage if surface planes
are not allocated as one memory block.
This is must-condition for CM usage.