### PR TITLE
[hevce] Separate P and BL0 in GetMaxNumRef

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
@@ -321,7 +321,7 @@ namespace Base
         mfxU8  chroma_loc_info_present_flag        : 1;
         mfxU8  chroma_sample_loc_type_top_field    : 3;
         mfxU8  chroma_sample_loc_type_bottom_field : 3;
-    
+
         mfxU8  neutral_chroma_indication_flag : 1;
         mfxU8  field_seq_flag                 : 1;
         mfxU8  frame_field_info_present_flag  : 1;
@@ -397,7 +397,7 @@ namespace Base
 
         mfxU8  scaling_list_enabled_flag      : 1;
         mfxU8  scaling_list_data_present_flag : 1;
-    
+
         mfxU8  amp_enabled_flag                    : 1;
         mfxU8  sample_adaptive_offset_enabled_flag : 1;
 
@@ -680,7 +680,7 @@ namespace Base
     constexpr mfxU8 CODING_TYPE_B2 = 5; //B2, references include B1
 
     // Min frame params required for Reorder, RPL/DPB management
-    struct FrameBaseInfo 
+    struct FrameBaseInfo
         : Storable
     {
         mfxI32   POC            = -1;
@@ -799,7 +799,7 @@ namespace Base
 
         struct DPBs
         {
-            DpbArray 
+            DpbArray
                 Active   // available during task execution (modified dpb[BEFORE] )
                 , After  // after task execution (ACTIVE + curTask if ref)
                 , Before // after previous task execution (prevTask dpb[AFTER])
@@ -1116,7 +1116,7 @@ namespace Base
         TChain<mfxU32> GetMaxKbps;
         TChain<mfxU32> GetBufferSizeInKB;
         TChain<std::tuple<mfxU16, mfxU16>> GetNumTiles; // (NumTileColumns, NumTileRows)
-        TChain<std::tuple<mfxU16, mfxU16>> GetMaxNumRef;
+        TChain<std::tuple<mfxU16, mfxU16, mfxU16>> GetMaxNumRef;
         TChain<std::tuple<mfxU32, mfxU32>> GetFrameRate;
         TChain<std::tuple<mfxU16, mfxU16, mfxU16>> GetQPMFX; //I,P,B
         TChain<mfxU8> GetMinQPMFX;
@@ -1130,7 +1130,7 @@ namespace Base
             , const Defaults::Param&
             , mfxU16(*)[8] //P
             , mfxU16(*)[8] //BL0
-            , mfxU16(*)[8]>; //BL1 
+            , mfxU16(*)[8]>; //BL1
         TGetNumRefActive GetNumRefActive;
 
         using TGetQPOffset = CallChain<

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -498,12 +498,13 @@ void Legacy::SetInherited(ParamInheritance& par)
         if (parInit.mfx.TargetUsage != parReset.mfx.TargetUsage)
         {
             auto maxRef = m_GetMaxRef(parReset);
-            auto ClipRef0 = [&](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<0>(maxRef)); };
-            auto ClipRef1 = [&](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<1>(maxRef)); };
+            auto ClipRefP   = [maxRef](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<P>(maxRef)); };
+            auto ClipRefBL0 = [maxRef](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<BL0>(maxRef)); };
+            auto ClipRefBL1 = [maxRef](mfxU16 ref) { return std::min<mfxU16>(ref, std::get<BL1>(maxRef)); };
 
