### PR TITLE
[core] Unlock frames before checking fast copy status

### DIFF
--- a/_studio/shared/src/libmfx_core.cpp
+++ b/_studio/shared/src/libmfx_core.cpp
@@ -1135,19 +1135,20 @@ mfxStatus CommonCORE::DoFastCopyWrapper(mfxFrameSurface1 *pDst, mfxU16 dstMemTyp
         return MFX_ERR_UNDEFINED_BEHAVIOR;
     }
 
-    sts = DoFastCopyExtended(&dstTempSurface, &srcTempSurface);
-    MFX_CHECK_STS(sts);
+    mfxStatus fcSts = DoFastCopyExtended(&dstTempSurface, &srcTempSurface);
 
     if (true == isSrcLocked)
     {
         if (srcMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
             sts = UnlockExternalFrame(srcMemId, &srcTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (srcMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
             sts = UnlockFrame(srcMemId, &srcTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
     }
@@ -1157,16 +1158,18 @@ mfxStatus CommonCORE::DoFastCopyWrapper(mfxFrameSurface1 *pDst, mfxU16 dstMemTyp
         if (dstMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
             sts = UnlockExternalFrame(dstMemId, &dstTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (dstMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
             sts = UnlockFrame(dstMemId, &dstTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
     }
 
-    return MFX_ERR_NONE;
+    return fcSts;
 }
 
 mfxStatus CommonCORE::DoFastCopy(mfxFrameSurface1 *dst, mfxFrameSurface1 *src)

--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -1063,27 +1063,27 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         }
     }
 
-    sts = DoFastCopyExtended(&dstTempSurface, &srcTempSurface);
+    mfxStatus fcSts = DoFastCopyExtended(&dstTempSurface, &srcTempSurface);
 
-    if (MFX_ERR_DEVICE_FAILED == sts && 0 != dstTempSurface.Data.Corrupted)
+    if (MFX_ERR_DEVICE_FAILED == fcSts && 0 != dstTempSurface.Data.Corrupted)
     {
         // complete task even if frame corrupted
         pDst->Data.Corrupted = dstTempSurface.Data.Corrupted;
-        sts = MFX_ERR_NONE;
+        fcSts = MFX_ERR_NONE;
     }
-
-    MFX_CHECK_STS(sts);
 
     if (true == isSrcLocked)
     {
         if (srcMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
             sts = UnlockExternalFrame(srcMemId, &srcTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (srcMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
             sts = UnlockFrame(srcMemId, &srcTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
     }
@@ -1093,16 +1093,18 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         if (dstMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
             sts = UnlockExternalFrame(dstMemId, &dstTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (dstMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
             sts = UnlockFrame(dstMemId, &dstTempSurface.Data);
+            MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
     }
 
-    return MFX_ERR_NONE;
+    return fcSts;
 
 } // mfxStatus VAAPIVideoCORE::DoFastCopyWrapper(...)
 


### PR DESCRIPTION
To avoid potential memory leak if FastCopy fails