### PR TITLE
sample_vpp: fix reset with colorfillParam

### DIFF
--- a/samples/sample_vpp/src/sample_vpp_parser.cpp
+++ b/samples/sample_vpp/src/sample_vpp_parser.cpp
@@ -679,6 +679,7 @@ mfxStatus vppParseResetPar(msdk_char* strInput[], mfxU8 nArgNum, mfxU8& curArg, 
     pParams->videoSignalInfoParam.push_back(*pDefaultFiltersParam->pVideoSignalInfo    );
     pParams->mirroringParam.push_back(      *pDefaultFiltersParam->pMirroringParam     );
     pParams->rotate.push_back(               0                                         );
+    pParams->colorfillParam.push_back(      *pDefaultFiltersParam->pColorfillParam     );
 
     mfxU32 readData;
     mfxU32 ioStatus;


### PR DESCRIPTION
When we use pipeline with reset, for example:
```
sample_vpp.exe -i hevc.yuv -sw 1920 -sh 1080 -dw 720 -dh 480 -scc nv12 -dcc nv12 -o 720x480_vpp.yuv -d3d \ 
-iopattern d3d_to_d3d  -reset_start 50 -dw 720 -dh 480 -denoise 32 -reset_end
```
We access to a non-existed vector element pParams->colorfillParam[paramID]
https://github.com/Intel-Media-SDK/MediaSDK/blob/3a7ed88055b8d1bbe7812c29a51758a9b319f7c8/samples/sample_vpp/src/sample_vpp_config.cpp#L117