### PR TITLE
fix RGB32->RGB32 composition with tile issue

### DIFF
--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -1689,7 +1689,7 @@ mfxStatus VAAPIVideoProcessing::Execute_Composition_TiledVideoWall(mfxExecutePar
 
         m_pipelineParam[i].filters      = 0;
         m_pipelineParam[i].num_filters  = 0;
-        m_pipelineParam[i].output_background_color = 0;
+        m_pipelineParam[i].output_background_color = 0xff000000;
 
         vaSts = vaCreateBuffer(m_vaDisplay,
                             m_vaContextVPP,


### PR DESCRIPTION
set output_background_color to fix RGB32->RGB32 composition with tile
incorrect output issue

Signed-off-by: Yuqin Wei <yuqin.wei@intel.com>