### PR TITLE
[ASC] Unbreak build with libc++ after [AVC][MCFT]

### DIFF
--- a/_studio/shared/asc/src/asc.cpp
+++ b/_studio/shared/asc/src/asc.cpp
@@ -33,6 +33,7 @@
 #include "motion_estimation_engine.h"
 #include <limits.h>
 #include <algorithm>
+#include <cmath>
 
 using std::min;
 using std::max;


### PR DESCRIPTION
Regressed by #2319. From [error log](https://github.com/Intel-Media-SDK/MediaSDK/files/5328380/intel-media-sdk-20.3.0.log):
```c++
_studio/shared/asc/src/asc.cpp:1129:26: error: no member named 'log' in namespace 'std'
    result = ((c1 * std::log(x)) + c0) >= y;
                    ~~~~~^
```
