### PR TITLE
[doc] Add note for MFXQueryAdapter* functions

### DIFF
--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -1585,7 +1585,7 @@ In each function description, only commonly used status codes are documented. Th
 
 ## Global Functions
 
-Global functions initialize and de-initialize the SDK library and perform query functions on a global scale within an application.
+Global functions initialize and de-initialize the SDK library and perform query functions on a global scale within an application. Please, note that result of MFXQueryAdapters*** functions corresponds only to DX11 adapters enumeration (see [Multiple Monitors](#Multiple_monitors) section and each function description for details).
 
  **Member Functions** | Description
  -------------------- | -----------


### PR DESCRIPTION
Currently MFXQueryAdapter* functions results corresponds to
DX11 adapters enumeration only. Added note about that to
make it more clear for user. Multiple Monitors section
is referenced for more explanation.