### PR TITLE
[h264e] AdaptiveMaxFrameSize is unsupported under libva

### DIFF
--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_struct_vaapi.h
@@ -326,6 +326,8 @@ struct MFX_ENCODE_CAPS
     bool CBRSupport;
     bool VBRSupport;
     bool AVBRSupport;
+
+    bool AdaptiveMaxFrameSizeSupport;
 };
 
 // this enumeration is used to define the block size for intra prediction. they

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -788,6 +788,12 @@ namespace
 #if MFX_VERSION >= 1023
         if (!CheckTriStateOption(extOpt3.AdaptiveMaxFrameSize)) changed = true;
 
+        if(!hwCaps.AdaptiveMaxFrameSizeSupport && IsOn(extOpt3.AdaptiveMaxFrameSize))
+        {
+            extOpt3.AdaptiveMaxFrameSize = MFX_CODINGOPTION_UNKNOWN;
+            unsupported = true;
+        }
+
         if (hwCaps.ddi_caps.UserMaxFrameSizeSupport == 0 && !IsEnabledSwBrc && IsOn(extOpt3.AdaptiveMaxFrameSize))
         {
             extOpt3.AdaptiveMaxFrameSize = MFX_CODINGOPTION_UNKNOWN;

--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1478,6 +1478,9 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
     m_caps.ddi_caps.BRCReset        = 1; // no bitrate resolution control
     m_caps.ddi_caps.HeaderInsertion = 0; // we will provide headers (SPS, PPS) in binary format to the driver
 
+    // libva doesn't accept AdaptiveMaxFrameSize and MaxFrameSizeP, so unsupported
+    m_caps.AdaptiveMaxFrameSizeSupport = false;
+
     std::map<VAConfigAttribType, int> idx_map;
     VAConfigAttribType attr_types[] = {
         VAConfigAttribRTFormat,


### PR DESCRIPTION
Issue: MDP-50286