### PR TITLE
[Disp] MSDK HW library loading from DriverStore

### DIFF
--- a/api/mfx_dispatch/windows/include/mfx_dispatcher.h
+++ b/api/mfx_dispatch/windows/include/mfx_dispatcher.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2019 Intel Corporation
+// Copyright (c) 2012-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -111,7 +111,7 @@ enum eMfxImplType
 enum
 {
     MFX_DISPATCHER_VERSION_MAJOR = 1,
-    MFX_DISPATCHER_VERSION_MINOR = 2
+    MFX_DISPATCHER_VERSION_MINOR = 3
 };
 
 struct _mfxSession
@@ -176,6 +176,17 @@ private:
     MFX_DISP_HANDLE(const MFX_DISP_HANDLE &);
     MFX_DISP_HANDLE & operator = (const MFX_DISP_HANDLE &);
 
+};
+
+// This struct extends MFX_DISP_HANDLE, we cannot extend MFX_DISP_HANDLE itself due to possible compatibility issues
+// This struct was added in dispatcher version 1.3
+// Check dispatcher handle's version when you cast session struct which came from outside of MSDK API function to this
+struct MFX_DISP_HANDLE_EX : public MFX_DISP_HANDLE
+{
+    MFX_DISP_HANDLE_EX(const mfxVersion requiredVersion);
+
+    mfxU16 mediaAdapterType;
+    mfxU16 reserved[10];
 };
 
 // declare comparison operator

--- a/api/mfx_dispatch/windows/include/mfx_dispatcher_uwp.h
+++ b/api/mfx_dispatch/windows/include/mfx_dispatcher_uwp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2020 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,30 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
-#include "mfxdefs.h"
-#include <cstring>
-#include <cstdio>
+#if !defined(__MFX_DISPATCHER_UWP_H)
+#define __MFX_DISPATCHER_UWP_H
 
-#if defined(MFX_DISPATCHER_LOG)
-#include <string>
-#include <string.h>
-#endif
+// Loads intel_gfx_api dll from DriverStore fro specified device and calls InitialiseMediaSession from it
+mfxStatus GfxApiInit(mfxInitParam par, mfxU32 deviceID, mfxSession *session, mfxModuleHandle& hModule);
 
-#define MAX_PLUGIN_PATH 4096
-#define MAX_PLUGIN_NAME 4096
+// Calls DisposeMediaSession from the intel_gfx_api dll and unloads it
+mfxStatus GfxApiClose(mfxSession& session, mfxModuleHandle& hModule);
 
-#if _MSC_VER < 1400
-#define wcscpy_s(to,to_size, from) wcscpy(to, from)
-#define wcscat_s(to,to_size, from) wcscat(to, from)
-#endif
+// Initializes intel_gfx_api for specified adapter number
+mfxStatus GfxApiInitByAdapterNum(mfxInitParam par, mfxU32 adapterNum, mfxSession *session, mfxModuleHandle& hModule);
 
-// declare library module's handle
-typedef void * mfxModuleHandle;
+// Initializes intel_gfx_api for any Intel adapter, chooses integrated adapter with higher priority
+mfxStatus GfxApiInitPriorityIntegrated(mfxInitParam par, mfxSession *session, mfxModuleHandle& hModule);
 
-typedef void (MFX_CDECL * mfxFunctionPointer)(void);
-
-// Tracer uses lib loading from Program Files logic (via Dispatch reg key) to make dispatcher load tracer dll.
-// With DriverStore loading put at 1st place, dispatcher loads real lib before it finds tracer dll.
-// This workaround explicitly checks tracer presence in Dispatch reg key and loads tracer dll before the search for lib in all other places.
-#define MFX_TRACER_WA_FOR_DS 1
+#endif // __MFX_DISPATCHER_UWP_H

--- a/api/mfx_dispatch/windows/include/mfx_driver_store_loader.h
+++ b/api/mfx_dispatch/windows/include/mfx_driver_store_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
 #if !defined(__MFX_DRIVER_STORE_LOADER_H)
 #define __MFX_DRIVER_STORE_LOADER_H
 
-#if !defined(MEDIASDK_ARM_LOADER)
 #include <windows.h>
 #include <cfgmgr32.h>
 #include <devguid.h>
@@ -42,10 +41,9 @@ public:
     DriverStoreLoader(void);
     ~DriverStoreLoader(void);
 
