### PR TITLE
[HEVCe] Fix DPB handling issue when RollingI is enabled

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -2574,7 +2574,8 @@ void Legacy::InitDPB(
         for (mfxU8 i = 0; !isDpbEnd(prevTask.DPB.After, i); i++)
         {
             const DpbFrame& ref = prevTask.DPB.After[i]; // initial POC = -1
-            if (ref.POC > task.DPB.Active[0].POC) // disable multiref within IntraRefCycle and next frame
+            if (ref.POC > task.DPB.Active[0].POC && ref.TemporalID == 0) // disable multiref within IntraRefCycle and next frame
+                                                                         // and update DPB.Active only if temporal layer id = 0 for IntraRef cases
                 task.DPB.Active[0] = ref;
         }
     }


### PR DESCRIPTION
Fix issue that pushing frames with temporal_layer_id > 0 to DPB when
Rolling I is enabled. Because Rolling I is only expected on the frames
which temporal_layer_id is 0, and its reference frame should be layer 0
as well.