### PR TITLE
Sample: fix chroma size for Y210 and Y216

### DIFF
--- a/samples/sample_common/src/sample_utils.cpp
+++ b/samples/sample_common/src/sample_utils.cpp
@@ -928,11 +928,19 @@ mfxStatus GetChromaSize(const mfxFrameInfo & pInfo, mfxU32 & ChromaW, mfxU32 & C
         break;
     }
     case MFX_FOURCC_P010:
-    case MFX_FOURCC_P210:
     case MFX_FOURCC_P016:
     {
         ChromaW = (pInfo.CropW % 2) ? (pInfo.CropW + 1) : pInfo.CropW;
-        ChromaH = pInfo.FourCC == MFX_FOURCC_P210 ? (mfxU32)pInfo.CropH : (mfxU32)(pInfo.CropH + 1) / 2;
+        ChromaH = (mfxU32)(pInfo.CropH + 1) / 2;
+        break;
+    }
+
+    case MFX_FOURCC_P210:
+    case MFX_FOURCC_Y210:
+    case MFX_FOURCC_Y216:
+    {
+        ChromaW = (pInfo.CropW % 2) ? (pInfo.CropW + 1) : pInfo.CropW;
+        ChromaH = pInfo.CropH;
         break;
     }
 


### PR DESCRIPTION
Without this patch, GetChromaSize() returns MFX_ERR_UNSUPPORTED for Y210
and Y216 frames, hence sample_decode fails to dump YUV data to a file
for a 422 video

Example:
sample_decode h265 -i input.12b.422.hevc -o output.yuv

[WARNING], sts=MFX_ERR_UNKNOWN(-1), RunDecoding, SyncOutputSurface failed