### PR TITLE
[Disp] Fix QueryAdapterInfo to report DX11 adapters only

### DIFF
--- a/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
+++ b/api/mfx_dispatch/windows/src/mfx_dispatcher.cpp
@@ -441,7 +441,7 @@ static inline bool QueryAdapterInfo(mfxU32 adapter_n, mfxU32& VendorID, mfxU32& 
 {
     MFX::DXVA2Device dxvaDevice;
 
-    if (!dxvaDevice.InitD3D9(adapter_n) && !dxvaDevice.InitDXGI1(adapter_n))
+    if (!dxvaDevice.InitDXGI1(adapter_n))
         return false;
 
     VendorID = dxvaDevice.GetVendorID();

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -1616,7 +1616,7 @@ Global functions initialize and de-initialize the SDK library and perform query 
 
 **Description**
 
-This function returns number of Intel Gen Graphics adapters. It can be used before [MFXQueryAdapters](#MFXQueryAdapters) call to determine size of input data which user needs to allocate.
+This function returns number of Intel Gen Graphics adapters. It can be used before [MFXQueryAdapters](#MFXQueryAdapters) call to determine size of input data which user needs to allocate. Result of this function corresponds only to DX11 adapters enumeration.
 
 **Return Status**
 
@@ -1644,7 +1644,7 @@ This function is available since SDK API 1.31.
 
 **Description**
 
-This function returns list of adapters suitable to handle workload `input_info`. The list is sorted in priority order: iGPU has advantage over dGPU with only exception when workload is HEVC encode and iGPU is less than Gen12. This rule might be changed in future. If `input_info` pointer is NULL, list of all available Intel adapters will be returned.
+This function returns list of adapters suitable to handle workload `input_info`. The list is sorted in priority order: iGPU has advantage over dGPU with only exception when workload is HEVC encode and iGPU is less than Gen12. This rule might be changed in future. If `input_info` pointer is NULL, list of all available Intel adapters will be returned. Result of this function corresponds only to DX11 adapters enumeration.
 
 **Return Status**
 
@@ -1675,7 +1675,7 @@ This function is available since SDK API 1.31.
 
 **Description**
 
-This function returns list of adapters suitable to decode input `bitstream`. The list is sorted in priority order where iGPU has advantage. This rule might be changed in future. This function is actually a simplification of [MFXQueryAdapters](#MFXQueryAdapters), because `bitstream` is description of workload itself.
+This function returns list of adapters suitable to decode input `bitstream`. The list is sorted in priority order where iGPU has advantage. This rule might be changed in future. This function is actually a simplification of [MFXQueryAdapters](#MFXQueryAdapters), because `bitstream` is description of workload itself. Result of this function corresponds only to DX11 adapters enumeration.
 
 **Return Status**
 


### PR DESCRIPTION
In current behavior of QueryAdapterInfo, it always reports
VID/DID values filled from DX9 data. On multiadapter systems,
enumeration for DX9/DX11 adapters may be different, so this may
lead to error when no adapter is reported but some DX11 adapters
are available. This fix makes QueryAdapterInfo to report only
adapters available for DX11. Doc is also updated.