-    bool GetDriverStorePath(wchar_t *path, DWORD dwPathSize);
+    bool GetDriverStorePath(wchar_t *path, DWORD dwPathSize, mfxU32 deviceID);
 
 protected:
-    bool IsIntelDeviceInstanceID(const wchar_t* DeviceID);
     bool LoadCfgMgr();
     bool LoadCmFuncs();
 
@@ -63,6 +61,5 @@ private:
 };
 
 } // namespace MFX
-#endif // !defined(MEDIASDK_ARM_LOADER)
 
 #endif // __MFX_DRIVER_STORE_LOADER_H

--- a/api/mfx_dispatch/windows/include/mfx_library_iterator.h
+++ b/api/mfx_dispatch/windows/include/mfx_library_iterator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2019 Intel Corporation
+// Copyright (c) 2012-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,8 @@
 #include "mfx_win_reg_key.h"
 #endif
 
+#include "mfx_driver_store_loader.h"
+
 #include "mfx_dispatcher.h"
 
 namespace MFX
@@ -36,13 +38,26 @@ namespace MFX
 // declare desired storage ID
 enum
 {
+#if defined (MFX_TRACER_WA_FOR_DS)
     MFX_UNKNOWN_KEY             = -1,
-    MFX_CURRENT_USER_KEY        = 0,
-    MFX_LOCAL_MACHINE_KEY       = 1,
-    MFX_APP_FOLDER              = 2,
-    MFX_PATH_MSDK_FOLDER        = 3,
-    MFX_STORAGE_ID_FIRST    = MFX_CURRENT_USER_KEY,
+    MFX_TRACER                  = 0,
+    MFX_DRIVER_STORE            = 1,
+    MFX_CURRENT_USER_KEY        = 2,
+    MFX_LOCAL_MACHINE_KEY       = 3,
+    MFX_APP_FOLDER              = 4,
+    MFX_PATH_MSDK_FOLDER        = 5,
+    MFX_STORAGE_ID_FIRST = MFX_TRACER,
+    MFX_STORAGE_ID_LAST = MFX_PATH_MSDK_FOLDER
+#else
+    MFX_UNKNOWN_KEY             = -1,
+    MFX_DRIVER_STORE            = 0,
+    MFX_CURRENT_USER_KEY        = 1,
+    MFX_LOCAL_MACHINE_KEY       = 2,
+    MFX_APP_FOLDER              = 3,
+    MFX_PATH_MSDK_FOLDER        = 4,
+    MFX_STORAGE_ID_FIRST    = MFX_DRIVER_STORE,
     MFX_STORAGE_ID_LAST     = MFX_PATH_MSDK_FOLDER
+#endif
 };
 
 // Try to initialize using given implementation type. Select appropriate type automatically in case of MFX_IMPL_VIA_ANY.
@@ -79,9 +94,13 @@ protected:
     void Release(void);
 
     // Initialize the registry iterator
-    mfxStatus InitRegistry(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, int storageID);
+    mfxStatus InitRegistry(int storageID);
+#if defined(MFX_TRACER_WA_FOR_DS)
+    // Initialize the registry iterator for searching for tracer
+    mfxStatus InitRegistryTracer();
+#endif
     // Initialize the app/module folder iterator
-    mfxStatus InitFolder(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, const wchar_t * path, const int storageID);
+    mfxStatus InitFolder(eMfxImplType implType, const wchar_t * path, const int storageID);
 
 
     eMfxImplType m_implType;                                    // Required library implementation
@@ -101,6 +120,8 @@ protected:
     mfxU32 m_lastLibMerit;                                      // (mfxU32) merit of previously returned library
 
     wchar_t  m_path[msdk_disp_path_len];
+
+    DriverStoreLoader m_driverStoreLoader;                      // for loading MediaSDK from DriverStore
 
 private:
     // unimplemented by intent to make this class non-copyable

--- a/api/mfx_dispatch/windows/libmfx_uwp.vcxproj
+++ b/api/mfx_dispatch/windows/libmfx_uwp.vcxproj
@@ -79,7 +79,7 @@
       <TreatWarningAsError>false</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>Async</ExceptionHandling>
