### PR TITLE
Revert "[AV1d] Correct AV1 decode profile usage, VAProfileAV1Profile0 is used for 420 8 bit and 10 bit"

### DIFF
--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -182,7 +182,7 @@ VAProfile g_AV1Profiles[] =
 };
 VAProfile g_AV110BitsPProfiles[] =
 {
-    VAProfileAV1Profile0
+    VAProfileAV1Profile1
 };
 #endif
 


### PR DESCRIPTION
https://github.com/intel/media-driver/pull/1062  wasn't merged timely so reverting Intel-Media-SDK/MediaSDK#2423