### PR TITLE
fix compilation errors with GCC-11

### DIFF
--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
+#include <limits>
 #include "cmrt_cross_platform.h"
 
 using std::min;


### PR DESCRIPTION
Prior to gcc-11 various C++ headers in gcc included `<limits>` even though
it was not strictly necessary; this results in the compiler having to
parse unnecessary code and thus slows down compilation for everyone. 
Those unnecessary #includes of `<limits>` have been removed and
applications which need the `<limits>` header file need to explicitly
include it.

Without the patch, when compiling with gcc-11 you will get this error:

```
/builddir/build/BUILD/MediaSDK-intel-mediasdk-20.3.0/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp:
In function 'mfxU16 CalcNoiseStrength(double, double)':
/builddir/build/BUILD/MediaSDK-intel-mediasdk-20.3.0/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp:2302:37:
error: 'numeric_limits' is not a member of 'std'
 2302 |     if (std::fabs(NSC) <= 10 *
std::numeric_limits<double>::epsilon()) return 0;
      |                                     ^~~~~~~~~~~~~~
/builddir/build/BUILD/MediaSDK-intel-mediasdk-20.3.0/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp:2302:52:
error: expected primary-expression before 'double'
 2302 |     if (std::fabs(NSC) <= 10 *
std::numeric_limits<double>::epsilon()) return 0;
      |                                                    ^~~~~~
/builddir/build/BUILD/MediaSDK-intel-mediasdk-20.3.0/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp:2302:52:
error: expected ')' before 'double'
 2302 |     if (std::fabs(NSC) <= 10 *
std::numeric_limits<double>::epsilon()) return 0;
      |        ~                                           ^~~~~~
```