### PR TITLE
increase decode picture buffer

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -472,7 +472,7 @@ namespace MFX_VPX_Utility
         // Increase minimum number by one
         // E.g., decoder unlocks references in sync part (NOT async), so in order to free some surface
         // application need an additional surface to call DecodeFrameAsync()
-        p_request->NumFrameMin += 1;
+        p_request->NumFrameMin += 2;
 
         p_request->NumFrameSuggested = p_request->NumFrameMin;
 

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
@@ -57,7 +57,7 @@ namespace UMC_AV1_DECODER
         packer.reset(Packer::CreatePacker(va));
 
         uint32_t const dpb_size =
-            params.async_depth + TOTAL_REFS;
+            params.async_depth + TOTAL_REFS + 2;
         SetDPBSize(dpb_size);
         SetRefSize(TOTAL_REFS);
         return UMC::UMC_OK;


### PR DESCRIPTION
For current AV1's DPB implementation, after decoding a frame, Output
frame will be saved in a temporary variable for DPB update when next
 frame coming. Need to give one more buffer to save temporary frame
for DPB update.

For this stream, it has 8 reference frames in DPB, if we only
 allocate 8 + 1 + async_depth buffers, DPB is not update immediately
so no output, in app side, it can't get any more free buffer to
feed next frame, then deadlock.

Issue: MDP-63996
Tests: ./sample_decode -hw av1 -i ./test_stream_av1.ivf -o 0001.yuv
        -async 1  -vaapi

Change-Id: I10ab4b697cd392b76068e4e83935688fa1279ee8