### PR TITLE
[Encode] Unify conversion way from bits to bytes in external BRC

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -2971,7 +2971,7 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
                         }
                         else if (((res & UMC::BRC_NOT_ENOUGH_BUFFER) || (task->m_repack >2))&& (res & UMC::BRC_ERR_SMALL_FRAME ))
                         {
-                            task->m_minFrameSize = m_brc.GetMinFrameSize()/8;
+                            task->m_minFrameSize = (mfxU32) ((m_brc.GetMinFrameSize() + 7) >> 3 );
 
                             task->m_brcFrameParams.CodedFrameSize = task->m_minFrameSize;
                             m_brc.Report(task->m_brcFrameParams, 0, hrd.GetMaxFrameSize((task->m_type[task->m_fid[0]] & MFX_FRAMETYPE_IDR)), task->m_brcFrameCtrl);

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_ext_brc.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_ext_brc.cpp
@@ -484,9 +484,9 @@ void ExtBRC::QueryTask(const FeatureBlocks& /*blocks*/, TPushQT Push)
         case MFX_BRC_OK:
             break;
         case MFX_BRC_PANIC_SMALL_FRAME:
-            task.MinFrameSize = (mfxU32)(fs.MinFrameSize >>3);
+            task.MinFrameSize = (mfxU32)((fs.MinFrameSize + 7) >> 3);
             fp.NumRecode++;
-            fp.CodedFrameSize = (mfxU32)(fs.MinFrameSize >>3);
+            fp.CodedFrameSize = (mfxU32)((fs.MinFrameSize + 7) >> 3);
 
             sts = m_brc.Update(m_brc.pthis, &fp, &fc, &fs);
             MFX_CHECK_STS(sts);

--- a/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_brc_common.cpp
@@ -1010,7 +1010,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             m_hrd.UpdateMinMaxQPForRec(brcSts, qpY);
         else if (!m_ctx.bPanic)
             bNeedUpdateQP = true;
-        status->MinFrameSize = m_hrd.GetMinFrameSize() + 7;
+        status->MinFrameSize = m_hrd.GetMinFrameSize();
         //printf("%d: poc %d, size %d QP %d (%d %d), HRD sts %d, maxFrameSize %d, type %d \n",frame_par->EncodedOrder, frame_par->DisplayOrder, bitsEncoded, m_ctx.Quant, m_ctx.QuantMin, m_ctx.QuantMax, brcSts,  m_hrd.GetMaxFrameSize(), frame_par->FrameType);
     }
     if ((e2pe > BRC_SCENE_CHANGE_RATIO2  && bitsEncoded > 4 * m_par.inputBitsPerFrame) ||

--- a/samples/sample_common/src/brc_routines.cpp
+++ b/samples/sample_common/src/brc_routines.cpp
@@ -712,7 +712,7 @@ mfxStatus ExtBRC::Update(mfxBRCFrameParam* frame_par, mfxBRCFrameCtrl* frame_ctr
             m_hrd.UpdateMinMaxQPForRec(brcSts, qpY);
         else
             bNeedUpdateQP = true;
-        status->MinFrameSize = m_hrd.GetMinFrameSize() + 7;
+        status->MinFrameSize = m_hrd.GetMinFrameSize();
         //printf("%d: poc %d, size %d QP %d (%d %d), HRD sts %d, maxFrameSize %d, type %d \n",frame_par->EncodedOrder, frame_par->DisplayOrder, bitsEncoded, m_ctx.Quant, m_ctx.QuantMin, m_ctx.QuantMax, brcSts,  m_hrd.GetMaxFrameSize(), frame_par->FrameType);
     }
     if (m_avg.get())


### PR DESCRIPTION
Repeat +7 when calculating the MinFrameSize in legacy 265 and mpeg2. Unify the
conversion way that the MinFrameSize is added 7 when bits are converted to bytes.

Signed-off-by: Wang Dylan <dylan.wang@intel.com>