### PR TITLE
smt:all child sessions must be disjoined before closing a parent session

### DIFF
--- a/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
+++ b/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
@@ -1112,7 +1112,12 @@ mfxStatus Launcher::CreateSafetyBuffers()
 
 void Launcher::Close()
 {
-    m_pThreadContextArray.clear();
+    while(m_pThreadContextArray.size())
+    {
+        m_pThreadContextArray[m_pThreadContextArray.size() - 1].reset();
+        m_pThreadContextArray.pop_back();
+    }
+
     m_pAllocArray.clear();
     m_pBufferArray.clear();
     m_pExtBSProcArray.clear();


### PR DESCRIPTION
Based on MediaSDK manual
https://github.com/Intel-Media-SDK/MediaSDK/blob/master/doc/mediasdk-man.md#MFXClose

fixes: 7815801(TranscodingSample::Launcher: replaced pointers to unique_ptr)