### PR TITLE
MCTF: Substitute in-place filtering with intercepting output

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -37,7 +37,7 @@
 #include "vm_time.h"
 #include "asc.h"
 
-#ifdef MXF_ENABLE_MCTF_IN_AVC
+#ifdef MFX_ENABLE_MCTF_IN_AVC
 #include "cmvm.h"
 #include "mctf_common.h"
 #endif
@@ -969,7 +969,7 @@ namespace MfxHwH264Encode
             , m_midRaw(MID_INVALID)
             , m_midRec(MID_INVALID)
             , m_midBit(mfxMemId(MID_INVALID))
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
             , m_midMCTF(mfxMemId(MID_INVALID))
             , m_idxMCTF(NO_INDEX)
             , m_cmMCTF(0)
@@ -1020,7 +1020,7 @@ namespace MfxHwH264Encode
             , m_hwType(MFX_HW_UNKNOWN)
             , m_TCBRCTargetFrameSize(0)
             , m_SceneChange(0)
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
             , m_doMCTFIntraFiltering(0)
 #endif
             , m_LowDelayPyramidLayer(0)
@@ -1041,7 +1041,7 @@ namespace MfxHwH264Encode
             Zero(m_ctrl);
             Zero(m_internalListCtrl);
             Zero(m_handleRaw);
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
             Zero(m_handleMCTF);
 #endif
             Zero(m_fid);
@@ -1217,7 +1217,7 @@ namespace MfxHwH264Encode
         mfxMemId        m_midRec;       // reconstruction
         Pair<mfxMemId>  m_midBit;       // output bitstream
         mfxHDLPair      m_handleRaw;    // native handle to raw surface (self-allocated or given by app)
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
         mfxMemId        m_midMCTF;
         mfxHDLPair      m_handleMCTF;   // Handle to MCTF denoised surface
         mfxU32          m_idxMCTF;
@@ -1296,7 +1296,7 @@ namespace MfxHwH264Encode
 #endif
         mfxU32 m_TCBRCTargetFrameSize;
         mfxU32 m_SceneChange;
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
         mfxU32 m_doMCTFIntraFiltering;
 #endif
         mfxU32 m_LowDelayPyramidLayer;
@@ -2865,7 +2865,7 @@ private:
         }
 
     protected:
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
         std::shared_ptr<CMC>
             amtMctf;
 
@@ -3043,7 +3043,7 @@ private:
 
         mfxU32 m_recNonRef[2];
 
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
         MfxFrameAllocResponse   m_mctf;
 #endif
         MfxFrameAllocResponse   m_scd;

--- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
+++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
@@ -969,6 +969,11 @@ namespace MfxHwH264Encode
             , m_midRaw(MID_INVALID)
             , m_midRec(MID_INVALID)
             , m_midBit(mfxMemId(MID_INVALID))
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+            , m_midMCTF(mfxMemId(MID_INVALID))
+            , m_idxMCTF(NO_INDEX)
+            , m_cmMCTF(0)
+#endif
             , m_cmRaw(0)
             , m_cmRawLa(0)
             , m_cmMb(0)
@@ -981,7 +986,6 @@ namespace MfxHwH264Encode
             , m_vmeData(0)
             , m_fwdRef(0)
             , m_bwdRef(0)
-            , m_cmRawForMCTF(0)
             , m_fieldPicFlag(0)
             , m_singleFieldMode(false)
             , m_fieldCounter(0)
@@ -1016,6 +1020,9 @@ namespace MfxHwH264Encode
             , m_hwType(MFX_HW_UNKNOWN)
             , m_TCBRCTargetFrameSize(0)
             , m_SceneChange(0)
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+            , m_doMCTFIntraFiltering(0)
+#endif
             , m_LowDelayPyramidLayer(0)
             , m_frameLtrOff(1)
             , m_frameLtrReassign(0)
@@ -1034,6 +1041,9 @@ namespace MfxHwH264Encode
             Zero(m_ctrl);
             Zero(m_internalListCtrl);
             Zero(m_handleRaw);
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+            Zero(m_handleMCTF);
+#endif
             Zero(m_fid);
             Zero(m_pwt);
             Zero(m_brcFrameParams);