-      <PreprocessorDefinitions>_LIB;WINAPI_FAMILY=WINAPI_FAMILY_APP;MEDIASDK_UWP_DISPATCHER;MFX_D3D11_ENABLED;_UNICODE;UNICODE;MFX_VA;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_LIB;WINAPI_FAMILY=WINAPI_FAMILY_APP;MEDIASDK_UWP_DISPATCHER;MFX_D3D11_ENABLED;_UNICODE;UNICODE;MFX_VA;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions);WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAsWinRT>false</CompileAsWinRT>
@@ -122,9 +122,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="!$(Platform.Contains('ARM'))">
-    <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP</PreprocessorDefinitions>
-    </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>$(MfxBuildDir)..\build\win_$(Platform)\lib\</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
@@ -157,19 +154,23 @@
   <ItemGroup>
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\mfx_dispatcher.cpp" />
+    <ClCompile Include="src\mfx_dispatcher_uwp.cpp" />
     <ClCompile Include="src\mfx_dispatcher_log.cpp" />
     <ClCompile Include="src\mfx_driver_store_loader.cpp" />
     <ClCompile Include="src\mfx_function_table.cpp" />
     <ClCompile Include="src\mfx_load_dll.cpp" />
+    <ClCompile Include="src\mfx_dxva2_device.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\mfxaudio_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_dispatcher.h" />
+    <ClInclude Include="include\mfx_dispatcher_uwp.h" />
     <ClInclude Include="include\mfx_dispatcher_defs.h" />
     <ClInclude Include="include\mfx_dispatcher_log.h" />
     <ClInclude Include="include\mfx_driver_store_loader.h" />
     <ClInclude Include="include\mfx_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_load_dll.h" />
+    <ClInclude Include="include\mfx_dxva2_device.h" />
     <ClInclude Include="include\mfx_vector.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/api/mfx_dispatch/windows/libmfx_uwp.vcxproj.filters
+++ b/api/mfx_dispatch/windows/libmfx_uwp.vcxproj.filters
@@ -2,21 +2,25 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="src\mfx_dispatcher.cpp" />
+    <ClCompile Include="src\mfx_dispatcher_uwp.cpp" />
     <ClCompile Include="src\mfx_dispatcher_log.cpp" />
     <ClCompile Include="src\mfx_function_table.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\mfx_load_dll.cpp" />
     <ClCompile Include="src\mfx_driver_store_loader.cpp" />
+    <ClCompile Include="src\mfx_dxva2_device.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\mfxaudio_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_dispatcher.h" />
+    <ClInclude Include="include\mfx_dispatcher_uwp.h" />
     <ClInclude Include="include\mfx_dispatcher_defs.h" />
     <ClInclude Include="include\mfx_dispatcher_log.h" />
     <ClInclude Include="include\mfx_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_vector.h" />
     <ClInclude Include="include\mfx_load_dll.h" />
     <ClInclude Include="include\mfx_driver_store_loader.h" />
+    <ClInclude Include="include\mfx_dxva2_device.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Documentation">

--- a/api/mfx_dispatch/windows/libmfx_vs2015.vcxproj
+++ b/api/mfx_dispatch/windows/libmfx_vs2015.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="src\mfx_critical_section.cpp" />
     <ClCompile Include="src\mfx_dispatcher.cpp" />
     <ClCompile Include="src\mfx_dispatcher_log.cpp" />
+    <ClCompile Include="src\mfx_driver_store_loader.cpp" />
     <ClCompile Include="src\mfx_dxva2_device.cpp" />
     <ClCompile Include="src\mfx_function_table.cpp" />
     <ClCompile Include="src\mfx_library_iterator.cpp" />
@@ -232,6 +233,7 @@
     <ClInclude Include="include\mfx_dispatcher.h" />
     <ClInclude Include="include\mfx_dispatcher_defs.h" />
     <ClInclude Include="include\mfx_dispatcher_log.h" />
+    <ClInclude Include="include\mfx_driver_store_loader.h" />
     <ClInclude Include="include\mfx_dxva2_device.h" />
     <ClInclude Include="include\mfx_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_library_iterator.h" />

--- a/api/mfx_dispatch/windows/mfx_prefixed_dispatch_trace_lib.vcxproj
+++ b/api/mfx_dispatch/windows/mfx_prefixed_dispatch_trace_lib.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="src\mfx_critical_section.cpp" />
     <ClCompile Include="src\mfx_dispatcher.cpp" />
     <ClCompile Include="src\mfx_dispatcher_log.cpp" />
