### PR TITLE
Use lowercase for windows.h

### DIFF
--- a/api/mfx_dispatch/windows/src/main.cpp
+++ b/api/mfx_dispatch/windows/src/main.cpp
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <Windows.h>
+#include <windows.h>
 #include <stringapiset.h>
 
 #include <new>


### PR DESCRIPTION
To prevent errors when cross-compiling
from Linux to Windows.
windows.h is all lowercase in mingw.