### PR TITLE
[MCTF] Segmentation fault bug fix related to missing output pointer

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -1988,6 +1988,7 @@ namespace MfxHwH264Encode
         }
 
     protected:
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
         std::shared_ptr<CMC>
             amtMctf;
 
@@ -2000,7 +2001,7 @@ namespace MfxHwH264Encode
             void *pParam,
             bool bEoF
         );
-
+#endif
         ASC       amtScd;
         mfxStatus SCD_Put_Frame(
             DdiTask & newTask);

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -1135,6 +1135,7 @@ mfxStatus ImplementationAvc::Init(mfxVideoParam * par)
 
     if (IsMctfSupported(m_video))
     {
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
         if (!m_cmDevice)
         {
             m_cmDevice.Reset(TryCreateCmDevicePtr(m_core));
@@ -1147,6 +1148,7 @@ mfxStatus ImplementationAvc::Init(mfxVideoParam * par)
 
         sts = amtMctf->MCTF_INIT(m_core, m_cmDevice, m_video.mfx.FrameInfo, NULL, IsCmNeededForSCD(m_video), true, true, true);
         MFX_CHECK_STS(sts);
+#endif
     }
 
     sts = m_ddi->Register(m_bit, D3DDDIFMT_INTELENCODE_BITSTREAMDATA);
@@ -1979,7 +1981,7 @@ void ImplementationAvc::BrcPreEnc(
 
     m_brc.PreEnc(task.m_brcFrameParams, m_tmpVmeData);
 }
-
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
 mfxStatus ImplementationAvc::SubmitToMctf(DdiTask * pTask, bool isSceneChange, bool doIntraFiltering)
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_API, "VideoVPPHW::SubmitToMctf");
@@ -2061,7 +2063,7 @@ mfxStatus ImplementationAvc::QueryFromMctf(void *pParam, bool bEoF)
     }
     return MFX_ERR_NONE;
 }
-
+#endif
 using namespace ns_asc;
 mfxStatus ImplementationAvc::SCD_Put_Frame(DdiTask & task)
 {
@@ -2547,8 +2549,10 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "Avc::STG_BIT_START_MCTF");
         if (IsMctfSupported(m_video))
         {
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
             DdiTask & task = m_MctfStarted.back();
             MFX_CHECK_STS(SubmitToMctf(&task, amtScd.Get_frame_shot_Decision(), amtScd.Get_intra_frame_denoise_recommendation()));
+#endif
         }
         OnMctfQueried();
     }
@@ -2558,8 +2562,10 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "Avc::STG_BIT_WAIT_MCTF");
         if (IsMctfSupported(m_video))
         {
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
             DdiTask & task = m_MctfFinished.front();
             MFX_CHECK_STS(QueryFromMctf(&task, false));
+#endif
         }
         OnMctfFinished();
     }

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1407,6 +1407,8 @@ bool MfxHwH264Encode::IsMctfSupported(
         (video.mfx.FrameInfo.BitDepthLuma == 0 || video.mfx.FrameInfo.BitDepthLuma == 8) &&
         (video.mfx.GopRefDist == 8) &&
         !video.mfx.EncodedOrder);
+#else
+    video;
 #endif
     return isSupported;
 }

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1399,6 +1399,7 @@ bool MfxHwH264Encode::IsMctfSupported(
     mfxExtCodingOption2 const & extOpt2 = GetExtBufferRef(video);
     isSupported = (IsOn(extOpt2.ExtBRC) &&
         IsExtBrcSceneChangeSupported(video) &&
+        (video.mfx.FrameInfo.Width <= 3840 && video.vpp.In.Height <= 2160) &&
         (video.mfx.RateControlMethod == MFX_RATECONTROL_CBR || video.mfx.RateControlMethod == MFX_RATECONTROL_VBR) &&
         (video.mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_PROGRESSIVE) &&
         ((video.mfx.FrameInfo.FourCC == MFX_FOURCC_NV12) || (video.mfx.FrameInfo.FourCC == MFX_FOURCC_YV12)) &&

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -68,7 +68,7 @@
         #define MFX_ENABLE_H264_VIDEO_FEI_PAK
     #endif
     #if defined(MFX_ENABLE_MCTF)
-        #define MXF_ENABLE_MCTF_IN_AVC
+        //#define MXF_ENABLE_MCTF_IN_AVC
     #endif
 #endif
 


### PR DESCRIPTION
A segmentation faul was happening because the ouput pointer was not
being assigned when the previous frame was assigned as a P frame to
be denoised and the next frame happened to be and I frame which
also needed to be denoised. The second frame (I frame) was not able
to get the actual output pointer for itself and that caused the
segmentation fault.

The next part addresses the DEVICE_FAILED issue, for this system
checks what is the platform using the filter and based on that
compares if the input width and height are supported, if not
then MCTF disables itself.

Issue: https://github.com/Intel-Media-SDK/MediaSDK/issues/2412
Test:  Manual testing based on MDP-64761