+    <ClCompile Include="src\mfx_driver_store_loader.cpp" />
     <ClCompile Include="src\mfx_dxva2_device.cpp" />
     <ClCompile Include="src\mfx_function_table.cpp" />
     <ClCompile Include="src\mfx_library_iterator.cpp" />
@@ -177,6 +178,7 @@
     <ClInclude Include="include\mfx_dispatcher.h" />
     <ClInclude Include="include\mfx_dispatcher_defs.h" />
     <ClInclude Include="include\mfx_dispatcher_log.h" />
+    <ClInclude Include="include\mfx_driver_store_loader.h" />
     <ClInclude Include="include\mfx_dxva2_device.h" />
     <ClInclude Include="include\mfx_exposed_functions_list.h" />
     <ClInclude Include="include\mfx_library_iterator.h" />

--- a/api/mfx_dispatch/windows/src/main.cpp
+++ b/api/mfx_dispatch/windows/src/main.cpp
@@ -31,7 +31,7 @@
 #include "mfx_critical_section.h"
 
 #if defined(MEDIASDK_UWP_DISPATCHER)
-#include "mfx_driver_store_loader.h"
+#include "mfx_dispatcher_uwp.h"
 #endif
 
 #include <string.h> /* for memset on Linux */
@@ -115,7 +115,7 @@ using namespace MFX;
 // All other functions are implemented implicitly.
 //
 
-typedef MFXVector<MFX_DISP_HANDLE*> HandleVector;
+typedef MFXVector<MFX_DISP_HANDLE_EX*> HandleVector;
 typedef MFXVector<mfxStatus>        StatusVector;
 
 struct VectorHandleGuard
@@ -137,11 +137,32 @@ private:
 };
 
 
-int HandleSort (const void * plhs, const void * prhs)
+static int HandleSort (const void * plhs, const void * prhs)
 {
-    const MFX_DISP_HANDLE * lhs = *(const MFX_DISP_HANDLE **)plhs;
-    const MFX_DISP_HANDLE * rhs = *(const MFX_DISP_HANDLE **)prhs;
+    const MFX_DISP_HANDLE_EX * lhs = *(const MFX_DISP_HANDLE_EX **)plhs;
+    const MFX_DISP_HANDLE_EX * rhs = *(const MFX_DISP_HANDLE_EX **)prhs;
 
+    // prefer HW implementation
+    if (lhs->implType != MFX_LIB_HARDWARE && rhs->implType == MFX_LIB_HARDWARE)
+    {
+        return 1;
+    }
+    if (lhs->implType == MFX_LIB_HARDWARE && rhs->implType != MFX_LIB_HARDWARE)
+    {
+        return -1;
+    }
+
+    // prefer integrated GPU
+    if (lhs->mediaAdapterType != MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType == MFX_MEDIA_INTEGRATED)
+    {
+        return 1;
+    }
+    if (lhs->mediaAdapterType == MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType != MFX_MEDIA_INTEGRATED)
+    {
+        return -1;
+    }
+
+    // prefer dll with lower API version
     if (lhs->actualApiVersion < rhs->actualApiVersion)
     {
         return -1;
@@ -179,7 +200,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
     HandleVector allocatedHandle;
     VectorHandleGuard handleGuard(allocatedHandle);
 
-    MFX_DISP_HANDLE *pHandle;
+    MFX_DISP_HANDLE_EX *pHandle;
     wchar_t dllName[MFX_MAX_DLL_PATH] = { 0 };
     MFX::MFXLibraryIterator libIterator;
 
@@ -218,7 +239,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
         *session = 0;
 
         // allocate the dispatching handle and call-table
-        pHandle = new MFX_DISP_HANDLE(requiredVersion);
+        pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
     }
     catch(...)
     {
@@ -285,14 +306,27 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                     if (MFX_ERR_NONE != mfxRes)
                     {
                         pHandle->Close();
+                        continue;
                     }
-                    else
+
+                    mfxPlatform platform = { MFX_PLATFORM_UNKNOWN, 0, MFX_MEDIA_UNKNOWN };
+                    if (pHandle->callTable[eMFXVideoCORE_QueryPlatform])
                     {
-                        libIterator.GetSubKeyName(pHandle->subkeyName, sizeof(pHandle->subkeyName) / sizeof(pHandle->subkeyName[0]));
-                        pHandle->storageID = libIterator.GetStorageID();
-                        allocatedHandle.push_back(pHandle);
-                        pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                        mfxRes = MFXVideoCORE_QueryPlatform((mfxSession)pHandle, &platform);
+                        if (MFX_ERR_NONE != mfxRes)
+                        {
+                            DISPATCHER_LOG_WRN(("MFXVideoCORE_QueryPlatform failed, rejecting loaded library\n"));
+                            pHandle->Close();
+                            continue;
+                        }
                     }
+                    pHandle->mediaAdapterType = platform.MediaAdapterType;
+                    DISPATCHER_LOG_INFO((("media adapter type is %d\n"), pHandle->mediaAdapterType));
+
+                    libIterator.GetSubKeyName(pHandle->subkeyName, sizeof(pHandle->subkeyName) / sizeof(pHandle->subkeyName[0]));
+                    pHandle->storageID = libIterator.GetStorageID();
+                    allocatedHandle.push_back(pHandle);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
 
                 } while (MFX_ERR_NONE != mfxRes);
             }
