### PR TITLE
[hevce] Fix vdenc LDB L1 part2

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1412,7 +1412,7 @@ public:
     {
         mfxU8 nL0 = 0, nL1 = 0;
 
-        if (IsB(fi.FrameType))
+        if (IsB(fi.FrameType) && !fi.isLDB)
         {
             const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
             const mfxExtCodingOption2& CO2 = ExtBuffer::Get(par.mvp);
@@ -1422,7 +1422,7 @@ public:
             nL1 = (mfxU8)CO3.NumRefActiveBL1[layer];
         }
 
-        if (IsP(fi.FrameType))
+        if (IsP(fi.FrameType) || fi.isLDB)
         {
             const mfxExtCodingOption3& CO3 = ExtBuffer::Get(par.mvp);
             auto layer = mfx::clamp<mfxI32>(fi.PyramidLevel, 0, 7);


### PR DESCRIPTION
Addition to commits 2219 and 2229.
After GetMaxNumRef was separated for LDB and RAB,
for LDB on VDEnc L1 became different with L0.
2229 fixed for P, but didn't after change P to LDB.
NumRefs code now works both for P and LDB.

Fix: #2236