### PR TITLE
Fix infinite loop for Ref 4 @ L5.2

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -732,8 +732,8 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
             break;
 #endif
         default:
-            // We don't support level greater than 5.2 but
-            // relax resolution constrains up to 4K, hence
+            // Relax resolution constraints up to 4K when
+            // level_idc reaches 5.1+.  That is,
             // use value 696320 which is from level 6+ for
             // the calculation of the DPB size when level_idc
             // reaches 5.1+ but dpbSize is still less
@@ -792,15 +792,21 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         // can be used to calculate the DPB size.
         case H264VideoDecoderParams::H264_LEVEL_51:
         case H264VideoDecoderParams::H264_LEVEL_52:
-            level_idc = H264VideoDecoderParams::H264_LEVEL_52;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+            level_idc = H264VideoDecoderParams::H264_LEVEL_6;
+#else
+            level_idc = INTERNAL_MAX_LEVEL;
+#endif
             break;
+
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:
-            level_idc = H264VideoDecoderParams::H264_LEVEL_MAX;
+            level_idc = INTERNAL_MAX_LEVEL;
             break;
 #endif
+
         default:
             throw h264_exception(UMC_ERR_FAILED);
         }


### PR DESCRIPTION
This fixes an infinite loop when an AVC stream has
4 ref frames and level 5.2... regression introduced
by:

```
commit e126273431b470a738e4c26896b829a6801cb455
Author: Guo, Will <will.guo@intel.com>
Date:   Sun Apr 26 19:22:34 2020 +0800

    Support AVC Level 6/6.1/6.2

    Support Decode AVC Level 6/6.1/6.2

    Issue: MDP-47088

    Change-Id: I42aa5f67b7480a264f86822d5e5e3cd750d8d090
```

Fixes #2325

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>