### PR TITLE
core: refactored part of core as prerequisite for future oneVPL changes

### DIFF
--- a/_studio/shared/include/libmfx_core.h
+++ b/_studio/shared/include/libmfx_core.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2017-2019 Intel Corporation
-// 
+// Copyright (c) 2017-2020 Intel Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,114 +45,112 @@ public:
 
     friend class FactoryCORE;
 
-    virtual ~CommonCORE(void);
+    virtual ~CommonCORE() override { Close(); }
 
-    virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *handle);
-    virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL handle);
+    virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *handle)          override;
+    virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL handle)           override;
 
-    virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator);
-    virtual mfxStatus SetFrameAllocator(mfxFrameAllocator *allocator);
+    virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *)               override;
+    virtual mfxStatus SetFrameAllocator(mfxFrameAllocator *allocator)        override;
 
     // Utility functions for memory access
-    virtual mfxStatus  AllocBuffer(mfxU32 nbytes, mfxU16 type, mfxMemId *mid);
-    virtual mfxStatus  LockBuffer(mfxMemId mid, mfxU8 **ptr);
-    virtual mfxStatus  UnlockBuffer(mfxMemId mid);
-    virtual mfxStatus  FreeBuffer(mfxMemId mid);
+    virtual mfxStatus AllocBuffer(mfxU32 nbytes, mfxU16 type, mfxMemId *mid) override;
+    virtual mfxStatus LockBuffer(mfxMemId mid, mfxU8 **ptr)                  override;
+    virtual mfxStatus UnlockBuffer(mfxMemId mid)                             override;
+    virtual mfxStatus FreeBuffer(mfxMemId mid)                               override;
 
     // DEPRECATED
-    virtual mfxStatus  CheckHandle();
+    virtual mfxStatus CheckHandle() override { return MFX_ERR_NONE; }
 
-    virtual mfxStatus  GetFrameHDL(mfxMemId mid, mfxHDL *handle, bool ExtendedSearch = true);
+    virtual mfxStatus GetFrameHDL(mfxMemId mid, mfxHDL *handle, bool ExtendedSearch = true)               override;
 
-    virtual mfxStatus  AllocFrames(mfxFrameAllocRequest *request, 
-                                   mfxFrameAllocResponse *response, bool isNeedCopy = true);
-   
-    virtual mfxStatus  AllocFrames(mfxFrameAllocRequest *request, 
+    virtual mfxStatus AllocFrames(mfxFrameAllocRequest *request,
+                                   mfxFrameAllocResponse *response, bool isNeedCopy = true)               override;
+
+    virtual mfxStatus AllocFrames(mfxFrameAllocRequest *request,
                                    mfxFrameAllocResponse *response,
-                                   mfxFrameSurface1 **pOpaqueSurface, 
-                                   mfxU32 NumOpaqueSurface);
+                                   mfxFrameSurface1 **pOpaqueSurface,
+                                   mfxU32 NumOpaqueSurface)                                               override;
 
-    virtual mfxStatus  LockFrame(mfxMemId mid, mfxFrameData *ptr);
-    virtual mfxStatus  UnlockFrame(mfxMemId mid, mfxFrameData *ptr=0);
-    virtual mfxStatus  FreeFrames(mfxFrameAllocResponse *response, bool ExtendedSearch = true);
+    virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData *ptr)                                          override;
+    virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData *ptr = nullptr)                              override;
+    virtual mfxStatus FreeFrames(mfxFrameAllocResponse *response, bool ExtendedSearch = true)             override;
 
-    virtual mfxStatus  LockExternalFrame(mfxMemId mid, mfxFrameData *ptr, bool ExtendedSearch = true);
-    virtual mfxStatus  GetExternalFrameHDL(mfxMemId mid, mfxHDL *handle, bool ExtendedSearch = true);
-    virtual mfxStatus  UnlockExternalFrame(mfxMemId mid, mfxFrameData *ptr=0, bool ExtendedSearch = true);
+    virtual mfxStatus LockExternalFrame(mfxMemId mid, mfxFrameData *ptr, bool ExtendedSearch = true)      override;
+    virtual mfxStatus GetExternalFrameHDL(mfxMemId mid, mfxHDL *handle, bool ExtendedSearch = true)       override;
+    virtual mfxStatus UnlockExternalFrame(mfxMemId mid, mfxFrameData *ptr=0, bool ExtendedSearch = true)  override;
 
-    virtual mfxMemId MapIdx(mfxMemId mid);
+    virtual mfxMemId MapIdx(mfxMemId mid)                                                                 override;
 
     // Get original Surface corresponding to OpaqueSurface
-    virtual mfxFrameSurface1* GetNativeSurface(mfxFrameSurface1 *pOpqSurface, bool ExtendedSearch = true);
+    virtual mfxFrameSurface1* GetNativeSurface(mfxFrameSurface1 *pOpqSurface, bool ExtendedSearch = true) override;
     // Get OpaqueSurface corresponding to Original
-    virtual mfxFrameSurface1* GetOpaqSurface(mfxMemId mid, bool ExtendedSearch = true);
-
-
+    virtual mfxFrameSurface1* GetOpaqSurface(mfxMemId mid, bool ExtendedSearch = true)                    override;
 
     // Increment Surface lock caring about opaq
-    virtual mfxStatus  IncreaseReference(mfxFrameData *ptr, bool ExtendedSearch = true);
+    virtual mfxStatus IncreaseReference(mfxFrameData *ptr, bool ExtendedSearch = true)                    override;
     // Decrement Surface lock caring about opaq
-    virtual mfxStatus  DecreaseReference(mfxFrameData *ptr, bool ExtendedSearch = true);
+    virtual mfxStatus DecreaseReference(mfxFrameData *ptr, bool ExtendedSearch = true)                    override;
 
     // no care about surface, opaq and all round. Just increasing reference
-    virtual mfxStatus IncreasePureReference(mfxU16 &Locked);
+    virtual mfxStatus IncreasePureReference(mfxU16 &Locked)                                               override;
     // no care about surface, opaq and all round. Just decreasing reference
-    virtual mfxStatus DecreasePureReference(mfxU16 &Locked);
+    virtual mfxStatus DecreasePureReference(mfxU16 &Locked)                                               override;
 
     // Get Video Accelerator.
-    virtual void  GetVA(mfxHDL* phdl, mfxU16 type);
-    virtual mfxStatus CreateVA(mfxVideoParam * , mfxFrameAllocRequest *, mfxFrameAllocResponse *, UMC::FrameAllocator *) { return MFX_ERR_UNSUPPORTED; }
+    virtual void  GetVA(mfxHDL* phdl, mfxU16)                   override { *phdl = nullptr; }
+    virtual mfxStatus CreateVA(mfxVideoParam *, mfxFrameAllocRequest *, mfxFrameAllocResponse *, UMC::FrameAllocator *) override { MFX_RETURN(MFX_ERR_UNSUPPORTED); }
     // Get the current working adapter's number
-    virtual mfxU32 GetAdapterNumber(void) {return 0;}
+    virtual mfxU32 GetAdapterNumber()                           override { return 0; }
     //
-    virtual eMFXPlatform GetPlatformType() {return  MFX_PLATFORM_SOFTWARE;}
+    virtual eMFXPlatform GetPlatformType()                      override { return MFX_PLATFORM_SOFTWARE; }
 
     // Get Video Processing
-    virtual void  GetVideoProcessing(mfxHDL* phdl) {*phdl = 0;}
-    virtual mfxStatus CreateVideoProcessing(mfxVideoParam *) { return MFX_ERR_UNSUPPORTED; }
+    virtual void  GetVideoProcessing(mfxHDL* phdl)              override { *phdl = 0; }
+    virtual mfxStatus CreateVideoProcessing(mfxVideoParam *)    override { MFX_RETURN(MFX_ERR_UNSUPPORTED); }
 
     // Get the current number of working threads
