### PR TITLE
Add -dec::sys flag for setting of the output memory to system type

### DIFF
--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -85,6 +85,9 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
 |  -n| Number of frames to transcode<br>(session ends after this number of frames is reached).<br>In decoding sessions (-o::sink) this parameter limits number<br>of frames acquired from decoder.<br>In encoding sessions (-o::source) and transcoding sessions<br>this parameter limits number of frames sent to encoder.
 | -ext_allocator |   Force usage of external allocators|
 |  -sys| Force usage of external system allocator|
+|  -dec::sys| Set dec output to system memory|
+|  -vpp::sys| Set vpp output to system memory|
+|  -vpp::vid| Set vpp output to video memory|
 |  -fps <frames per second\>|  Transcoding frame rate limit|
   |-pe | Set encoding plugin for this particular session.<br>This setting overrides plugin settings defined by SET clause.|
 |  -pd|  Set decoding plugin for this particular session.<br> This setting overrides plugin settings defined by SET clause.<br>Supported values: hevcd_sw, hevcd_hw, hevce_sw, hevce_gacc, hevce_hw, vp8d_hw, vp8e_hw, vp9d_hw, vp9e_hw, camera_hw, capture_hw, h264_la_hw, ptir_hw, hevce_fei_hw<br>Direct GUID number can be used as well|

--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -315,6 +315,7 @@ namespace TranscodingSample
 
         bool bUseOpaqueMemory;
         bool bForceSysMem;
+        mfxU16 DecOutPattern;
         mfxU16 VppOutPattern;
         mfxU16 nGpuCopyMode;
 

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -2238,7 +2238,8 @@ mfxStatus CTranscodingPipeline::InitDecMfxParams(sInputParams *pInParams)
     // set memory pattern
     if (m_bUseOpaqueMemory)
         m_mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
-    else if (pInParams->bForceSysMem || (MFX_IMPL_SOFTWARE == pInParams->libType))
+    else if (pInParams->bForceSysMem || (MFX_IMPL_SOFTWARE == pInParams->libType)
+         || (pInParams->DecOutPattern == MFX_IOPATTERN_OUT_SYSTEM_MEMORY))
         m_mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
     else
         m_mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -203,6 +203,7 @@ void TranscodingSample::PrintHelp()
 
     msdk_printf(MSDK_STRING("  -ext_allocator    Force usage of external allocators\n"));
     msdk_printf(MSDK_STRING("  -sys          Force usage of external system allocator\n"));
+    msdk_printf(MSDK_STRING("  -dec::sys     Set dec output to system memory\n"));
     msdk_printf(MSDK_STRING("  -vpp::sys     Set vpp output to system memory\n"));
     msdk_printf(MSDK_STRING("  -vpp::vid     Set vpp output to video memory\n"));
     msdk_printf(MSDK_STRING("  -fps <frames per second>\n"));
@@ -1268,6 +1269,10 @@ mfxStatus ParseAdditionalParams(msdk_char *argv[], mfxU32 argc, mfxU32& i, Trans
             PrintError(argv[0], MSDK_STRING("ICQQuality param is invalid"));
             return MFX_ERR_UNSUPPORTED;
         }
+    }
+    else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-dec::sys")))
+    {
+        InputParams.DecOutPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
     }
     else
     {


### PR DESCRIPTION
Current flag helps to build pipeline with system memory from
decoder output and vpp input + video memory from vpp output
and encoder input as example.

Issue: n/a