@@ -302,7 +336,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 
         } while ((MFX_ERR_NONE != mfxRes) && (MFX::MFX_STORAGE_ID_LAST >= currentStorage));
 
-    } while ((MFX_ERR_NONE != mfxRes) && (++curImplIdx <= maxImplIdx));
+    } while (++curImplIdx <= maxImplIdx);
 
     curImplIdx = implTypesRange[implMethod].minIndex;
     maxImplIdx = implTypesRange[implMethod].maxIndex;
@@ -361,7 +395,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                     }
                     pHandle->storageID = MFX::MFX_UNKNOWN_KEY;
                     allocatedHandle.push_back(pHandle);
-                    pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
                 }
 
             } while (MFX_ERR_NONE != mfxRes);
@@ -423,7 +457,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                 {
                     pHandle->storageID = MFX::MFX_UNKNOWN_KEY;
                     allocatedHandle.push_back(pHandle);
-                    pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
                 }
         }
     }
@@ -442,9 +476,9 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
             if (HandleSort(&(*first), &(*it)) != 0)
                 NeedSort = true;
 
-        // select dll with version with lowest version number still greater or equal to requested
+        // sort allocatedHandle so that the most preferred dll is at the beginning
         if (NeedSort)
-            qsort(&(*allocatedHandle.begin()), allocatedHandle.size(), sizeof(MFX_DISP_HANDLE*), &HandleSort);
+            qsort(&(*allocatedHandle.begin()), allocatedHandle.size(), sizeof(MFX_DISP_HANDLE_EX*), &HandleSort);
     }
     HandleVector::iterator candidate = allocatedHandle.begin();
     // check the final result of loading
@@ -505,7 +539,41 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 
     // everything is OK. Save pointers to the output variable
     *candidate = 0; // keep this one safe from guard destructor
-    *((MFX_DISP_HANDLE **) session) = pHandle;
+
+
+    //===================================
+
+    // MFXVideoCORE_QueryPlatform call creates d3d device handle, so we have handle right after MFXInit and can't accept external handle
+    // This is a workaround which calls close-init to remove that handle
+
+    mfxFunctionPointer *actualTable = (pHandle->impl & MFX_IMPL_AUDIO) ? pHandle->callAudioTable : pHandle->callTable;
+    mfxFunctionPointer pFunc;
+
+    pFunc = actualTable[eMFXClose];
+    mfxRes = (*(mfxStatus(MFX_CDECL *) (mfxSession)) pFunc) (pHandle->session);
+    if (mfxRes != MFX_ERR_NONE)
+        return mfxRes;
+
+    pHandle->session = 0;
+    bool callOldInit = (pHandle->impl & MFX_IMPL_AUDIO) || !actualTable[eMFXInitEx];
+    pFunc = actualTable[(callOldInit) ? eMFXInit : eMFXInitEx];
+
+    mfxVersion version(pHandle->apiVersion);
+    if (callOldInit)
+    {
+        pHandle->loadStatus = (*(mfxStatus(MFX_CDECL *) (mfxIMPL, mfxVersion *, mfxSession *)) pFunc) (pHandle->impl | pHandle->implInterface, &version, &pHandle->session);
+    }
+    else
+    {
+        mfxInitParam initPar = par;
+        initPar.Implementation = pHandle->impl | pHandle->implInterface;
+        initPar.Version = version;
+        pHandle->loadStatus = (*(mfxStatus(MFX_CDECL *) (mfxInitParam, mfxSession *)) pFunc) (initPar, &pHandle->session);
+    }
+
+    //===================================
+
+    *((MFX_DISP_HANDLE_EX **) session) = pHandle;
 
     return pHandle->loadStatus;
 