@@ -1207,7 +1217,12 @@ namespace MfxHwH264Encode
         mfxMemId        m_midRec;       // reconstruction
         Pair<mfxMemId>  m_midBit;       // output bitstream
         mfxHDLPair      m_handleRaw;    // native handle to raw surface (self-allocated or given by app)
-
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+        mfxMemId        m_midMCTF;
+        mfxHDLPair      m_handleMCTF;   // Handle to MCTF denoised surface
+        mfxU32          m_idxMCTF;
+        CmSurface2D *   m_cmMCTF;
+#endif
         CmSurface2D *   m_cmRaw;        // CM surface made of m_handleRaw
         CmSurface2D *   m_cmRawLa;      // down-sized input surface for Lookahead
         CmBufferUP *    m_cmMb;         // macroblock data, VME kernel output
@@ -1220,8 +1235,6 @@ namespace MfxHwH264Encode
         VmeData *       m_vmeData;
         DdiTask const * m_fwdRef;
         DdiTask const * m_bwdRef;
-
-        CmSurface2D *   m_cmRawForMCTF; // CM surface made of m_handleRaw for MCTF
 
         mfxU8   m_fieldPicFlag;    // true for frames with interlaced content
         bool    m_singleFieldMode; // true for FEI single-field processing mode
@@ -1283,6 +1296,9 @@ namespace MfxHwH264Encode
 #endif
         mfxU32 m_TCBRCTargetFrameSize;
         mfxU32 m_SceneChange;
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+        mfxU32 m_doMCTFIntraFiltering;
+#endif
         mfxU32 m_LowDelayPyramidLayer;
         mfxU32 m_frameLtrOff;
         mfxU32 m_frameLtrReassign;
@@ -2854,13 +2870,10 @@ private:
             amtMctf;
 
         mfxStatus SubmitToMctf(
-            DdiTask * pTask,
-            bool      isSceneChange,
-            bool      doIntraFiltering
+            DdiTask * pTask
         );
         mfxStatus QueryFromMctf(
-            void *pParam,
-            bool bEoF
+            void *pParam
         );
 #endif
         ASC       amtScd;
@@ -3030,6 +3043,9 @@ private:
 
         mfxU32 m_recNonRef[2];
 
