### PR TITLE
[hevce] Expand zero ROI to minimum supported size

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_roi.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_roi.cpp
@@ -50,6 +50,13 @@ static mfxStatus CheckAndFixRect(
     changed += AlignUp(rect.Right, blockSize);
     changed += AlignUp(rect.Bottom, blockSize);
 
+    if(rect.Left == 0 && rect.Top == 0 && rect.Right == 0 && rect.Bottom == 0)
+    {
+        rect.Right  = blockSize;//expand zero rectangle to min supported size
+        rect.Bottom = blockSize;
+        changed++;
+    }
+
     MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
     return MFX_ERR_NONE;
 }


### PR DESCRIPTION
Fixes [#2013](https://github.com/Intel-Media-SDK/MediaSDK/issues/2013).

Change (0 0 0 0) ROIs instead of removing them.