### PR TITLE
[vpp] Add platform check for YUV 16bit color formats (backmerge)

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
@@ -932,6 +932,24 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
             }
         }
 
+#if (MFX_VERSION >= 1031)
+        if (core->GetHWType() <= MFX_HW_ICL_LP)
+        {
+            if (out->vpp.In.FourCC == MFX_FOURCC_P016 ||
+                out->vpp.In.FourCC == MFX_FOURCC_Y216 ||
+                out->vpp.In.FourCC == MFX_FOURCC_Y416 ||
+                out->vpp.Out.FourCC == MFX_FOURCC_P016 ||
+                out->vpp.Out.FourCC == MFX_FOURCC_Y216 ||
+                out->vpp.Out.FourCC == MFX_FOURCC_Y416) {
+                if( out->vpp.In.FourCC )
+                {
+                    out->vpp.In.FourCC = 0;
+                    mfxSts = MFX_ERR_UNSUPPORTED;
+                }
+            }
+        }
+#endif
+
         if ( out->vpp.In.FourCC  != MFX_FOURCC_P010 &&
              out->vpp.In.FourCC  != MFX_FOURCC_P210 &&
              out->vpp.In.FourCC  != MFX_FOURCC_A2RGB10 &&


### PR DESCRIPTION
YUV 16bit color formats are not supported on ICL and platforms below