### PR TITLE
av1d: assign a VA surface ID to ref_frame_map

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
@@ -206,7 +206,7 @@ namespace UMC_AV1_DECODER
         }
 
         for (uint8_t ref = 0; ref < NUM_REF_FRAMES; ++ref)
-            picParam.ref_frame_map[ref] = frame.frame_dpb[ref]->GetMemID(SURFACE_RECON);
+            picParam.ref_frame_map[ref] = (VASurfaceID)m_va->GetSurfaceID(frame.frame_dpb[ref]->GetMemID(SURFACE_RECON));
 
         for (uint8_t ref_idx = 0; ref_idx < INTER_REFS; ref_idx++)
         {

--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -946,7 +946,14 @@ Status LinuxVideoAccelerator::EndFrame(void*)
 int32_t LinuxVideoAccelerator::GetSurfaceID(int32_t idx)
 {
     VASurfaceID *surface;
-    Status sts = m_allocator->GetFrameHandle(idx, &surface);
+    Status sts = UMC_OK;
+
+    try {
+        sts = m_allocator->GetFrameHandle(idx, &surface);
+    } catch (std::exception&) {
+        return VA_INVALID_SURFACE;
+    }
+
     if (sts != UMC_OK)
         return VA_INVALID_SURFACE;
 


### PR DESCRIPTION
The type of ref_frame_map is VASurfaceID, not FrameMemID, so we should
assign a VA surface ID to ref_frame_map
    
In addition, return VA_INVALID_SURFACE from
LinuxVideoAccelerator::GetSurfaceID() once catching an exception