-            std::transform(ebInit.NumRefActiveP, ebInit.NumRefActiveP + 8, ebReset.NumRefActiveP, ClipRef0);
-            std::transform(ebInit.NumRefActiveBL0, ebInit.NumRefActiveBL0 + 8, ebReset.NumRefActiveBL0, ClipRef0);
-            std::transform(ebInit.NumRefActiveBL1, ebInit.NumRefActiveBL1 + 8, ebReset.NumRefActiveBL1, ClipRef1);
+            std::transform(ebInit.NumRefActiveP, ebInit.NumRefActiveP + 8, ebReset.NumRefActiveP, ClipRefP);
+            std::transform(ebInit.NumRefActiveBL0, ebInit.NumRefActiveBL0 + 8, ebReset.NumRefActiveBL0, ClipRefBL0);
+            std::transform(ebInit.NumRefActiveBL1, ebInit.NumRefActiveBL1 + 8, ebReset.NumRefActiveBL1, ClipRefBL1);
         }
         else
         {

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.h
@@ -32,6 +32,12 @@ namespace HEVCEHW
 {
 namespace Base
 {
+    enum FType { // Frame type for GetMaxNumRef tuple
+        P = 0,
+        BL0 = 1,
+        BL1 = 2
+    };
+
     class Legacy
         : public FeatureBase
     {
@@ -124,7 +130,7 @@ namespace Base
         mfxU16
             m_CUQPBlkW          = 0
             , m_CUQPBlkH        = 0;
-        std::function<std::tuple<mfxU16, mfxU16>(const mfxVideoParam&)> m_GetMaxRef;
+        std::function<std::tuple<mfxU16, mfxU16, mfxU16>(const mfxVideoParam&)> m_GetMaxRef;
         std::unique_ptr<Defaults::Param> m_pQWCDefaults;
         NotNull<Defaults*> m_pQNCDefaults;
         eMFXHWType m_hw = MFX_HW_UNKNOWN;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
@@ -36,28 +36,24 @@ void Caps::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
         MFX_CHECK(!bSet, MFX_ERR_NONE);
 
         defaults.GetMaxNumRef.Push([](
-            Base::Defaults::TChain<std::tuple<mfxU16, mfxU16>>::TExt
+            Base::Defaults::TChain<std::tuple<mfxU16, mfxU16, mfxU16>>::TExt
             , const Base::Defaults::Param& dpar)
         {
-            const mfxU16 nRef[3][2][7] =
+            const mfxU16 nRef[2][3][7] =
             {
                 {   // VME
                     { 4, 4, 3, 3, 3, 1, 1 },
+                    { 4, 4, 3, 3, 3, 1, 1 },
                     { 2, 2, 1, 1, 1, 1, 1 }
                 },
-                {   // VDENC P
+                {   // VDENC
                     { 3, 3, 2, 2, 2, 1, 1 },
-                    { 3, 3, 2, 2, 2, 1, 1 }
-                },
-                {   // Gen12 VDENC RA B
                     { 2, 2, 1, 1, 1, 1, 1 },
                     { 1, 1, 1, 1, 1, 1, 1 }
                 }
             };
-            bool    bBFrames = (dpar.mvp.mfx.GopRefDist > 1);
-            bool    bVDEnc   = IsOn(dpar.mvp.mfx.LowPower);
-            mfxU16  tu       = dpar.mvp.mfx.TargetUsage;
-            mfxU32  idx      = bVDEnc * (1 + bBFrames);
+            bool    bVDEnc = IsOn(dpar.mvp.mfx.LowPower);
+            mfxU16  tu     = dpar.mvp.mfx.TargetUsage;
 
             CheckRangeOrSetDefault<mfxU16>(tu, 1, 7, 4);
             --tu;
@@ -66,8 +62,9 @@ void Caps::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
             mfxU16 numRefFrame = dpar.mvp.mfx.NumRefFrame + !dpar.mvp.mfx.NumRefFrame * 16;
 
             return std::make_tuple(
-                std::min<mfxU16>(nRef[idx][0][tu], std::min<mfxU16>(dpar.caps.MaxNum_Reference0, numRefFrame))
-                , std::min<mfxU16>(nRef[idx][1][tu], std::min<mfxU16>(dpar.caps.MaxNum_Reference1, numRefFrame)));
+                std::min<mfxU16>(nRef[bVDEnc][0][tu], std::min<mfxU16>(dpar.caps.MaxNum_Reference0, numRefFrame))
+                , std::min<mfxU16>(nRef[bVDEnc][1][tu], std::min<mfxU16>(dpar.caps.MaxNum_Reference0, numRefFrame))
+                , std::min<mfxU16>(nRef[bVDEnc][2][tu], std::min<mfxU16>(dpar.caps.MaxNum_Reference1, numRefFrame)));
         });
 
         bSet = true;


### PR DESCRIPTION
GetMaxNumRef now distinguishes P or LDB with RAB
when returns MaxNumRefActive. In the result LDB
can have different NumRef with RAB L0.
Implemented in both R and legacy.