### PR TITLE
[AV1d] Correct AV1 decode profile usage, VAProfileAV1Profile0 is used for 420 8 bit and 10 bit

### DIFF
--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -182,7 +182,7 @@ VAProfile g_AV1Profiles[] =
 };
 VAProfile g_AV110BitsPProfiles[] =
 {
-    VAProfileAV1Profile1
+    VAProfileAV1Profile0
 };
 #endif
 


### PR DESCRIPTION
VAProfileAV1Profile1 is removed on gen12.

Signed-off-by: Li Zefu <zefu.li@intel.com>