### PR TITLE
[AVCd] Smaple_decode support AVC decode level 6+

### DIFF
--- a/samples/sample_decode/include/pipeline_decode.h
+++ b/samples/sample_decode/include/pipeline_decode.h
@@ -135,6 +135,10 @@ struct sInputParams
     bool bPrefferiGfx;
 #endif
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    bool bIgnoreLevelConstrain;
+#endif
+
     msdk_char     strSrcFile[MSDK_MAX_FILENAME_LEN];
     msdk_char     strDstFile[MSDK_MAX_FILENAME_LEN];
     sPluginParams pluginParams;

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -529,6 +529,10 @@ mfxStatus CDecodingPipeline::Init(sInputParams *pParams)
         MSDK_CHECK_STATUS(sts, "Plugin load failed");
     }
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    m_mfxVideoParams.mfx.IgnoreLevelConstrain = pParams->bIgnoreLevelConstrain;
+#endif
+
     // Populate parameters. Involves DecodeHeader call
     sts = InitMfxParams(pParams);
     MSDK_CHECK_STATUS(sts, "InitMfxParams failed");

--- a/samples/sample_decode/src/sample_decode.cpp
+++ b/samples/sample_decode/src/sample_decode.cpp
@@ -73,6 +73,9 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("                                              '-device /dev/dri/renderD128'\n"));
     msdk_printf(MSDK_STRING("                                 If not specified, defaults to the first Intel device found on the system\n"));
 #endif
+#if (MFX_VERSION >= MFX_VERSION_NEXT)   
+    msdk_printf(MSDK_STRING("   [-ignore_level_constrain] - ignore level constrain\n"));
+#endif
     msdk_printf(MSDK_STRING("\n"));
     msdk_printf(MSDK_STRING("JPEG Chroma Type:\n"));
     msdk_printf(MSDK_STRING("   [-jpeg_rgb] - RGB Chroma Type\n"));
@@ -633,6 +636,12 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
         {
             ;
         }
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-ignore_level_constrain")))
+        {
+            pParams->bIgnoreLevelConstrain = true;
+        }
+#endif
         else // 1-character options
         {
             switch (strInput[i][1])


### PR DESCRIPTION
Support Decode AVC Level 6/6.1/6.2

Issue: MDP-47088
Test: sample_decode.exe h264 -i src_AVC_4K.mp4.h264 -o out.yuv -hw