### PR TITLE
Fix return type of AV1DecoderFrame::FrameOrder()

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_frame.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_frame.h
@@ -205,7 +205,7 @@ namespace UMC_AV1_DECODER
         { return frame_time; };
         void SetFrameOrder(mfxU16 order)
         { frame_order = order; };
-        mfxF64 FrameOrder() const
+        mfxU16 FrameOrder() const
         { return frame_order; };
 
     public:


### PR DESCRIPTION
Signed-off-by: Yan Wang <yan.wang@linux.intel.com>