+#if defined(MXF_ENABLE_MCTF_IN_AVC)
+        MfxFrameAllocResponse   m_mctf;
+#endif
         MfxFrameAllocResponse   m_scd;
         MfxFrameAllocResponse   m_raw;
         MfxFrameAllocResponse   m_rawSkip;

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -1197,7 +1197,7 @@ mfxStatus ImplementationAvc::Init(mfxVideoParam * par)
 
     if (IsMctfSupported(m_video))
     {
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
         if (!m_cmDevice)
         {
             m_cmDevice.Reset(TryCreateCmDevicePtr(m_core));
@@ -2000,7 +2000,7 @@ void ImplementationAvc::OnEncodingQueried(DdiTaskIter task)
 
     if (m_useMbControlSurfs && task->m_isMBControl)
         ReleaseResource(m_mbControl, task->m_midMBControl);
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
     if (IsMctfSupported(m_video) && task->m_midMCTF)
     {
         ReleaseResource(m_mctf, task->m_midMCTF);
@@ -2082,7 +2082,7 @@ void ImplementationAvc::BrcPreEnc(
 
     m_brc.PreEnc(task.m_brcFrameParams, m_tmpVmeData);
 }
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
 mfxStatus ImplementationAvc::SubmitToMctf(DdiTask * pTask)
 {
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_API, "VideoVPPHW::SubmitToMctf");
@@ -2332,7 +2332,7 @@ mfxStatus ImplementationAvc::SCD_Get_FrameType(DdiTask & task)
     mfxExtCodingOption2 const & extOpt2 = GetExtBufferRef(m_video);
     mfxExtCodingOption3 const & extOpt3 = GetExtBufferRef(m_video);
     task.m_SceneChange = amtScd.Get_frame_shot_Decision();
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
     task.m_doMCTFIntraFiltering = amtScd.Get_intra_frame_denoise_recommendation();
 #endif
 
@@ -3063,7 +3063,7 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "Avc::STG_BIT_START_MCTF");
         if (IsMctfSupported(m_video))
         {
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
             DdiTask & task = m_MctfStarted.back();
             MFX_CHECK_STS(SubmitToMctf(&task));
 #endif
@@ -3076,7 +3076,7 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
         MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_HOTSPOTS, "Avc::STG_BIT_WAIT_MCTF");
         if (IsMctfSupported(m_video))
         {
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
             DdiTask & task = m_MctfFinished.front();
             MFX_CHECK_STS(QueryFromMctf(&task));
 #endif
@@ -3514,7 +3514,7 @@ mfxStatus ImplementationAvc::AsyncRoutine(mfxBitstream * bs)
                 mfxStatus sts = MFX_ERR_NONE;
 
                 //printf("Execute: %d, type %d, qp %d\n", task->m_frameOrder, task->m_type[0], task->m_cqpValue[0]);
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
                 if(task->m_handleMCTF.first)//Intercept encoder so MCTF denoised frame can be fed at the right moment.
                     sts = m_ddi->Execute(task->m_handleMCTF, *task, fieldId, m_sei);
                 else

--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -2097,9 +2097,12 @@ mfxStatus ImplementationAvc::SubmitToMctf(DdiTask * pTask)
     {
         pTask->m_idxMCTF = FindFreeResourceIndex(m_mctf);
         pTask->m_midMCTF = AcquireResource(m_mctf, pTask->m_idxMCTF);
-        if (!pTask->m_midMCTF)
-            return MFX_TASK_BUSY;
-        MFX_SAFE_CALL(m_core->GetFrameHDL(pTask->m_midMCTF, &pTask->m_handleMCTF.first));
+        if (pTask->m_midMCTF)
+        {
+            MFX_SAFE_CALL(m_core->GetFrameHDL(pTask->m_midMCTF, &pTask->m_handleMCTF.first));
+        }
+        else
+            isAnchorFrame = false; //No resource available to generate filtered output, let it pass.
     }
     if (IsCmNeededForSCD(m_video))
     {

--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -1816,6 +1816,8 @@ mfxI32 CMC::MCTF_RUN_DOUBLE_TASK(
     }
     res = task->AddKernel(meKernel);
     MCTF_CHECK_CM_ERR(res, res);
+    res = task->AddSync();
+    MCTF_CHECK_CM_ERR(res, res);
     res = task->AddKernel(mcKernel);
     MCTF_CHECK_CM_ERR(res, res);
     res = MCTF_Enqueue(task, e);
@@ -2118,6 +2120,8 @@ mfxI32 CMC::MCTF_RUN_ME_MC_HE(
     }
 
     res = task->AddKernel(kernelMeB2);
+    MCTF_CHECK_CM_ERR(res, res);
+    res = task->AddSync();
     MCTF_CHECK_CM_ERR(res, res);
     res = task->AddKernel(kernelMc2r);
     MCTF_CHECK_CM_ERR(res, res);

--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -359,13 +359,19 @@ mfxStatus CMC::MCTF_GET_FRAME(
     return sts;
 }
 
+bool CMC::MCTF_CHECK_FILTER_USE()
+{
+    if (QfIn.front().filterStrength == 0)
+        return false;
+    return true;
+}
+
 mfxStatus CMC::MCTF_RELEASE_FRAME(
+    bool isCmUsed
 )
 {
     if (MCTF_ReadyToOutput())
     {
-        MFX_CHECK(mco, MFX_ERR_UNDEFINED_BEHAVIOR);
-        mco = nullptr;
         MctfState = AMCTF_NOT_READY;
         if (mco2)
         {
@@ -373,6 +379,17 @@ mfxStatus CMC::MCTF_RELEASE_FRAME(
             idxMco = idxMco2;
             mco2 = nullptr;
             idxMco2 = nullptr;
+        }
+    }
+    //Buffer has rotated enough at this point that last position is old and needs to eb recycled.
+    if (isCmUsed)
+    {
+        if (QfIn.back().frameData)
+        {
+            device->DestroySurface(QfIn.back().frameData);//This Surface is created by MCTF and needs to be destroyed after denoised frame has been used.
+            QfIn.back().frameData = nullptr;
+            QfIn.back().fIdx      = nullptr;
+            QfIn.back().mfxFrame  = nullptr;
         }
     }
     return MFX_ERR_NONE;
@@ -434,12 +451,10 @@ mfxStatus CMC::MCTF_InitQueue(
         return MFX_ERR_INVALID_VIDEO_PARAM;
     };
 
-    for (mfxU32 i = 0; i < buffer_size; i++)
+    for (mfxU8 i = 0; i < buffer_size; i++)
     {
         scene_numbers[i] = 0;
         QfIn.push_back(gpuFrameData());
-        QfIn[i].fIdx = NULL;
-        QfIn[i].idxMag = NULL;//For MRE use
     }
 
     return MFX_ERR_NONE;
@@ -603,16 +618,15 @@ mfxStatus CMC::MCTF_SetMemory(
     bool isCmUsed
 )
 {
-        res = IM_SURF_SET_Int();
-        MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
-        // mco & idxmco will be extracted from an output surface
-        mco = nullptr;
+        // mco & idxmco will be extracted from input/output surface
         if (!isCmUsed)
         {
-            res = IM_SURF_SET(&mco, &idxMco);
+            res = IM_SURF_SET_Int();
             MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
         }
-        mco2 = nullptr;
+        mco     = nullptr;
+        idxMco  = nullptr;
+        mco2    = nullptr;
         idxMco2 = nullptr;
 
         //Setup for 2 references
@@ -663,7 +677,7 @@ mfxStatus CMC::MCTF_INIT(
     exeTimeT        = 0;
     m_externalSCD   = externalSCD;
     m_adaptControl  = useFilterAdaptControl;
-    m_doFilterFrame = true;
+    m_doFilterFrame = false;
 
     //--filter configuration parameters
     m_AutoMode = MCTF_MODE::MCTF_NOT_INITIALIZED_MODE;
@@ -1721,9 +1735,8 @@ mfxI32 CMC::MCTF_RUN_TASK_NA(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(widthTs, heightTs, threadSpace);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpace->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = kernel->AssociateThreadSpace(threadSpace);
+    MCTF_CHECK_CM_ERR(res, res);
 
     if (reset)
     {
@@ -1751,9 +1764,8 @@ mfxI32 CMC::MCTF_RUN_TASK(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidth, tsHeight, threadSpace);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpace->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = kernel->AssociateThreadSpace(threadSpace);
+    MCTF_CHECK_CM_ERR(res, res);
 
     if (reset)
     {
@@ -1782,17 +1794,15 @@ mfxI32 CMC::MCTF_RUN_DOUBLE_TASK(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidth, tsHeight, threadSpace2);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpace2->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = meKernel->AssociateThreadSpace(threadSpace2);
+    MCTF_CHECK_CM_ERR(res, res);
 
     res = mcKernel->SetThreadCount(tsWidthMC * tsHeightMC);
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidthMC, tsHeightMC, threadSpaceMC);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpaceMC->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = mcKernel->AssociateThreadSpace(threadSpaceMC);
+    MCTF_CHECK_CM_ERR(res, res);
 
     if (reset)
     {
@@ -1822,8 +1832,6 @@ mfxI32 CMC::MCTF_RUN_MCTASK(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidthMC, tsHeightMC, threadSpaceMC2);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpaceMC2->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
 
     if (reset)
     {
@@ -1851,8 +1859,6 @@ mfxI32 CMC::MCTF_RUN_TASK(
     res = kernel->SetThreadCount(tsWidth * tsHeight);
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidth, tsHeight, tS);
-    MCTF_CHECK_CM_ERR(res, res);
-    res = tS->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY);
     MCTF_CHECK_CM_ERR(res, res);
     if (reset)
     {
@@ -2042,8 +2048,6 @@ mfxI32 CMC::MCTF_RUN_ME_MC_HE(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidth, tsHeight, threadSpace);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpace->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = kernelMeB->AssociateThreadSpace(threadSpace);
     MCTF_CHECK_CM_ERR(res, res);
 
@@ -2051,16 +2055,12 @@ mfxI32 CMC::MCTF_RUN_ME_MC_HE(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidth, tsHeight, threadSpace2);
     MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpace2->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
-    MCTF_CHECK_CM_ERR(res, res);
     res = kernelMeB2->AssociateThreadSpace(threadSpace2);
     MCTF_CHECK_CM_ERR(res, res);
 
     res = kernelMc2r->SetThreadCount(tsWidthMC * tsHeightMC);
     MCTF_CHECK_CM_ERR(res, res);
     res = device->CreateThreadSpace(tsWidthMC, tsHeightMC, threadSpaceMC);
-    MCTF_CHECK_CM_ERR(res, res);
-    res = threadSpaceMC->SelectThreadDependencyPattern(CM_HORIZONTAL_DEPENDENCY);
     MCTF_CHECK_CM_ERR(res, res);
     res = kernelMc2r->AssociateThreadSpace(threadSpaceMC);
     MCTF_CHECK_CM_ERR(res, res);
@@ -2090,7 +2090,7 @@ mfxI32 CMC::MCTF_RUN_ME_MC_HE(
         (this->*(pMCTF_NOA_func))(m_adaptControl);
         if (QfIn[1].filterStrength == 0)
         {
-            MctfState = 1;
+            MctfState = AMCTF_READY;
             return CM_SUCCESS;
         }
 
@@ -2147,6 +2147,7 @@ mfxI32 CMC::MCTF_RUN_ME_MC_HE(
     MCTF_CHECK_CM_ERR(res, res);
     res = device->DestroyTask(task);
     MCTF_CHECK_CM_ERR(res, res);
+    MctfState = AMCTF_READY;
     task = 0;
     return res;
 }
@@ -2329,7 +2330,7 @@ mfxU16 CalcNoiseStrength(
 
     s  = c3 * pow(STC, 3.0) + c2 * pow(STC, 2.0) + c1 * STC + c0;
     s2 = d3 * pow(ISTC, 3.0) + d2 * pow(ISTC, 2.0) + d1 * ISTC + d0;
-    s = NMIN(s, s2) + 4;
+    s = NMIN(s, s2) + 5;
     s  = NMAX(0.0, NMIN(20.0, s));
     return (mfxU16)(s + 0.5);
 }
@@ -3163,21 +3164,10 @@ mfxU32 CMC::IM_SURF_PUT(
     return res;
 }
 
-mfxU32 CMC::IM_SURF_PUT(
-    CmSurface2D *p_DstSurface,
-    CmSurface2D *p_SrcSurface)
-{
-    CM_STATUS
-        status = CM_STATUS_FLUSHED;
-    res = queue->EnqueueCopyGPUToGPU(p_DstSurface, p_SrcSurface, NULL, copyEv);
-    MCTF_CHECK_CM_ERR(res, res);
-    copyEv->GetStatus(status);
-    while (status != CM_STATUS_FINISHED)
-        copyEv->GetStatus(status);
-    return res;
-}
-
-void CMC::IntBufferUpdate(bool isSceneChange)
+void CMC::IntBufferUpdate(
+    bool isSceneChange,
+    bool isIntraFrame,
+    bool doIntraFiltering)
 {
     size_t
         buffer_size = QfIn.size() - 1;
@@ -3186,98 +3176,103 @@ void CMC::IntBufferUpdate(bool isSceneChange)
         exit(-1);
     }
     if (bufferCount == 0)
-        QfIn[bufferCount].frame_number = 0;
+        QfIn.back().frame_number = 0;
     else
-        QfIn[bufferCount].frame_number = QfIn[bufferCount - 1].frame_number + 1;
+        QfIn.back().frame_number = (QfIn.end() - 2)->frame_number + 1;
 
-    if (isSceneChange || bufferCount == 0)
+    if (!firstFrame)
+        sceneNum += isSceneChange;
+
+    QfIn.back().isSceneChange = (firstFrame || isSceneChange);
+    QfIn.back().isIntra = isIntraFrame;
+
+    if (isSceneChange || isIntraFrame || bufferCount == 0)
         countFrames = 0;
     else
         countFrames++;
-    QfIn[bufferCount].frame_relative_position = countFrames;
-    QfIn[bufferCount].frame_added = false;
-    if(isSceneChange)
+    QfIn.back().frame_relative_position = countFrames;
+    QfIn.back().frame_added             = false;
+    QfIn.back().scene_idx               = sceneNum;
+    if((QfIn.back().isSceneChange || QfIn.back().isIntra) && doIntraFiltering)
         m_doFilterFrame = true;
 }
 
-void CMC::BufferFilterAssignment(mfxU16 * filterStrength, bool doIntraFiltering)
+void CMC::BufferFilterAssignment(
+    mfxU16 * filterStrength,
+    bool     doIntraFiltering,
+    bool     isAnchorFrame,
+    bool     isSceneChange)
 {
     if (!filterStrength)
     {
-        if (countFrames == 0)
+        if (isAnchorFrame && isSceneChange)
         {
-            QfIn[bufferCount].filterStrength = doIntraFiltering ? MCTFSTRENGTH : MCTFNOFILTER;
+            QfIn.back().filterStrength = doIntraFiltering ? MCTFSTRENGTH : MCTFNOFILTER;
 #ifdef MFX_MCTF_DEBUG_PRINT
             ASC_PRINTF("\nI frame denoising is: %i, strength set at: %i\n", doIntraFiltering, QfIn[bufferCount].filterStrength));
 #endif
             gopBasedFilterStrength = MCTFADAPTIVE;
         }
-        else if (!(countFrames % MCTFCADENCE))
-            QfIn[bufferCount].filterStrength = gopBasedFilterStrength;
+        else if (isAnchorFrame)
+            QfIn.back().filterStrength = gopBasedFilterStrength;
         else
-            QfIn[bufferCount].filterStrength = MCTFNOFILTER;
+            QfIn.back().filterStrength = MCTFNOFILTER;
     }
     else
-        QfIn[bufferCount].filterStrength = *filterStrength;
-}
-
-bool CMC::MCTF_Check_Use()
-{
-    bool
-        frameToBeUsed = false;
-
-    frameToBeUsed = ((countFrames == 0 ||                     //Add frame when is I frame or first frame
-                     ((!(countFrames % MCTFCADENCE) ||         //Add frame in cadence 
-                       !((countFrames + 1) % MCTFCADENCE) ||   //Add previous frame to candence frame
-                       !((countFrames - 1) % MCTFCADENCE)) &&     //Add next frame to cadence frame
-                     countFrames > 1)) &&
-                     m_doFilterFrame);
-
-    return frameToBeUsed;
+        QfIn.back().filterStrength = *filterStrength;
 }
 
 mfxStatus CMC::MCTF_PUT_FRAME(
-    void   *frameData,
-    bool    isSceneChange,
-    bool    isCmSurface,
-    mfxU16 *filterStrength,
-    bool    doIntraFiltering)
+    void         * frameInData,
+    mfxHDLPair     frameOutHandle,
+    CmSurface2D ** frameOutData,
+    bool           isCmSurface,
+    mfxU16       * filterStrength,
+    bool           needsOutput,
+    bool           doIntraFiltering
+)
 {
-    sceneNum += isSceneChange;
-
-    if (MCTF_Check_Use())
+    if (!frameInData)
+        return MFX_ERR_UNDEFINED_BEHAVIOR;
+    if (isCmSurface)
     {
-        if (!frameData)
-            return MFX_ERR_UNDEFINED_BEHAVIOR;
-        if (isCmSurface)
+        mfxFrameSurface1 *
+            mfxFrame = (mfxFrameSurface1 *)frameInData;
+        mfxHDLPair
+            handle;
+        // if a surface is opaque, need to extract normal surface
+        mfxFrameSurface1
+            * pSurf = m_pCore->GetNativeSurface(mfxFrame, false);
+        QfIn.back().mfxFrame = pSurf ? pSurf : mfxFrame;
+        if (pSurf)
         {
-            res = IM_SURF_PUT(QfIn[bufferCount].frameData, (CmSurface2D*)frameData);
-            if ((countFrames == 0 || !(countFrames % MCTFCADENCE)))
-            {
-                if (mco && isSceneChange)
-                {
-                    mco2 = (CmSurface2D*)frameData;
-                    mco2->GetIndex(idxMco2);
-                }
-                else
-                {
-                    mco = (CmSurface2D*)frameData;
-                    mco->GetIndex(idxMco);
-                }
-            }
+            MFX_SAFE_CALL(m_pCore->GetFrameHDL(QfIn.back().mfxFrame->Data.MemId, reinterpret_cast<mfxHDL*>(&handle)));
         }
         else
-            res = IM_SURF_PUT(QfIn[bufferCount].frameData, (mfxU8*)frameData);
+        {
+            MFX_SAFE_CALL(m_pCore->GetExternalFrameHDL(QfIn.back().mfxFrame->Data.MemId, reinterpret_cast<mfxHDL*>(&handle)));
+        }
+        MFX_SAFE_CALL(IM_SURF_SET(reinterpret_cast<AbstractSurfaceHandle>(handle.first), &QfIn.back().frameData, &QfIn.back().fIdx));
+    }
+    else
+    {
+        res = IM_SURF_PUT(QfIn.back().frameData, (mfxU8*)frameInData);
         MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
-        QfIn[bufferCount].frame_added = true;
+    }
+    QfIn.back().frame_added = true;
+    if (needsOutput)
+    {
+        SurfaceIndex
+            *fIdx = nullptr;
+        MFX_SAFE_CALL(IM_SURF_SET(reinterpret_cast<AbstractSurfaceHandle>(frameOutHandle.first), frameOutData, &fIdx));
+        QfIn.back().fOut    = *frameOutData;
+        QfIn.back().fIdxOut = fIdx;
     }
 
-    QfIn[bufferCount].scene_idx = sceneNum;
-
     if (m_doFilterFrame)
-        BufferFilterAssignment(filterStrength, doIntraFiltering);
+        BufferFilterAssignment(filterStrength, doIntraFiltering, needsOutput, QfIn.back().isSceneChange);
     else
-        QfIn[bufferCount].filterStrength = MCTFNOFILTER;
+        QfIn.back().filterStrength = MCTFNOFILTER;
     return MFX_ERR_NONE;
 }
 
@@ -3326,40 +3321,40 @@ mfxStatus CMC::MCTF_DO_FILTERING_IN_AVC()
 {
     // do filtering based on temporal mode & how many frames are
     // already in the queue:
+    res = MFX_ERR_NONE;
     switch (number_of_References)
     {
     case 2://else if (number_of_References == 2)
     {
         if (bufferCount < 2) /*One frame delay*/
         {
+            firstFrame = 0;
+            RotateBuffer();
             MctfState = AMCTF_NOT_READY;
             return MFX_ERR_NONE;
         }
 
-        switch (firstFrame)
+        MCTF_UpdateANDApplyRTParams(1);
+        if (QfIn[1].fOut)
         {
-            case 0:
+            mco    = QfIn[1].fOut;
+            idxMco = QfIn[1].fIdxOut;
+            if (QfIn[1].isSceneChange)
             {
-                MCTF_UpdateANDApplyRTParams(1);
-                if (QfIn[1].scene_idx != QfIn[0].scene_idx)
-                {
+                if(QfIn[1].filterStrength)
                     res = MCTF_RUN_AMCTF(1);
-                    RotateBuffer();
-                }
-                else
-                    res = (this->*(pMCTF_func))(false);
-                CurrentIdx2Out = DefaultIdx2Out;
-                break;
+                RotateBuffer();
             }
-            default:
-            {
-                MCTF_UpdateANDApplyRTParams(0);
-                res = MCTF_RUN_AMCTF(0);
-                firstFrame = 0;
-                CurrentIdx2Out = 0;
-                break;
-            }
+            else
+                res = (this->*(pMCTF_func))(false);
+            CurrentIdx2Out = DefaultIdx2Out;
+            MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
+            QfIn.front().fOut    = mco    = nullptr;
+            QfIn.front().fIdxOut = idxMco = nullptr;
         }
+        else
+            RotateBuffer();
+        break;
     };
     break;
     default://    else
@@ -3367,6 +3362,11 @@ mfxStatus CMC::MCTF_DO_FILTERING_IN_AVC()
     }
     MCTF_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
     return MFX_ERR_NONE;
+}
+
+mfxU16 CMC::MCTF_QUERY_FILTER_STRENGTH()
+{
+    return QfIn[1].filterStrength;
 }
 
 mfxStatus CMC::MCTF_DO_FILTERING()

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1414,7 +1414,7 @@ bool MfxHwH264Encode::IsMctfSupported(
     (void)video;
     bool
         isSupported = false;
-#if defined(MXF_ENABLE_MCTF_IN_AVC)
+#if defined(MFX_ENABLE_MCTF_IN_AVC)
     mfxExtCodingOption2 const & extOpt2 = GetExtBufferRef(video);
     isSupported = (IsOn(extOpt2.ExtBRC) &&
         IsExtBrcSceneChangeSupported(video) &&

--- a/_studio/shared/asc/src/asc.cpp
+++ b/_studio/shared/asc/src/asc.cpp
@@ -351,8 +351,6 @@ mfxStatus ASC::CreateCmKernels() {
 
     res = m_device->CreateThreadSpace(m_threadsWidth, m_threadsHeight, m_threadSpace);
     SCD_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
-    res = m_threadSpace->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY);
-    SCD_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
     res = m_device->CreateKernel(m_program, CM_KERNEL_FUNCTION(SubSamplePoint_p), m_kernel_p);
     SCD_CHECK_CM_ERR(res, MFX_ERR_DEVICE_FAILED);
     res = m_kernel_p->SetThreadCount(m_threadsWidth * m_threadsHeight);
@@ -531,7 +529,6 @@ mfxStatus ASC::IO_Setup() {
         m_threadsWidth = (UINT)ceil((double)m_gpuwidth / SCD_BLOCK_PIXEL_WIDTH);
         m_threadsHeight = (UINT)ceil((double)m_gpuheight / SCD_BLOCK_HEIGHT);
         SCD_CHECK_CM_ERR(m_device->CreateThreadSpace(m_threadsWidth, m_threadsHeight, m_threadSpaceCp), MFX_ERR_DEVICE_FAILED);
-        SCD_CHECK_CM_ERR(m_threadSpaceCp->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY), MFX_ERR_DEVICE_FAILED);
         SCD_CHECK_CM_ERR(m_kernel_cp->SetThreadCount(m_threadsWidth * m_threadsHeight), MFX_ERR_DEVICE_FAILED);
 #ifndef CMRT_EMU
         SCD_CHECK_CM_ERR(m_kernel_cp->AssociateThreadSpace(m_threadSpaceCp), MFX_ERR_DEVICE_FAILED);

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -68,7 +68,7 @@
         #define MFX_ENABLE_H264_VIDEO_FEI_PAK
     #endif
     #if defined(MFX_ENABLE_MCTF)
-        //#define MFX_ENABLE_MCTF_IN_AVC
+        #define MFX_ENABLE_MCTF_IN_AVC
     #endif
 #endif
 

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -68,7 +68,7 @@
         #define MFX_ENABLE_H264_VIDEO_FEI_PAK
     #endif
     #if defined(MFX_ENABLE_MCTF)
-        //#define MXF_ENABLE_MCTF_IN_AVC
+        //#define MFX_ENABLE_MCTF_IN_AVC
     #endif
 #endif
 


### PR DESCRIPTION
In-place denoising is not appropriate as input frames
still used by decoder for frame decoding/generation,
changed current approach with new encoder internal 2
frame buffer for denoising frame generation, then that
frame is used to intercept the input frame at the
encoder execute call

Issue: MDP-64761
Test:  Manual testing