### PR TITLE
[CM][Core] Fix stride alignment

### DIFF
--- a/_studio/shared/src/cm_mem_copy.cpp
+++ b/_studio/shared/src/cm_mem_copy.cpp
@@ -3164,6 +3164,8 @@ mfxStatus CmCopyWrapper::CopyMirrorVideoToVideoMemory(void *pDst, void *pSrc, mf
 
 bool CmCopyWrapper::CheckSurfaceContinuouslyAllocated(const mfxFrameSurface1 &surf)
 {
+    mfxU32 stride_in_bytes = surf.Data.PitchLow + ((mfxU32)surf.Data.PitchHigh << 16);
+
     switch (surf.Info.FourCC)
     {
     // Packed formats like YUY2, UYVY, AYUV, Y416, Y210, Y410, A2RGB10, RGB565, RGB3 
@@ -3176,8 +3178,7 @@ bool CmCopyWrapper::CheckSurfaceContinuouslyAllocated(const mfxFrameSurface1 &su
     case MFX_FOURCC_NV12:
     case MFX_FOURCC_NV16:
         {
-            mfxU32 stride_in_bytes = surf.Data.PitchLow + ((mfxU32)surf.Data.PitchHigh << 16);
-            size_t luma_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height);
+            size_t luma_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height, 32);
             return surf.Data.Y + luma_size_in_bytes == surf.Data.UV;
             break;
         }
@@ -3185,8 +3186,7 @@ bool CmCopyWrapper::CheckSurfaceContinuouslyAllocated(const mfxFrameSurface1 &su
     // Handling planar formats
     case MFX_FOURCC_YV12:
         {
-            mfxU32 stride_in_bytes = surf.Data.PitchLow + ((mfxU32)surf.Data.PitchHigh << 16);
-            size_t luma_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height);
+            size_t luma_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height, 32);
             size_t chroma_size_in_bytes = luma_size_in_bytes / 4; //stride of the V plane is half the stride of the Y plane; and the V plane contains half as many lines as the Y plane
             return surf.Data.Y + luma_size_in_bytes == surf.Data.V && surf.Data.V + chroma_size_in_bytes == surf.Data.U;
             break;
@@ -3195,8 +3195,7 @@ bool CmCopyWrapper::CheckSurfaceContinuouslyAllocated(const mfxFrameSurface1 &su
     // Handling RGB-like formats
     case MFX_FOURCC_RGBP:
         {
-            mfxU32 stride_in_bytes = surf.Data.PitchLow + ((mfxU32)surf.Data.PitchHigh << 16);
-            size_t channel_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height);
+            size_t channel_size_in_bytes = stride_in_bytes * mfx::align2_value(surf.Info.Height, 32);
             return surf.Data.B + channel_size_in_bytes == surf.Data.G && surf.Data.G + channel_size_in_bytes == surf.Data.R;
             break;
         }


### PR DESCRIPTION
This change fixes incorrect behavior of
CheckSurfaceContinuouslyAllocated()
in case of 2160x3840 stream size.
Change was tested with streams with
different resolutions - works as expected.