-    virtual mfxU32 GetNumWorkingThreads(void) {return m_numThreadsAvailable;}
-    virtual void INeedMoreThreadsInside(const void *pComponent);
+    virtual mfxU32 GetNumWorkingThreads()                       override { return m_numThreadsAvailable; }
+    virtual void INeedMoreThreadsInside(const void *pComponent) override;
 
-    virtual mfxStatus DoFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
-    virtual mfxStatus DoFastCopyExtended(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
+    virtual mfxStatus DoFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)         override;
+    virtual mfxStatus DoFastCopyExtended(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc) override;
 
-    virtual mfxStatus DoFastCopyWrapper(mfxFrameSurface1 *pDst, mfxU16 dstMemType, mfxFrameSurface1 *pSrc, mfxU16 srcMemType);
+    virtual mfxStatus DoFastCopyWrapper(mfxFrameSurface1 *pDst, mfxU16 dstMemType, mfxFrameSurface1 *pSrc, mfxU16 srcMemType) override;
 
     // DEPRECATED
-    virtual bool IsFastCopyEnabled(void);
+    virtual bool IsFastCopyEnabled()              override { return true; }
 
-    virtual bool IsExternalFrameAllocator() const;
-    virtual eMFXHWType   GetHWType() { return MFX_HW_UNKNOWN; }
+    virtual bool IsExternalFrameAllocator() const override;
+    virtual eMFXHWType GetHWType()                override { return MFX_HW_UNKNOWN; }
 
-    virtual
-    mfxStatus CopyFrame(mfxFrameSurface1 *dst, mfxFrameSurface1 *src);
+    virtual mfxStatus CopyFrame(mfxFrameSurface1 *dst, mfxFrameSurface1 *src) override;
 
-    virtual
-    mfxStatus CopyBuffer(mfxU8 * /*dst*/, mfxU32 /*dst_size*/, mfxFrameSurface1 * /*src*/) {return MFX_ERR_UNKNOWN;}
+    virtual mfxStatus CopyBuffer(mfxU8 *, mfxU32, mfxFrameSurface1 *)         override { MFX_RETURN(MFX_ERR_UNKNOWN); }
 
-    virtual
-    mfxStatus CopyFrameEx(mfxFrameSurface1 *pDst, mfxU16 dstMemType, mfxFrameSurface1 *pSrc, mfxU16 srcMemType) {return DoFastCopyWrapper(pDst, dstMemType, pSrc, srcMemType);}
+    virtual mfxStatus CopyFrameEx(mfxFrameSurface1 *pDst, mfxU16 dstMemType, mfxFrameSurface1 *pSrc, mfxU16 srcMemType) override
+    {
+        return DoFastCopyWrapper(pDst, dstMemType, pSrc, srcMemType);
+    }
 
-    virtual mfxStatus IsGuidSupported(const GUID /*guid*/, mfxVideoParam * /*par*/, bool /*isEncoder = false*/) { return MFX_ERR_NONE; };
+    virtual mfxStatus IsGuidSupported(const GUID, mfxVideoParam *, bool)      override { return MFX_ERR_NONE; }
 
-    bool CheckOpaqueRequest(mfxFrameAllocRequest *request, mfxFrameSurface1 **pOpaqueSurface, mfxU32 NumOpaqueSurface, bool ExtendedSearch = true);
-    
-    virtual eMFXVAType   GetVAType() const {return MFX_HW_NO; };
+    virtual bool CheckOpaqueRequest(mfxFrameAllocRequest *request, mfxFrameSurface1 **pOpaqueSurface, mfxU32 NumOpaqueSurface, bool ExtendedSearch = true) override;
 
-    virtual bool SetCoreId(mfxU32 Id);
-    virtual void* QueryCoreInterface(const MFX_GUID &guid);
+    virtual eMFXVAType GetVAType() const                   override { return MFX_HW_NO; }
 
-    virtual mfxSession GetSession() {return m_session;}
+    virtual bool SetCoreId(mfxU32 Id)                      override;
+    virtual void* QueryCoreInterface(const MFX_GUID &guid) override;
 
-    virtual void SetWrapper(void* pWrp);
+    virtual mfxSession GetSession()                        override { return m_session; }
 
-    virtual mfxU16 GetAutoAsyncDepth();
+    virtual void SetWrapper(void* pWrp)                    override;
 
-    virtual bool IsCompatibleForOpaq() {return true;};  
+    virtual mfxU16 GetAutoAsyncDepth()                     override;
 
-    // keep frame response structure dwscribing plug-in memory surfaces
+    virtual bool IsCompatibleForOpaq()                     override { return true; }
+
+    // keep frame response structure describing plug-in memory surfaces
     void AddPluginAllocResponse(mfxFrameAllocResponse& response);
 
     // get response which corresponds required conditions: same mids and number
@@ -162,8 +160,8 @@ public:
     mfxStatus QueryPlatform(mfxPlatform* platform);
 
 protected:
-    
-    CommonCORE(const mfxU32 numThreadsAvailable, const mfxSession session = NULL);
+
+    CommonCORE(const mfxU32 numThreadsAvailable, const mfxSession session = nullptr);
 
     class API_1_19_Adapter : public IVideoCore_API_1_19
     {
@@ -200,7 +198,7 @@ protected:
     };
 
     //function checks if surfaces already allocated and mapped and request is consistent. Fill response if surfaces are correct
-    bool IsOpaqSurfacesAlreadyMapped(mfxFrameSurface1 **pOpaqueSurface, mfxU32 NumOpaqueSurface, mfxFrameAllocResponse *response, bool ExtendedSearch = true);
+    virtual bool IsOpaqSurfacesAlreadyMapped(mfxFrameSurface1 **pOpaqueSurface, mfxU32 NumOpaqueSurface, mfxFrameAllocResponse *response, bool ExtendedSearch = true) override;
 
     typedef struct
     {
@@ -220,64 +218,63 @@ protected:
     typedef std::map<mfxFrameAllocResponse*, mfxU32> RefCtrTbl;
 
 
-    CorrespTbl m_CTbl;
-    AllocQueue m_AllocatorQueue;
-    MemIDMap   m_RespMidQ;
-    OpqTbl     m_OpqTbl;
-    OpqTbl_MemId m_OpqTbl_MemId;
+    CorrespTbl       m_CTbl;
+    AllocQueue       m_AllocatorQueue;
+    MemIDMap         m_RespMidQ;
+    OpqTbl           m_OpqTbl;
+    OpqTbl_MemId     m_OpqTbl_MemId;
     OpqTbl_FrameData m_OpqTbl_FrameData;
-    RefCtrTbl  m_RefCtrTbl;
+    RefCtrTbl        m_RefCtrTbl;
 
     // Number of available threads
     const
-    mfxU32 m_numThreadsAvailable;
+    mfxU32                                     m_numThreadsAvailable;
     // Handler to the owning session
     const
-    mfxSession m_session;
+    mfxSession                                 m_session;
 
     // Common I/F
-    mfxWideBufferAllocator m_bufferAllocator;
-    mfxBaseWideFrameAllocator m_FrameAllocator;
+    mfxWideBufferAllocator                     m_bufferAllocator;
+    mfxBaseWideFrameAllocator                  m_FrameAllocator;
 
-    mfxU32 m_NumAllocators;
-    mfxHDL                     m_hdl;
+    mfxU32                                     m_NumAllocators;
+    mfxHDL                                     m_hdl;
 
-    mfxHDL                     m_DXVA2DecodeHandle;
+    mfxHDL                                     m_DXVA2DecodeHandle;
 
-    mfxHDL                     m_D3DDecodeHandle;
-    mfxHDL                     m_D3DEncodeHandle;
-    mfxHDL                     m_D3DVPPHandle;
+    mfxHDL                                     m_D3DDecodeHandle;
+    mfxHDL                                     m_D3DEncodeHandle;
+    mfxHDL                                     m_D3DVPPHandle;
 
-    bool m_bSetExtBufAlloc;
-    bool m_bSetExtFrameAlloc;
+    bool                                       m_bSetExtBufAlloc;
+    bool                                       m_bSetExtFrameAlloc;
 
     std::unique_ptr<mfxMemId[]>                m_pMemId;
     std::unique_ptr<mfxBaseWideFrameAllocator> m_pcAlloc;
 
     std::unique_ptr<FastCopy>                  m_pFastCopy;
-    bool m_bUseExtManager;
-    UMC::Mutex m_guard;
+    bool                                       m_bUseExtManager;
+    UMC::Mutex                                 m_guard;
 
-    bool        m_bIsOpaqMode;
+    bool                                       m_bIsOpaqMode;
 
-    mfxU32      m_CoreId;
+    mfxU32                                     m_CoreId;
 
-    mfx_UMC_FrameAllocator *m_pWrp;
+    mfx_UMC_FrameAllocator*                    m_pWrp;
 
-    EncodeHWCaps  m_encode_caps;
-    EncodeHWCaps  m_encode_mbprocrate;
+    EncodeHWCaps                               m_encode_caps;
+    EncodeHWCaps                               m_encode_mbprocrate;
 
-    std::vector<mfxFrameAllocResponse> m_PlugInMids;
+    std::vector<mfxFrameAllocResponse>         m_PlugInMids;
 
-    API_1_19_Adapter m_API_1_19;
+    API_1_19_Adapter                           m_API_1_19;
 
 
-    mfxU16      m_deviceId;
-private:
-    // Forbid the assignment operator
-    CommonCORE & operator = (const CommonCORE &);
+    mfxU16                                     m_deviceId;
+
+    CommonCORE & operator = (const CommonCORE &) = delete;
 };
 
-mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc, int copyFlag);
+mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 & dst, const mfxFrameSurface1 & src, int copyFlag);
 
 #endif

--- a/_studio/shared/include/mfx_utils.h
+++ b/_studio/shared/include/mfx_utils.h
@@ -67,11 +67,13 @@ static inline T mfx_print_err(T sts, const char *file, int line, const char *fun
 #define MFX_CHECK_STS_ALLOC(pointer)    MFX_CHECK(pointer, MFX_ERR_MEMORY_ALLOC)
 #define MFX_CHECK_COND(cond)            MFX_CHECK(cond, MFX_ERR_UNSUPPORTED)
 #define MFX_CHECK_INIT(InitFlag)        MFX_CHECK(InitFlag, MFX_ERR_MORE_DATA)
+#define MFX_CHECK_HDL(hdl)              MFX_CHECK(hdl,      MFX_ERR_INVALID_HANDLE)
 
 #define MFX_CHECK_UMC_ALLOC(err)     { if (err != true) {return MFX_ERR_MEMORY_ALLOC;} }
 #define MFX_CHECK_EXBUF_INDEX(index) { if (index == -1) {return MFX_ERR_MEMORY_ALLOC;} }
 
-#define MFX_CHECK_WITH_ASSERT(EXPR, ERR) {assert(EXPR); MFX_CHECK(EXPR,ERR); }
+#define MFX_CHECK_WITH_ASSERT(EXPR, ERR) { assert(EXPR); MFX_CHECK(EXPR,ERR); }
+#define MFX_CHECK_WITH_THROW(EXPR, ERR, EXP)  { if (!(EXPR)) { std::ignore = MFX_STS_TRACE(ERR); throw EXP; } }
 
 static const mfxU32 MFX_TIME_STAMP_FREQUENCY = 90000; // will go to mfxdefs.h
 static const mfxU64 MFX_TIME_STAMP_INVALID = (mfxU64)-1; // will go to mfxdefs.h
@@ -123,10 +125,14 @@ bool LumaIsNull(const mfxFrameSurface1 * surf)
 {
 #if (MFX_VERSION >= 1027)
     if (surf->Info.FourCC == MFX_FOURCC_Y410)
+    {
         return !surf->Data.Y410;
+    }
     else
 #endif
+    {
         return !surf->Data.Y;
+    }
 }
 
 #ifndef SAFE_RELEASE

--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -42,23 +42,21 @@
 #include "va/va.h"
 #include <va/va_backend.h>
 
-#define MFX_CHECK_HDL(hdl) {if (!hdl) MFX_RETURN(MFX_ERR_INVALID_HANDLE);}
-
 typedef struct drm_i915_getparam {
     int param;
     int *value;
 } drm_i915_getparam_t;
 
-#define I915_PARAM_CHIPSET_ID            4
-#define DRM_I915_GETPARAM   0x06
+#define I915_PARAM_CHIPSET_ID   4
+#define DRM_I915_GETPARAM       0x06
 #define DRM_IOCTL_BASE          'd'
-#define DRM_COMMAND_BASE                0x40
+#define DRM_COMMAND_BASE        0x40
 #define DRM_IOWR(nr,type)       _IOWR(DRM_IOCTL_BASE,nr,type)
-#define DRM_IOCTL_I915_GETPARAM         DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_GETPARAM, drm_i915_getparam_t)
+#define DRM_IOCTL_I915_GETPARAM DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_GETPARAM, drm_i915_getparam_t)
 
 typedef struct {
-    int device_id;
-    eMFXHWType platform;
+    int          device_id;
+    eMFXHWType   platform;
     eMFXGTConfig config;
 } mfx_device_item;
 
@@ -407,29 +405,28 @@ mfx_device_item getDeviceItem(VADisplay pVaDisplay)
 {
     /* This is value by default */
     mfx_device_item retDeviceItem = { 0x0000, MFX_HW_UNKNOWN, MFX_GT_UNKNOWN };
-    int fd = 0, i = 0, listSize = 0;
-    int devID = 0;
-    int ret = 0;
-    drm_i915_getparam_t gp;
-    VADisplayContextP pDisplayContext_test = NULL;
-    VADriverContextP  pDriverContext_test = NULL;
 
-    pDisplayContext_test = (VADisplayContextP) pVaDisplay;
-    pDriverContext_test  = pDisplayContext_test->pDriverContext;
-    fd = *(int*) pDriverContext_test->drm_state;
+    VADisplayContextP pDisplayContext_test = reinterpret_cast<VADisplayContextP>(pVaDisplay);
+    VADriverContextP  pDriverContext_test  = pDisplayContext_test->pDriverContext;
+
+    int fd = *(int*)pDriverContext_test->drm_state;
 
     /* Now as we know real authenticated fd of VAAPI library,
-     * we can call ioctl() to kernel mode driver,
-     * get device ID and find out platform type
-     * */
+    * we can call ioctl() to kernel mode driver,
+    * get device ID and find out platform type
+    * */
+    int devID = 0;
+    drm_i915_getparam_t gp;
     gp.param = I915_PARAM_CHIPSET_ID;
     gp.value = &devID;
 
-    ret = ioctl(fd, DRM_IOCTL_I915_GETPARAM, &gp);
+    int ret = ioctl(fd, DRM_IOCTL_I915_GETPARAM, &gp);
+
     if (!ret)
     {
-        listSize = (sizeof(listLegalDevIDs) / sizeof(mfx_device_item));
-        for (i = 0; i < listSize; ++i)
+        mfxU32 listSize = (sizeof(listLegalDevIDs) / sizeof(mfx_device_item));
+
+        for (mfxU32 i = 0; i < listSize; ++i)
         {
             if (listLegalDevIDs[i].device_id == devID)
             {
@@ -442,12 +439,14 @@ mfx_device_item getDeviceItem(VADisplay pVaDisplay)
     return retDeviceItem;
 } // eMFXHWType getDeviceItem (VADisplay pVaDisplay)
 
+template class VAAPIVideoCORE_T<CommonCORE  >;
 
-VAAPIVideoCORE::VAAPIVideoCORE(
+template <class Base>
+VAAPIVideoCORE_T<Base>::VAAPIVideoCORE_T(
     const mfxU32 adapterNum,
     const mfxU32 numThreadsAvailable,
-    const mfxSession session) :
-            CommonCORE(numThreadsAvailable, session)
+    const mfxSession session)
+          : Base(numThreadsAvailable, session)
           , m_Display(0)
           , m_VAConfigHandle((mfxHDL)VA_INVALID_ID)
           , m_VAContextHandle((mfxHDL)VA_INVALID_ID)
@@ -465,62 +464,54 @@ VAAPIVideoCORE::VAAPIVideoCORE(
 #endif
           , m_bHEVCFEIEnabled(false)
 {
-} // VAAPIVideoCORE::VAAPIVideoCORE(...)
+} // VAAPIVideoCORE_T<Base>::VAAPIVideoCORE_T(...)
 
-
-VAAPIVideoCORE::~VAAPIVideoCORE()
+template <class Base>
+VAAPIVideoCORE_T<Base>::~VAAPIVideoCORE_T()
 {
-    if (m_bCmCopy)
-    {
-        m_pCmCopy->Release();
-        m_bCmCopy = false;
-    }
-
     Close();
+}
 
-} // VAAPIVideoCORE::~VAAPIVideoCORE()
-
-
-void VAAPIVideoCORE::Close()
+template <class Base>
+void VAAPIVideoCORE_T<Base>::Close()
 {
     m_KeepVAState = false;
     m_pVA.reset();
-} // void VAAPIVideoCORE::Close()
+}
 
-
-mfxStatus
-VAAPIVideoCORE::GetHandle(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::GetHandle(
     mfxHandleType type,
     mfxHDL *handle)
 {
     MFX_CHECK_NULL_PTR1(handle);
-    UMC::AutomaticUMCMutex guard(m_guard);
+    UMC::AutomaticUMCMutex guard(this->m_guard);
 
 #if defined (MFX_ENABLE_CPLIB)
-    if (MFX_HANDLE_VA_CONTEXT_ID == (mfxU32)type )
+#if (MFX_VERSION >= 1030)
+    if (MFX_HANDLE_VA_CONTEXT_ID == (mfxU32)type)
     {
-        if (m_VAContextHandle != (mfxHDL)VA_INVALID_ID)
-        {
-            *handle = m_VAContextHandle;
-            return MFX_ERR_NONE;
-        }
         // not exist handle yet
-        else
-            return MFX_ERR_NOT_FOUND;
+        MFX_CHECK(m_VAContextHandle != (mfxHDL)VA_INVALID_ID, MFX_ERR_NOT_FOUND);
+
+        *handle = m_VAContextHandle;
+        return MFX_ERR_NONE;
     }
     else
 #endif
-        return CommonCORE::GetHandle(type, handle);
+#endif
+        return Base::GetHandle(type, handle);
 
-} // mfxStatus VAAPIVideoCORE::GetHandle(mfxHandleType type, mfxHDL *handle)
+} // mfxStatus VAAPIVideoCORE_T<Base>::GetHandle(mfxHandleType type, mfxHDL *handle)
 
-mfxStatus
-VAAPIVideoCORE::SetHandle(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::SetHandle(
     mfxHandleType type,
     mfxHDL hdl)
 {
-    MFX_CHECK_NULL_PTR1(hdl);
-    UMC::AutomaticUMCMutex guard(m_guard);
+    MFX_CHECK_HDL(hdl);
+
+    UMC::AutomaticUMCMutex guard(this->m_guard);
     try
     {
         switch ((mfxU32)type)
@@ -528,25 +519,29 @@ VAAPIVideoCORE::SetHandle(
 #if defined (MFX_ENABLE_CPLIB)
         case MFX_HANDLE_VA_CONFIG_ID:
             // if device manager already set
-            if (m_VAConfigHandle != (mfxHDL)VA_INVALID_ID)
-                return MFX_ERR_UNDEFINED_BEHAVIOR;
+            MFX_CHECK(m_VAConfigHandle == (mfxHDL)VA_INVALID_ID, MFX_ERR_UNDEFINED_BEHAVIOR);
+
             // set external handle
             m_VAConfigHandle = hdl;
             m_KeepVAState = true;
             break;
+
         case MFX_HANDLE_VA_CONTEXT_ID:
             // if device manager already set
-            if (m_VAContextHandle != (mfxHDL)VA_INVALID_ID)
-                return MFX_ERR_UNDEFINED_BEHAVIOR;
+            MFX_CHECK(m_VAContextHandle == (mfxHDL)VA_INVALID_ID, MFX_ERR_UNDEFINED_BEHAVIOR);
+
             // set external handle
             m_VAContextHandle = hdl;
             m_KeepVAState = true;
             break;
 #endif
-        default:
-            mfxStatus sts = CommonCORE::SetHandle(type, hdl);
-            MFX_CHECK_STS(sts);
-            m_Display = (VADisplay)m_hdl;
+        case MFX_HANDLE_VA_DISPLAY:
+        {
+            // If device manager already set, return error
+            MFX_CHECK(!this->m_hdl, MFX_ERR_UNDEFINED_BEHAVIOR);
+
+            this->m_hdl = hdl;
+            m_Display   = (VADisplay)this->m_hdl;
 
             /* As we know right VA handle (pointer),
             * we can get real authenticated fd of VAAPI library(display),
@@ -555,22 +550,26 @@ VAAPIVideoCORE::SetHandle(
             */
             const auto devItem = getDeviceItem(m_Display);
             MFX_CHECK_WITH_ASSERT(MFX_HW_UNKNOWN != devItem.platform, MFX_ERR_UNDEFINED_BEHAVIOR);
-            m_HWType   = devItem.platform;
-            m_GTConfig = devItem.config;
-            m_deviceId = mfxU16(devItem.device_id);
+
+            m_HWType         = devItem.platform;
+            m_GTConfig       = devItem.config;
+            this->m_deviceId = mfxU16(devItem.device_id);
+        }
+            break;
+
+        default:
+            return Base::SetHandle(type, hdl);
         }
         return MFX_ERR_NONE;
     }
     catch (...)
     {
-        ReleaseHandle();
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+        MFX_RETURN(MFX_ERR_UNDEFINED_BEHAVIOR);
     }
-}// mfxStatus VAAPIVideoCORE::SetHandle(mfxHandleType type, mfxHDL handle)
+}// mfxStatus VAAPIVideoCORE_T<Base>::SetHandle(mfxHandleType type, mfxHDL handle)
 
-
-mfxStatus
-VAAPIVideoCORE::TraceFrames(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::TraceFrames(
     mfxFrameAllocRequest* request,
     mfxFrameAllocResponse* response,
     mfxStatus sts)
@@ -581,16 +580,18 @@ VAAPIVideoCORE::TraceFrames(
     return sts;
 }
 
-mfxStatus
-VAAPIVideoCORE::AllocFrames(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::AllocFrames(
     mfxFrameAllocRequest* request,
     mfxFrameAllocResponse* response,
     bool isNeedCopy)
 {
-    UMC::AutomaticUMCMutex guard(m_guard);
+    MFX_CHECK_NULL_PTR2(request, response);
+
+    UMC::AutomaticUMCMutex guard(this->m_guard);
+
     try
     {
-        MFX_CHECK_NULL_PTR2(request, response);
         mfxStatus sts = MFX_ERR_NONE;
         mfxFrameAllocRequest temp_request = *request;
 
@@ -605,18 +606,23 @@ VAAPIVideoCORE::AllocFrames(
         if (!m_bCmCopy && m_bCmCopyAllowed && isNeedCopy && m_Display)
         {
             m_pCmCopy.reset(new CmCopyWrapper);
-            if (!m_pCmCopy->GetCmDevice(m_Display)){
-                m_bCmCopy = false;
+
+            if (!m_pCmCopy->GetCmDevice(m_Display))
+            {
+                m_bCmCopy        = false;
                 m_bCmCopyAllowed = false;
-                m_pCmCopy->Release();
                 m_pCmCopy.reset();
-            }else{
+            }
+            else
+            {
                 sts = m_pCmCopy->Initialize(GetHWType());
                 MFX_CHECK_STS(sts);
                 m_bCmCopy = true;
             }
-        }else if(m_bCmCopy){
-            if(m_pCmCopy)
+        }
+        else if (m_bCmCopy)
+        {
+            if (m_pCmCopy)
                 m_pCmCopy->ReleaseCmSurfaces();
             else
                 m_bCmCopy = false;
@@ -626,17 +632,17 @@ VAAPIVideoCORE::AllocFrames(
         // use common core for sw surface allocation
         if (request->Type & MFX_MEMTYPE_SYSTEM_MEMORY)
         {
-            sts = CommonCORE::AllocFrames(request, response);
+            sts = Base::AllocFrames(request, response);
             return TraceFrames(request, response, sts);
         } else
         {
+            bool isExtAllocatorCallAllowed = ((request->Type & MFX_MEMTYPE_EXTERNAL_FRAME) &&
+                (request->Type & MFX_MEMTYPE_FROM_DECODE)) || // 'fake' Alloc call to retrieve memId's of surfaces already allocated by app
+                (request->Type & (MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK)); // 'fake' Alloc call for FEI ENC/PAC cases to get reconstructed surfaces
             // external allocator
-            if (m_bSetExtFrameAlloc &&
-                request->Info.FourCC != MFX_FOURCC_P8 &&
-                (request->Type & (MFX_MEMTYPE_EXTERNAL_FRAME | MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK)))
+            if (this->m_bSetExtFrameAlloc && isExtAllocatorCallAllowed)
             {
-                // make 'fake' Alloc call to retrieve memId's of surfaces already allocated by app.
-                sts = (*m_FrameAllocator.frameAllocator.Alloc)(m_FrameAllocator.frameAllocator.pthis, &temp_request, response);
+                sts = (*this->m_FrameAllocator.frameAllocator.Alloc)(this->m_FrameAllocator.frameAllocator.pthis, &temp_request, response);
 
                 m_bUseExtAllocForHWFrames = false;
                 MFX_CHECK_STS(sts);
@@ -647,12 +653,12 @@ VAAPIVideoCORE::AllocFrames(
 
                 if (response->NumFrameActual < request->NumFrameMin)
                 {
-                    (*m_FrameAllocator.frameAllocator.Free)(m_FrameAllocator.frameAllocator.pthis, response);
+                    (*this->m_FrameAllocator.frameAllocator.Free)(this->m_FrameAllocator.frameAllocator.pthis, response);
                     MFX_RETURN(MFX_ERR_MEMORY_ALLOC);
                 }
 
                 m_bUseExtAllocForHWFrames = true;
-                sts = ProcessRenderTargets(request, response, &m_FrameAllocator);
+                sts = ProcessRenderTargets(request, response, &this->m_FrameAllocator);
                 MFX_CHECK_STS(sts);
 
                 return TraceFrames(request, response, sts);
@@ -661,7 +667,7 @@ VAAPIVideoCORE::AllocFrames(
             {
                 // Default Allocator is used for internal memory allocation and all coded buffers allocation
                 m_bUseExtAllocForHWFrames = false;
-                sts = DefaultAllocFrames(request, response);
+                sts = this->DefaultAllocFrames(request, response);
                 MFX_CHECK_STS(sts);
 
                 return TraceFrames(request, response, sts);
@@ -673,10 +679,10 @@ VAAPIVideoCORE::AllocFrames(
         return MFX_ERR_MEMORY_ALLOC;
     }
 
-} // mfxStatus VAAPIVideoCORE::AllocFrames(...)
+} // mfxStatus VAAPIVideoCORE_T<Base>::AllocFrames(...)
 
-
-mfxStatus VAAPIVideoCORE::ReallocFrame(mfxFrameSurface1 *surf)
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::ReallocFrame(mfxFrameSurface1 *surf)
 {
     MFX_CHECK_NULL_PTR1(surf);
 
@@ -687,22 +693,22 @@ mfxStatus VAAPIVideoCORE::ReallocFrame(mfxFrameSurface1 *surf)
          (surf->Data.MemType & MFX_MEMTYPE_DXVA2_PROCESSOR_TARGET))))
         return MFX_ERR_MEMORY_ALLOC;
 
-    mfxFrameAllocator *pFrameAlloc = GetAllocatorAndMid(memid);
-   if (!pFrameAlloc)
-       return MFX_ERR_MEMORY_ALLOC;
+    mfxFrameAllocator *pFrameAlloc = this->GetAllocatorAndMid(memid);
+    if (!pFrameAlloc)
+        return MFX_ERR_MEMORY_ALLOC;
 
-   mfxHDL srcHandle;
-   if (MFX_ERR_NONE == GetFrameHDL(surf->Data.MemId, &srcHandle))
-   {
-       VASurfaceID *va_surf = (VASurfaceID*)srcHandle;
-       return mfxDefaultAllocatorVAAPI::ReallocFrameHW(pFrameAlloc->pthis, surf, va_surf);
-   }
+    mfxHDL srcHandle;
+    if (MFX_ERR_NONE == this->GetFrameHDL(surf->Data.MemId, &srcHandle))
+    {
+        VASurfaceID *va_surf = (VASurfaceID*)srcHandle;
+        return mfxDefaultAllocatorVAAPI::ReallocFrameHW(pFrameAlloc->pthis, surf, va_surf);
+    }
 
     return MFX_ERR_MEMORY_ALLOC;
 }
 
-mfxStatus
-VAAPIVideoCORE::DefaultAllocFrames(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::DefaultAllocFrames(
     mfxFrameAllocRequest* request,
     mfxFrameAllocResponse* response)
 {
@@ -714,7 +720,7 @@ VAAPIVideoCORE::DefaultAllocFrames(
         if (!m_Display)
             return MFX_ERR_NOT_INITIALIZED;
 
-        mfxBaseWideFrameAllocator* pAlloc = GetAllocatorByReq(request->Type);
+        mfxBaseWideFrameAllocator* pAlloc = this->GetAllocatorByReq(request->Type);
         // VPP, ENC, PAK can request frames for several times
         if (pAlloc && (request->Type & MFX_MEMTYPE_FROM_DECODE))
             return MFX_ERR_MEMORY_ALLOC;
@@ -735,23 +741,22 @@ VAAPIVideoCORE::DefaultAllocFrames(
     }
     else
     {
-        return CommonCORE::DefaultAllocFrames(request, response);
+        return Base::DefaultAllocFrames(request, response);
     }
-    ++m_NumAllocators;
+    ++this->m_NumAllocators;
 
     return sts;
 
-} // mfxStatus VAAPIVideoCORE::DefaultAllocFrames(...)
+} // mfxStatus VAAPIVideoCORE_T<Base>::DefaultAllocFrames(...)
 
-
-mfxStatus
-VAAPIVideoCORE::CreateVA(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::CreateVA(
     mfxVideoParam* param,
     mfxFrameAllocRequest* request,
     mfxFrameAllocResponse* response,
     UMC::FrameAllocator *allocator)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+    MFX_CHECK_NULL_PTR3(param, request, response);
 
     if (!(request->Type & MFX_MEMTYPE_FROM_DECODE) ||
         !(request->Type & MFX_MEMTYPE_DXVA2_DECODER_TARGET))
@@ -762,13 +767,12 @@ VAAPIVideoCORE::CreateVA(
 
     bool init_render_targets =
 #if defined(ANDROID)
-        true
+        true;
 #else
         param->mfx.CodecId != MFX_CODEC_MPEG2 &&
         param->mfx.CodecId != MFX_CODEC_AVC   &&
-        param->mfx.CodecId != MFX_CODEC_HEVC
+        param->mfx.CodecId != MFX_CODEC_HEVC;
 #endif
-        ;
 
     VASurfaceID* RenderTargets = NULL;
     std::vector<VASurfaceID> rt_pool;
@@ -780,7 +784,7 @@ VAAPIVideoCORE::CreateVA(
         for (mfxU32 i = 0; i < response->NumFrameActual; i++)
         {
             mfxMemId InternalMid = response->mids[i];
-            mfxFrameAllocator* pAlloc = GetAllocatorAndMid(InternalMid);
+            mfxFrameAllocator* pAlloc = this->GetAllocatorAndMid(InternalMid);
             VASurfaceID *pSurface = NULL;
             if (pAlloc)
                 pAlloc->GetHDL(pAlloc->pthis, InternalMid, (mfxHDL*)&pSurface);
@@ -796,29 +800,27 @@ VAAPIVideoCORE::CreateVA(
     else
         m_KeepVAState = false;
 
-    sts = CreateVideoAccelerator(param, profile, response->NumFrameActual, RenderTargets, allocator);
+    return CreateVideoAccelerator(param, profile, response->NumFrameActual, RenderTargets, allocator);
+} // mfxStatus VAAPIVideoCORE_T<Base>::CreateVA(...)
 
-    return sts;
-
-} // mfxStatus VAAPIVideoCORE::CreateVA(...)
-
-mfxStatus VAAPIVideoCORE::CreateVideoProcessing(mfxVideoParam * param)
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::CreateVideoProcessing(mfxVideoParam * param)
 {
     (void)param;
 
-    mfxStatus sts = MFX_ERR_NONE;
 #if defined (MFX_ENABLE_VPP)
     if (!m_vpp_hw_resmng.GetDevice()){
-        sts = m_vpp_hw_resmng.CreateDevice(this);
+        return m_vpp_hw_resmng.CreateDevice(this);
     }
+
+    return MFX_ERR_NONE;
 #else
-    sts = MFX_ERR_UNSUPPORTED;
+    MFX_RETURN(MFX_ERR_UNSUPPORTED);
 #endif
-    return sts;
 }
 
-mfxStatus
-VAAPIVideoCORE::ProcessRenderTargets(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::ProcessRenderTargets(
     mfxFrameAllocRequest* request,
     mfxFrameAllocResponse* response,
     mfxBaseWideFrameAllocator* pAlloc)
@@ -828,77 +830,76 @@ VAAPIVideoCORE::ProcessRenderTargets(
         return MFX_ERR_UNSUPPORTED;
 #endif
 
-    RegisterMids(response, request->Type, !m_bUseExtAllocForHWFrames, pAlloc);
+    this->RegisterMids(response, request->Type, !m_bUseExtAllocForHWFrames, pAlloc);
     m_pcHWAlloc.release();
 
     return MFX_ERR_NONE;
 
-} // mfxStatus VAAPIVideoCORE::ProcessRenderTargets(
+} // mfxStatus VAAPIVideoCORE_T<Base>::ProcessRenderTargets(...)
 
-mfxStatus
-VAAPIVideoCORE::GetVAService(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::GetVAService(
     VADisplay*  pVADisplay)
 {
     // check if created already
-    if (m_Display)
+    MFX_CHECK(m_Display, MFX_ERR_NOT_INITIALIZED);
+
+    if (pVADisplay)
     {
-        if (pVADisplay)
-        {
-            *pVADisplay = m_Display;
-        }
-        return MFX_ERR_NONE;
+        *pVADisplay = m_Display;
     }
 
-    return MFX_ERR_NOT_INITIALIZED;
+    return MFX_ERR_NONE;
+} // mfxStatus VAAPIVideoCORE_T<Base>::GetVAService(...)
 
-} // mfxStatus VAAPIVideoCORE::GetVAService(...)
-
-void
-VAAPIVideoCORE::SetCmCopy(bool enable)
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::SetCmCopyStatus(bool enable)
 {
+    UMC::AutomaticUMCMutex guard(this->m_guard);
+
     m_bCmCopyAllowed = enable;
-    if (!enable)
+
+    if (!m_bCmCopyAllowed)
     {
-        if (m_pCmCopy)
-        {
-            m_pCmCopy->Release();
-        }
+        m_pCmCopy.reset();
+
         m_bCmCopy = false;
     }
-} // mfxStatus VAAPIVideoCORE::SetCmCopyStatus(...)
 
-mfxStatus
-VAAPIVideoCORE::CreateVideoAccelerator(
+    return MFX_ERR_NONE;
+} // mfxStatus VAAPIVideoCORE_T<Base>::SetCmCopyStatus(...)
+
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::CreateVideoAccelerator(
     mfxVideoParam* param,
     int profile,
     int NumOfRenderTarget,
     VASurfaceID* RenderTargets,
     UMC::FrameAllocator *allocator)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+    MFX_CHECK_NULL_PTR1(param);
+    MFX_CHECK(m_Display, MFX_ERR_NOT_INITIALIZED);
 
-    Status st;
+    UMC::AutomaticUMCMutex guard(this->m_guard);
+
     UMC::LinuxVideoAcceleratorParams params;
     mfxFrameInfo *pInfo = &(param->mfx.FrameInfo);
 
-    if (!m_Display)
-        return MFX_ERR_NOT_INITIALIZED;
-
     UMC::VideoStreamInfo VideoInfo;
-    VideoInfo.clip_info.width = pInfo->Width;
+    VideoInfo.clip_info.width  = pInfo->Width;
     VideoInfo.clip_info.height = pInfo->Height;
 
     // Init Accelerator
-    params.m_Display = m_Display;
-    params.m_pConfigId = (VAConfigID*)&m_VAConfigHandle;
-    params.m_pContext = (VAContextID*)&m_VAContextHandle;
-    params.m_pKeepVAState = &m_KeepVAState;
+    params.m_Display          = m_Display;
+    params.m_pConfigId        = (VAConfigID*)&m_VAConfigHandle;
+    params.m_pContext         = (VAContextID*)&m_VAContextHandle;
+    params.m_pKeepVAState     = &m_KeepVAState;
     params.m_pVideoStreamInfo = &VideoInfo;
-    params.m_iNumberSurfaces = NumOfRenderTarget;
-    params.m_allocator = allocator;
-    params.m_surf = (void **)RenderTargets;
+    params.m_iNumberSurfaces  = NumOfRenderTarget;
+    params.m_allocator        = allocator;
+    params.m_surf             = (void **)RenderTargets;
 
-    params.m_protectedVA = param->Protected;
+    params.m_protectedVA      = param->Protected;
 
     /* There are following conditions for post processing via HW fixed function engine:
      * (1): AVC
@@ -917,38 +918,32 @@ VAAPIVideoCORE::CreateVideoAccelerator(
     //check 'StreamOut' feature is requested
     {
         mfxExtBuffer* ext = GetExtBuffer(param->ExtParam, param->NumExtParam, MFX_EXTBUFF_FEI_PARAM);
-        if (ext)
-            params.m_CreateFlags |= reinterpret_cast<mfxExtFeiParam*>(ext)->Func == MFX_FEI_FUNCTION_DEC ? VA_DECODE_STREAM_OUT_ENABLE : 0;
+        if (ext && reinterpret_cast<mfxExtFeiParam*>(ext)->Func == MFX_FEI_FUNCTION_DEC)
+            params.m_CreateFlags |= VA_DECODE_STREAM_OUT_ENABLE;
     }
 
     m_pVA.reset((params.m_CreateFlags & VA_DECODE_STREAM_OUT_ENABLE) ? new FEIVideoAccelerator() : new LinuxVideoAccelerator());
-    m_pVA->m_Platform = UMC::VA_LINUX;
-    m_pVA->m_Profile = (VideoAccelerationProfile)profile;
+    m_pVA->m_Platform   = UMC::VA_LINUX;
+    m_pVA->m_Profile    = (VideoAccelerationProfile)profile;
     m_pVA->m_HWPlatform = m_HWType;
 
-    st = m_pVA->Init(&params);
+    Status st = m_pVA->Init(&params);
+    MFX_CHECK(st == UMC_OK, MFX_ERR_UNSUPPORTED);
 
-    if(UMC_OK != st)
-    {
-        return MFX_ERR_UNSUPPORTED;
-    }
+    return MFX_ERR_NONE;
+} // mfxStatus VAAPIVideoCORE_T<Base>::CreateVideoAccelerator(...)
 
-    return sts;
-
-} // mfxStatus VAAPIVideoCORE::CreateVideoAccelerator(...)
-
-
-mfxStatus
-VAAPIVideoCORE::DoFastCopyWrapper(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::DoFastCopyWrapper(
     mfxFrameSurface1* pDst,
     mfxU16 dstMemType,
     mfxFrameSurface1* pSrc,
     mfxU16 srcMemType)
 {
-    MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "VAAPIVideoCORE::DoFastCopyWrapper");
+    MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "VAAPIVideoCORE_T<Base>::DoFastCopyWrapper");
     mfxStatus sts;
 
-    mfxHDL srcHandle, dstHandle;
+    mfxHDL srcHandle = {}, dstHandle = {};
     mfxMemId srcMemId, dstMemId;
 
     mfxFrameSurface1 srcTempSurface, dstTempSurface;
@@ -975,7 +970,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         {
             if (nullptr == srcPtr)
             {
-                sts = LockExternalFrame(srcMemId, &srcTempSurface.Data);
+                sts = this->LockExternalFrame(srcMemId, &srcTempSurface.Data);
                 MFX_CHECK_STS(sts);
 
                 isSrcLocked = true;
@@ -988,7 +983,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         }
         else if (srcMemType & MFX_MEMTYPE_DXVA2_DECODER_TARGET)
         {
-            sts = GetExternalFrameHDL(srcMemId, &srcHandle);
+            sts = this->GetExternalFrameHDL(srcMemId, &srcHandle);
             MFX_CHECK_STS(sts);
 
             srcTempSurface.Data.MemId = srcHandle;
@@ -1000,7 +995,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         {
             if (nullptr == srcPtr)
             {
-                sts = LockFrame(srcMemId, &srcTempSurface.Data);
+                sts = this->LockFrame(srcMemId, &srcTempSurface.Data);
                 MFX_CHECK_STS(sts);
 
                 isSrcLocked = true;
@@ -1013,7 +1008,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         }
         else if (srcMemType & MFX_MEMTYPE_DXVA2_DECODER_TARGET)
         {
-            sts = GetFrameHDL(srcMemId, &srcHandle);
+            sts = this->GetFrameHDL(srcMemId, &srcHandle);
             MFX_CHECK_STS(sts);
 
             srcTempSurface.Data.MemId = srcHandle;
@@ -1026,7 +1021,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         {
             if (nullptr == dstPtr)
             {
-                sts = LockExternalFrame(dstMemId, &dstTempSurface.Data);
+                sts = this->LockExternalFrame(dstMemId, &dstTempSurface.Data);
                 MFX_CHECK_STS(sts);
 
                 isDstLocked = true;
@@ -1039,7 +1034,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         }
         else if (dstMemType & MFX_MEMTYPE_DXVA2_DECODER_TARGET)
         {
-            sts = GetExternalFrameHDL(dstMemId, &dstHandle);
+            sts = this->GetExternalFrameHDL(dstMemId, &dstHandle);
             MFX_CHECK_STS(sts);
 
             dstTempSurface.Data.MemId = dstHandle;
@@ -1051,7 +1046,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         {
             if (nullptr == dstPtr)
             {
-                sts = LockFrame(dstMemId, &dstTempSurface.Data);
+                sts = this->LockFrame(dstMemId, &dstTempSurface.Data);
                 MFX_CHECK_STS(sts);
 
                 isDstLocked = true;
@@ -1064,7 +1059,7 @@ VAAPIVideoCORE::DoFastCopyWrapper(
         }
         else if (dstMemType & MFX_MEMTYPE_DXVA2_DECODER_TARGET)
         {
-            sts = GetFrameHDL(dstMemId, &dstHandle);
+            sts = this->GetFrameHDL(dstMemId, &dstHandle);
             MFX_CHECK_STS(sts);
 
             dstTempSurface.Data.MemId = dstHandle;
@@ -1084,13 +1079,13 @@ VAAPIVideoCORE::DoFastCopyWrapper(
     {
         if (srcMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
-            sts = UnlockExternalFrame(srcMemId, &srcTempSurface.Data);
+            sts = this->UnlockExternalFrame(srcMemId, &srcTempSurface.Data);
             MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (srcMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
-            sts = UnlockFrame(srcMemId, &srcTempSurface.Data);
+            sts = this->UnlockFrame(srcMemId, &srcTempSurface.Data);
             MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
@@ -1100,13 +1095,13 @@ VAAPIVideoCORE::DoFastCopyWrapper(
     {
         if (dstMemType & MFX_MEMTYPE_EXTERNAL_FRAME)
         {
-            sts = UnlockExternalFrame(dstMemId, &dstTempSurface.Data);
+            sts = this->UnlockExternalFrame(dstMemId, &dstTempSurface.Data);
             MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
         else if (dstMemType & MFX_MEMTYPE_INTERNAL_FRAME)
         {
-            sts = UnlockFrame(dstMemId, &dstTempSurface.Data);
+            sts = this->UnlockFrame(dstMemId, &dstTempSurface.Data);
             MFX_CHECK_STS(fcSts);
             MFX_CHECK_STS(sts);
         }
@@ -1114,11 +1109,10 @@ VAAPIVideoCORE::DoFastCopyWrapper(
 
     return fcSts;
 
-} // mfxStatus VAAPIVideoCORE::DoFastCopyWrapper(...)
+} // mfxStatus VAAPIVideoCORE_T<Base>::DoFastCopyWrapper(...)
 
-
-mfxStatus
-VAAPIVideoCORE::DoFastCopyExtended(
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::DoFastCopyExtended(
     mfxFrameSurface1* pDst,
     mfxFrameSurface1* pSrc)
 {
@@ -1219,7 +1213,7 @@ VAAPIVideoCORE::DoFastCopyExtended(
                     mfxMemId saveMemId = pSrc->Data.MemId;
                     pSrc->Data.MemId = 0;
 
-                    sts = CoreDoSWFastCopy(pDst, pSrc, COPY_VIDEO_TO_SYS); // sw copy
+                    sts = CoreDoSWFastCopy(*pDst, *pSrc, COPY_VIDEO_TO_SYS); // sw copy
                     MFX_CHECK_STS(sts);
 
                     pSrc->Data.MemId = saveMemId;
@@ -1245,7 +1239,7 @@ VAAPIVideoCORE::DoFastCopyExtended(
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "FastCopy_sys2sys");
         // system memories were passed
         // use common way to copy frames
-        sts = CoreDoSWFastCopy(pDst, pSrc, COPY_SYS_TO_SYS); // sw copy
+        sts = CoreDoSWFastCopy(*pDst, *pSrc, COPY_SYS_TO_SYS); // sw copy
         MFX_CHECK_STS(sts);
     }
     else if (nullptr != srcPtr && nullptr != pDst->Data.MemId)
@@ -1282,7 +1276,7 @@ VAAPIVideoCORE::DoFastCopyExtended(
                 mfxMemId saveMemId = pDst->Data.MemId;
                 pDst->Data.MemId = 0;
 
-                sts = CoreDoSWFastCopy(pDst, pSrc, COPY_SYS_TO_VIDEO); // sw copy
+                sts = CoreDoSWFastCopy(*pDst, *pSrc, COPY_SYS_TO_VIDEO); // sw copy
                 MFX_CHECK_STS(sts);
 
                 pDst->Data.MemId = saveMemId;
@@ -1308,17 +1302,13 @@ VAAPIVideoCORE::DoFastCopyExtended(
 
     return MFX_ERR_NONE;
 
-} // mfxStatus VAAPIVideoCORE::DoFastCopyExtended(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
+} // mfxStatus VAAPIVideoCORE_T<Base>::DoFastCopyExtended(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc)
 
-
-void VAAPIVideoCORE::ReleaseHandle()
-{
-
-} // void VAAPIVideoCORE::ReleaseHandle()
 
 //function checks profile and entrypoint and video resolution support
 //On linux specific function!
-mfxStatus VAAPIVideoCORE::IsGuidSupported(const GUID guid,
+template <class Base>
+mfxStatus VAAPIVideoCORE_T<Base>::IsGuidSupported(const GUID guid,
                                          mfxVideoParam *par, bool /* isEncoder */)
 {
     MFX_CHECK(par, MFX_WRN_PARTIAL_ACCELERATION);
@@ -1328,10 +1318,10 @@ mfxStatus VAAPIVideoCORE::IsGuidSupported(const GUID guid,
 
 #if VA_CHECK_VERSION(1, 2, 0)
     VaGuidMapper mapper(guid);
-    VAProfile req_profile = mapper.profile;
-    VAEntrypoint req_entrypoint = mapper.entrypoint;
+    VAProfile req_profile         = mapper.profile;
+    VAEntrypoint req_entrypoint   = mapper.entrypoint;
     mfxI32 va_max_num_entrypoints = vaMaxNumEntrypoints(m_Display);
-    mfxI32 va_max_num_profiles = vaMaxNumProfiles(m_Display);
+    mfxI32 va_max_num_profiles    = vaMaxNumProfiles(m_Display);
     MFX_CHECK_COND(va_max_num_entrypoints && va_max_num_profiles);
 
     //driver always support VAProfileNone
@@ -1370,7 +1360,7 @@ mfxStatus VAAPIVideoCORE::IsGuidSupported(const GUID guid,
 
     MFX_CHECK(va_sts == VA_STATUS_SUCCESS, MFX_ERR_UNSUPPORTED);
 
-    //check resolution video
+    //check video resolution
     MFX_CHECK(attr[0].value != VA_ATTRIB_NOT_SUPPORTED, MFX_ERR_UNSUPPORTED);
     MFX_CHECK(attr[1].value != VA_ATTRIB_NOT_SUPPORTED, MFX_ERR_UNSUPPORTED);
     MFX_CHECK_COND(attr[0].value && attr[1].value);
@@ -1401,7 +1391,7 @@ mfxStatus VAAPIVideoCORE::IsGuidSupported(const GUID guid,
         MFX_CHECK(m_HWType >= MFX_HW_BDW, MFX_ERR_UNSUPPORTED);
         break;
     default:
-        return MFX_ERR_UNSUPPORTED;
+        MFX_RETURN(MFX_ERR_UNSUPPORTED);
     }
 
     MFX_CHECK(MFX_CODEC_JPEG == par->mfx.CodecId || MFX_CODEC_HEVC == par->mfx.CodecId ||
@@ -1413,51 +1403,57 @@ mfxStatus VAAPIVideoCORE::IsGuidSupported(const GUID guid,
 #endif
 }
 
-void* VAAPIVideoCORE::QueryCoreInterface(const MFX_GUID &guid)
+template <class Base>
+void* VAAPIVideoCORE_T<Base>::QueryCoreInterface(const MFX_GUID &guid)
 {
-    if(MFXIVideoCORE_GUID == guid)
-    {
-        return (void*) this;
-    }
-    else if( MFXICOREVAAPI_GUID == guid )
+    if (MFXICOREVAAPI_GUID == guid)
     {
         return (void*) m_pAdapter.get();
     }
-    else if (MFXICORE_GT_CONFIG_GUID == guid)
+
+    if (MFXICORE_GT_CONFIG_GUID == guid)
     {
         return (void*)&m_GTConfig;
     }
-    else if (MFXIHWCAPS_GUID == guid)
+
+    if (MFXIHWCAPS_GUID == guid)
     {
-        return (void*) &m_encode_caps;
+        return (void*) &this->m_encode_caps;
     }
 #ifdef MFX_ENABLE_MFE
-    else if (MFXMFEDDIENCODER_SEARCH_GUID == guid)
+    if (MFXMFEDDIENCODER_SEARCH_GUID == guid)
     {
         if (!m_mfe.get())
         {
-            m_mfe = (MFEVAAPIEncoder*)m_session->m_pOperatorCore->QueryGUID<ComPtrCore<MFEVAAPIEncoder> >(&VideoCORE::QueryCoreInterface, MFXMFEDDIENCODER_GUID);
+            m_mfe = reinterpret_cast<MFEVAAPIEncoder*>(this->m_session->m_pOperatorCore->template QueryGUID<ComPtrCore<MFEVAAPIEncoder> >(&VideoCORE::QueryCoreInterface, MFXMFEDDIENCODER_GUID));
             if (m_mfe.get())
                 m_mfe.get()->AddRef();
         }
         return (void*)&m_mfe;
     }
-    else if (MFXMFEDDIENCODER_GUID == guid)
+
+    if (MFXMFEDDIENCODER_GUID == guid)
     {
         return (void*)&m_mfe;
     }
 #endif
-    else if (MFXICORECM_GUID == guid)
+
+    if (MFXICORECM_GUID == guid)
     {
-        CmDevice* pCmDevice = NULL;
+        CmDevice* pCmDevice = nullptr;
         if (!m_bCmCopy)
         {
+            UMC::AutomaticUMCMutex guard(this->m_guard);
+
             m_pCmCopy.reset(new CmCopyWrapper);
             pCmDevice = m_pCmCopy->GetCmDevice(m_Display);
+
             if (!pCmDevice)
-                return NULL;
+                return nullptr;
+
             if (MFX_ERR_NONE != m_pCmCopy->Initialize(GetHWType()))
-                return NULL;
+                return nullptr;
+
             m_bCmCopy = true;
         }
         else
@@ -1466,59 +1462,54 @@ void* VAAPIVideoCORE::QueryCoreInterface(const MFX_GUID &guid)
         }
         return (void*)pCmDevice;
     }
-    else if (MFXICORECMCOPYWRAPPER_GUID == guid)
+
+    if (MFXICORECMCOPYWRAPPER_GUID == guid)
     {
         if (!m_pCmCopy)
         {
+            UMC::AutomaticUMCMutex guard(this->m_guard);
+
             m_pCmCopy.reset(new CmCopyWrapper);
             if (!m_pCmCopy->GetCmDevice(m_Display))
             {
-                m_bCmCopy = false;
+                m_bCmCopy        = false;
                 m_bCmCopyAllowed = false;
-                m_pCmCopy->Release();
+
                 m_pCmCopy.reset();
-                return NULL;
+                return nullptr;
             }
-            else
-            {
-                if (MFX_ERR_NONE != m_pCmCopy->Initialize(GetHWType()))
-                    return NULL;
-                else
-                    m_bCmCopy = true;
-            }
+
+            if (MFX_ERR_NONE != m_pCmCopy->Initialize(GetHWType()))
+                return nullptr;
+
+            m_bCmCopy = true;
         }
         return (void*)m_pCmCopy.get();
     }
-    else if (MFXICMEnabledCore_GUID == guid)
+
+    if (MFXICMEnabledCore_GUID == guid)
     {
         if (!m_pCmAdapter)
         {
+            UMC::AutomaticUMCMutex guard(this->m_guard);
+
             m_pCmAdapter.reset(new CMEnabledCoreAdapter(this));
         }
         return (void*)m_pCmAdapter.get();
     }
-    else if (MFXIHWMBPROCRATE_GUID == guid)
+
+    if (MFXIHWMBPROCRATE_GUID == guid)
     {
-        return (void*) &m_encode_mbprocrate;
+        return (void*) &this->m_encode_mbprocrate;
     }
-    else if (MFXIEXTERNALLOC_GUID == guid && m_bSetExtFrameAlloc)
-    {
-        return &m_FrameAllocator.frameAllocator;
-    }
-    else if (MFXICORE_API_1_19_GUID == guid)
-    {
-        return &m_API_1_19;
-    }
-    else if (MFXIFEIEnabled_GUID == guid)
+
+    if (MFXIFEIEnabled_GUID == guid)
     {
         return &m_bHEVCFEIEnabled;
     }
-    else
-    {
-        return NULL;
-    }
 
-} // void* VAAPIVideoCORE::QueryCoreInterface(const MFX_GUID &guid)
+    return Base::QueryCoreInterface(guid);
+} // void* VAAPIVideoCORE_T<Base>::QueryCoreInterface(const MFX_GUID &guid)
 
 bool IsHwMvcEncSupported()
 {


### PR DESCRIPTION
Part of core refactored:

- improved sts checks
- added explicit override specifiers
- clean up in checking macro
- added templatized inheritance  for future flexible integration of oneVPL cores
- more clear areas of responsibilities for each core established, reduced abstraction leaks from HW core to SW core
- multiple minor code style changes
- some alignment between OS and CS codebases done
- missing mutexes added