### PR TITLE
Fix floating point exception in case of AvcTemporalLayers "0 1 2 4 0 0 0 0"

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -3803,6 +3803,7 @@ mfxStatus Legacy::CheckTemporalLayers(mfxVideoParam & par)
         auto  scalePrev = pTL->Layer[prev].Scale;
 
         MFX_CHECK(!CheckMinOrZero(scaleCurr, scalePrev + 1), MFX_ERR_UNSUPPORTED);
+        MFX_CHECK(scalePrev, MFX_ERR_UNSUPPORTED);
         MFX_CHECK(!CheckOrZero(scaleCurr, mfxU16(scaleCurr - (scaleCurr % scalePrev))), MFX_ERR_UNSUPPORTED);
 
         prev = i;


### PR DESCRIPTION
Issue: https://github.com/Intel-Media-SDK/MediaSDK/issues/2316#issuecomment-691084502