@@ -796,40 +864,42 @@ static mfxModuleHandle hModule;
 // InitialiseMediaSession() implemented in intel_gfx_api.dll
 mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 {
-    HRESULT hr = S_OK;
-
 #if defined(MEDIASDK_ARM_LOADER)
-    hr = E_NOTIMPL;
+
+    return MFX_ERR_UNSUPPORTED;
+
 #else
+
     wchar_t IntelGFXAPIdllName[MFX_MAX_DLL_PATH] = { 0 };
+    mfxI32 adapterNum = -1;
 
-    DriverStoreLoader dsLoader;
-    if (!dsLoader.GetDriverStorePath(IntelGFXAPIdllName, sizeof(IntelGFXAPIdllName)))
+    switch (par.Implementation & 0xf)
     {
-        return MFX_ERR_UNSUPPORTED;
-    }
-
-    size_t pathLen = wcslen(IntelGFXAPIdllName);
-    mfx_get_default_intel_gfx_api_dll_name(IntelGFXAPIdllName + pathLen, sizeof(IntelGFXAPIdllName) / sizeof(IntelGFXAPIdllName[0]) - pathLen);
-    DISPATCHER_LOG_INFO((("loading %S\n"), IntelGFXAPIdllName));
-
-    hModule = MFX::mfx_dll_load(IntelGFXAPIdllName);
-    if (!hModule)
-    {
-        DISPATCHER_LOG_ERROR("Can't load intel_gfx_api\n");
-        return MFX_ERR_UNSUPPORTED;
-    }
-
-    mfxFunctionPointer pFunc = (mfxFunctionPointer)mfx_dll_get_addr(hModule, "InitialiseMediaSession");
-    if (!pFunc)
-    {
-        DISPATCHER_LOG_ERROR("Can't find required API function: InitialiseMediaSession\n");
-        return MFX_ERR_UNSUPPORTED;
-    }
-    hr = (*(HRESULT(APIENTRY *) (HANDLE*, LPVOID, LPVOID)) pFunc) ((HANDLE*)session, &par, NULL);
+    case MFX_IMPL_SOFTWARE:
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    case MFX_IMPL_SINGLE_THREAD:
 #endif
+        return MFX_ERR_UNSUPPORTED;
+    case MFX_IMPL_AUTO:
+    case MFX_IMPL_HARDWARE:
+        adapterNum = 0;
+        break;
+    case MFX_IMPL_HARDWARE2:
+        adapterNum = 1;
+        break;
+    case MFX_IMPL_HARDWARE3:
+        adapterNum = 2;
+        break;
+    case MFX_IMPL_HARDWARE4:
+        adapterNum = 3;
+        break;
+    default:
+        return GfxApiInitPriorityIntegrated(par, session, hModule);
+    }
 
-    return (hr == S_OK) ? MFX_ERR_NONE : (mfxStatus)hr;
+    return GfxApiInitByAdapterNum(par, adapterNum, session, hModule);
+
+#endif
 }
 
 // for the UWP_DISPATCHER purposes implementation of MFXClose is calling
@@ -840,27 +910,20 @@ mfxStatus MFXClose(mfxSession session)
         return MFX_ERR_INVALID_HANDLE;
     }
 
-    HRESULT hr = S_OK;
+    mfxStatus sts = MFX_ERR_NONE;
 
 #if defined(MEDIASDK_ARM_LOADER)
-    hr = E_NOTIMPL;
+
+    sts = MFX_ERR_UNSUPPORTED;
+
 #else
-    if (hModule)
-    {
-        mfxFunctionPointer pFunc = (mfxFunctionPointer)mfx_dll_get_addr(hModule, "DisposeMediaSession");
-        if (!pFunc)
-        {
-            DISPATCHER_LOG_ERROR("Can't find required API function: DisposeMediaSession\n");
-            return MFX_ERR_INVALID_HANDLE;
-        }
-        hr = (*(HRESULT(APIENTRY *) (HANDLE)) pFunc) ((HANDLE)session);
-    }
-    else
-        return MFX_ERR_INVALID_HANDLE;
+
+    sts = GfxApiClose(session, hModule);
+
 #endif
 
     session = (mfxSession)NULL;
