### PR TITLE
Revert "[HEVCe] Support B frames for all target usage with LowPower on"

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
@@ -80,7 +80,7 @@ void Caps::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
     {
         auto& caps = Glob::EncodeCaps::Get(strg);
 
-        caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && par.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC;
+        caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && (par.mfx.TargetUsage == 6 || par.mfx.TargetUsage == 7 || par.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC);
         caps.msdk.bSingleSliceMultiTile = false;
 
         caps.YUV422ReconSupport &= (!caps.Color420Only && !IsOn(par.mfx.LowPower));


### PR DESCRIPTION
Reverts Intel-Media-SDK/MediaSDK#2440
MDP-65024 