### PR TITLE
[hevce] Fix vdenc LDB L1 after separation

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1429,6 +1429,8 @@ public:
 
             nL0 = (mfxU8)CO3.NumRefActiveP[layer];
             nL1 = (mfxU8)std::min<mfxU16>(CO3.NumRefActiveP[layer], CO3.NumRefActiveBL1[layer]);
+            // on VDENC for LDB frames L1 must be completely identical to L0
+            nL1 = IsOn(par.mvp.mfx.LowPower) ? nL0: nL1;
         }
 
         return std::make_tuple(nL0, nL1);


### PR DESCRIPTION
After GetMaxNumRef was separated for LDB and RAB,
for LDB on VDEnc L1 became different with L0.
This commit fixes it.