### PR TITLE
[AV1D] Remove VAProfileAV1Profile1 on gen12,  VAProfileAV1Profile0 is…

### DIFF
--- a/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
+++ b/_studio/shared/umc/io/umc_va/src/umc_va_linux.cpp
@@ -182,7 +182,7 @@ VAProfile g_AV1Profiles[] =
 };
 VAProfile g_AV110BitsPProfiles[] =
 {
-    VAProfileAV1Profile1
+    VAProfileAV1Profile0
 };
 #endif
 


### PR DESCRIPTION
… used for 420 8 bit and 10 bit

Signed-off-by: Li Zefu <zefu.li@intel.com>