### PR TITLE
[avce] Fix external BRC for AVC on RKL

### DIFF
--- a/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
+++ b/_studio/mfx_lib/cmrt_cross_platform/include/cmrt_cross_platform.h
@@ -725,6 +725,7 @@ typedef enum _GPU_PLATFORM {
     PLATFORM_INTEL_TGLLP = 15,//TigerLakeLP
     PLATFORM_INTEL_GLK = 16,  //GeminiLake
     PLATFORM_INTEL_CFL = 17,  //CofeeLake
+    PLATFORM_INTEL_RKL = 19,  //RocketLake
     PLATFORM_INTEL_DG1 = 20,  //DG1
 } GPU_PLATFORM;
 

--- a/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
+++ b/_studio/mfx_lib/mctf_package/mctf/src/mctf_common.cpp
@@ -918,6 +918,7 @@ mfxStatus CMC::MCTF_SET_ENV(
         res = device->LoadProgram((void *)genx_me_gen11lp, sizeof(genx_me_gen11lp), programMe, "nojitter");
         break;
     case PLATFORM_INTEL_TGLLP:
+    case PLATFORM_INTEL_RKL:
     case PLATFORM_INTEL_DG1:
         res = device->LoadProgram((void *)genx_me_gen12lp, sizeof(genx_me_gen12lp), programMe, "nojitter");
         break;
@@ -977,6 +978,7 @@ mfxStatus CMC::MCTF_SET_ENV(
         res = device->LoadProgram((void *)genx_mc_gen11lp, sizeof(genx_mc_gen11lp), programMc, "nojitter");
         break;
     case PLATFORM_INTEL_TGLLP:
+    case PLATFORM_INTEL_RKL:
     case PLATFORM_INTEL_DG1:
         res = device->LoadProgram((void *)genx_mc_gen12lp, sizeof(genx_mc_gen12lp), programMc, "nojitter");
         break;
@@ -1007,6 +1009,7 @@ mfxStatus CMC::MCTF_SET_ENV(
         res = device->LoadProgram((void *)genx_sd_gen11lp, sizeof(genx_sd_gen11lp), programDe, "nojitter");
         break;
     case PLATFORM_INTEL_TGLLP:
+    case PLATFORM_INTEL_RKL:
     case PLATFORM_INTEL_DG1:
         res = device->LoadProgram((void *)genx_sd_gen12lp, sizeof(genx_sd_gen12lp), programDe, "nojitter");
         break;

--- a/_studio/shared/asc/src/asc.cpp
+++ b/_studio/shared/asc/src/asc.cpp
@@ -307,6 +307,7 @@ mfxStatus ASC::InitGPUsurf(CmDevice* pCmDevice) {
         res = m_device->LoadProgram((void *)genx_scd_gen11lp, sizeof(genx_scd_gen11lp), m_program, "nojitter");
         break;
     case PLATFORM_INTEL_TGLLP:
+    case PLATFORM_INTEL_RKL:
     case PLATFORM_INTEL_DG1:
         res = m_device->LoadProgram((void *)genx_scd_gen12lp, sizeof(genx_scd_gen12lp), m_program, "nojitter");
         break;


### PR DESCRIPTION
External BRC for AVC depends on some CM programs which are not loaded on
RKL, so the encoder can't be setup for AVC external BRC on RKL

Example:
ffmpeg -hwaccel qsv -c:v h264_qsv -i input.h264 -c:v h264_qsv -extbrc 1
output.h264

[h264_qsv @ 0x5643f4c60010] Error initializing the encoder: device
failed (-17)
Error initializing output stream 0:0 -- Error while opening encoder for
output stream #0:0 - maybe incorrect parameters such as bit_rate, rate,
width or height
Conversion failed!