-    return (hr == S_OK) ? MFX_ERR_NONE : mfxStatus(hr);
+    return sts;
 }
 
 #undef FUNCTION

--- a/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
+++ b/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
@@ -329,6 +329,13 @@ mfxStatus MFX_DISP_HANDLE::UnLoadSelectedDLL(void)
 
 } // mfxStatus MFX_DISP_HANDLE::UnLoadSelectedDLL(void)
 
+
+MFX_DISP_HANDLE_EX::MFX_DISP_HANDLE_EX(const mfxVersion requiredVersion)
+    : MFX_DISP_HANDLE(requiredVersion)
+    , mediaAdapterType(MFX_MEDIA_UNKNOWN)
+{}
+
+
 #if (defined(_WIN64) || defined(_WIN32)) && (MFX_VERSION >= 1031)
 static mfxStatus InitDummySession(mfxU32 adapter_n, MFXVideoSession & dummy_session)
 {

--- a/api/mfx_dispatch/windows/src/mfx_dispatcher_uwp.cpp
+++ b/api/mfx_dispatch/windows/src/mfx_dispatcher_uwp.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfx_dispatcher.h"
+#include "mfx_dispatcher_uwp.h"
+#include "mfx_driver_store_loader.h"
+#include "mfx_dxva2_device.h"
+#include "mfx_load_dll.h"
+
+mfxStatus GfxApiInit(mfxInitParam par, mfxU32 deviceID, mfxSession *session, mfxModuleHandle& hModule)
+{
+    HRESULT hr = S_OK;
+    wchar_t IntelGFXAPIdllName[MFX_MAX_DLL_PATH] = { 0 };
+    MFX::DriverStoreLoader dsLoader;
+
+    if (!dsLoader.GetDriverStorePath(IntelGFXAPIdllName, sizeof(IntelGFXAPIdllName), deviceID))
+    {
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    size_t pathLen = wcslen(IntelGFXAPIdllName);
+    MFX::mfx_get_default_intel_gfx_api_dll_name(IntelGFXAPIdllName + pathLen, sizeof(IntelGFXAPIdllName) / sizeof(IntelGFXAPIdllName[0]) - pathLen);
+    DISPATCHER_LOG_INFO((("loading %S\n"), IntelGFXAPIdllName));
+
+    hModule = MFX::mfx_dll_load(IntelGFXAPIdllName);
+    if (!hModule)
+    {
+        DISPATCHER_LOG_ERROR("Can't load intel_gfx_api\n");
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    mfxFunctionPointer pFunc = (mfxFunctionPointer)MFX::mfx_dll_get_addr(hModule, "InitialiseMediaSession");
+    if (!pFunc)
+    {
+        DISPATCHER_LOG_ERROR("Can't find required API function: InitialiseMediaSession\n");
+        MFX::mfx_dll_free(hModule);
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    typedef HRESULT(APIENTRY *InitialiseMediaSessionPtr) (HANDLE*, LPVOID, LPVOID);
+    InitialiseMediaSessionPtr init = (InitialiseMediaSessionPtr)pFunc;
+    hr = init((HANDLE*)session, &par, NULL);
+
+    return (hr == S_OK) ? MFX_ERR_NONE : MFX_ERR_UNKNOWN;
+}
+
+mfxStatus GfxApiClose(mfxSession& session, mfxModuleHandle& hModule)
+{
+    HRESULT hr = S_OK;
+
+    if (!hModule)
+    {
+        return MFX_ERR_INVALID_HANDLE;
+    }
+
+    mfxFunctionPointer pFunc = (mfxFunctionPointer)MFX::mfx_dll_get_addr(hModule, "DisposeMediaSession");
+    if (!pFunc)
+    {
+        DISPATCHER_LOG_ERROR("Can't find required API function: DisposeMediaSession\n");
+        return MFX_ERR_INVALID_HANDLE;
+    }
+
+    typedef HRESULT(APIENTRY *DisposeMediaSessionPtr) (HANDLE);
+    DisposeMediaSessionPtr dispose = (DisposeMediaSessionPtr)pFunc;
+    hr = dispose((HANDLE)session);
+    session = NULL;
+
+    MFX::mfx_dll_free(hModule);
+    hModule = NULL;
+
+    return (hr == S_OK) ? MFX_ERR_NONE : MFX_ERR_UNKNOWN;
+}
+
+mfxStatus GfxApiInitByAdapterNum(mfxInitParam par, mfxU32 adapterNum, mfxSession *session, mfxModuleHandle& hModule)
+{
+    MFX::DXVA2Device dxvaDevice;
+
+    if (!dxvaDevice.InitDXGI1(adapterNum))
+    {
+        DISPATCHER_LOG_ERROR((("dxvaDevice.InitDXGI1(%d) Failed\n"), adapterNum));
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    if (dxvaDevice.GetVendorID() != INTEL_VENDOR_ID)
+    {
+        DISPATCHER_LOG_ERROR("Specified adapter is not Intel\n");
+        return MFX_ERR_UNSUPPORTED;
+    }
+
+    return GfxApiInit(par, dxvaDevice.GetDeviceID(), session, hModule);
+}
+
+struct GfxApiHandle
+{
+    mfxModuleHandle hModule;
+    mfxSession session;
+    mfxU16 mediaAdapterType;
+};
+
+static int GfxApiHandleSort(const void * plhs, const void * prhs)
+{
+    const GfxApiHandle * lhs = *(const GfxApiHandle **)plhs;
+    const GfxApiHandle * rhs = *(const GfxApiHandle **)prhs;
+
+    // prefer integrated GPU
+    if (lhs->mediaAdapterType != MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType == MFX_MEDIA_INTEGRATED)
+    {
+        return 1;
+    }
+    if (lhs->mediaAdapterType == MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType != MFX_MEDIA_INTEGRATED)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+mfxStatus GfxApiInitPriorityIntegrated(mfxInitParam par, mfxSession *session, mfxModuleHandle& hModule)
+{
+    mfxStatus sts = MFX_ERR_UNSUPPORTED;
+    MFX::MFXVector<GfxApiHandle> gfxApiHandles;
+
+    for (int adapterNum = 0; adapterNum < 4; ++adapterNum)
+    {
+        MFX::DXVA2Device dxvaDevice;
+
+        if (!dxvaDevice.InitDXGI1(adapterNum) || dxvaDevice.GetVendorID() != INTEL_VENDOR_ID)
+        {
+            continue;
+        }
+
+        par.Implementation &= ~(0xf);
+        switch (adapterNum)
+        {
+        case 0:
+            par.Implementation |= MFX_IMPL_HARDWARE;
+            break;
+        case 1:
+            par.Implementation |= MFX_IMPL_HARDWARE2;
+            break;
+        case 2:
+            par.Implementation |= MFX_IMPL_HARDWARE3;
+            break;
+        case 3:
+            par.Implementation |= MFX_IMPL_HARDWARE4;
+            break;
+        }
+
+        mfxModuleHandle hModuleCur = NULL;
+        mfxSession sessionCur = NULL;
+
+        sts = GfxApiInit(par, dxvaDevice.GetDeviceID(), &sessionCur, hModuleCur);
+        if (sts != MFX_ERR_NONE)
+            continue;
+
+        mfxPlatform platform = { MFX_PLATFORM_UNKNOWN, 0, MFX_MEDIA_UNKNOWN };
+        sts = MFXVideoCORE_QueryPlatform(sessionCur, &platform);
+        if (sts != MFX_ERR_NONE)
+        {
+            sts = GfxApiClose(sessionCur, hModuleCur);
+            if (sts != MFX_ERR_NONE)
+                return sts;
+            continue;
+        }
+
+        GfxApiHandle handle = { hModuleCur, sessionCur, platform.MediaAdapterType };
+        gfxApiHandles.push_back(handle);
+    }
+
+    qsort(&(*gfxApiHandles.begin()), gfxApiHandles.size(), sizeof(GfxApiHandle), &GfxApiHandleSort);
+
+    hModule = gfxApiHandles.begin()->hModule;
+    *session = gfxApiHandles.begin()->session;
+
+    MFX::MFXVector<GfxApiHandle>::iterator it = gfxApiHandles.begin()++;
+    for (; it != gfxApiHandles.end(); ++it)
+    {
+        sts = GfxApiClose(it->session, it->hModule);
+        if (sts != MFX_ERR_NONE)
+            return sts;
+    }
+
+    return sts;
+}


### PR DESCRIPTION
Added search of HW library in adapter's DriverStore folder.
Changed preference conditions for found libraries.
Added workaround to keep MSDK tracer workable with DriverStore loading.
Increased dispatcher version 1.2 -> 1.3.