### PR TITLE
[core] Use typed arguments instead of void* in gpu_copy

### DIFF
--- a/_studio/shared/include/cm_mem_copy.h
+++ b/_studio/shared/include/cm_mem_copy.h
@@ -58,6 +58,11 @@ typedef mfxI32 cmStatus;
 #define CM_ALIGNED(PTR) (!((mfxU64(PTR))&0xf))
 #define CM_ALIGNED64(PTR) (!((mfxU64(PTR))&0x3f))
 
+static inline bool operator < (const mfxHDLPair & l, const mfxHDLPair & r)
+{
+    return (l.first == r.first) ? (l.second < r.second) : (l.first < r.first);
+};
+
 class CmDevice;
 class CmBuffer;
 class CmBufferUP;
@@ -146,21 +151,21 @@ public:
     mfxStatus CopySysToVideo(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
     mfxStatus CopyVideoToSys(mfxFrameSurface1 *pDst, mfxFrameSurface1 *pSrc);
 
-    mfxStatus CopyVideoToSystemMemoryAPI(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, void *pSrc, mfxU32 srcPitch, mfxSize roi);
-    mfxStatus CopyVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, void *pSrc, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
+    mfxStatus CopyVideoToSystemMemoryAPI(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, mfxMemId src, mfxU32 srcPitch, mfxSize roi);
+    mfxStatus CopyVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, mfxMemId src, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
 
-    mfxStatus CopySystemToVideoMemoryAPI(void *pDst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi);
-    mfxStatus CopySystemToVideoMemory(void *pDst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
-    mfxStatus CopyVideoToVideoMemoryAPI(void *pDst, void *pSrc, mfxSize roi);
+    mfxStatus CopySystemToVideoMemoryAPI(mfxMemId dst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi);
+    mfxStatus CopySystemToVideoMemory(mfxMemId dst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
+    mfxStatus CopyVideoToVideoMemoryAPI(mfxMemId dst, mfxMemId src, mfxSize roi);
 
-    mfxStatus CopySwapVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, void *pSrc, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
-    mfxStatus CopySwapSystemToVideoMemory(void *pDst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
-    mfxStatus CopyShiftSystemToVideoMemory(void *pDst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 bitshift, mfxU32 format);
-    mfxStatus CopyShiftVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, void *pSrc, mfxU32 srcPitch, mfxSize roi, mfxU32 bitshift, mfxU32 format);
-    mfxStatus CopyMirrorVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, void *pSrc, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
-    mfxStatus CopyMirrorSystemToVideoMemory(void *pDst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
-    mfxStatus CopySwapVideoToVideoMemory(void *pDst, void *pSrc, mfxSize roi, mfxU32 format);
-    mfxStatus CopyMirrorVideoToVideoMemory(void *pDst, void *pSrc, mfxSize roi, mfxU32 format);
+    mfxStatus CopySwapVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, mfxMemId src, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
+    mfxStatus CopySwapSystemToVideoMemory(mfxMemId dst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
+    mfxStatus CopyShiftSystemToVideoMemory(mfxMemId dst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 bitshift, mfxU32 format);
+    mfxStatus CopyShiftVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, mfxMemId src, mfxU32 srcPitch, mfxSize roi, mfxU32 bitshift, mfxU32 format);
+    mfxStatus CopyMirrorVideoToSystemMemory(mfxU8 *pDst, mfxU32 dstPitch, mfxU32 dstUVOffset, mfxMemId src, mfxU32 srcPitch, mfxSize roi, mfxU32 format);
+    mfxStatus CopyMirrorSystemToVideoMemory(mfxMemId dst, mfxU32 dstPitch, mfxU8 *pSrc, mfxU32 srcPitch, mfxU32 srcUVOffset, mfxSize roi, mfxU32 format);
+    mfxStatus CopySwapVideoToVideoMemory(mfxMemId dst, mfxMemId src, mfxSize roi, mfxU32 format);
+    mfxStatus CopyMirrorVideoToVideoMemory(mfxMemId dst, mfxMemId src, mfxSize roi, mfxU32 format);
 
     mfxStatus ReleaseCmSurfaces(void);
     mfxStatus EnqueueCopyNV12GPUtoCPU(   CmSurface2D* pSurface,
@@ -317,7 +322,7 @@ protected:
     std::map<CmSurface2D *, SurfaceIndex *> m_tableCmIndex;
     std::map<CmBufferUP *,  SurfaceIndex *> m_tableSysIndex;
 
-    std::map<void *, CmSurface2D *> m_tableCmRelations2;
+    std::map<mfxHDLPair, CmSurface2D *> m_tableCmRelations2;
     std::map<mfxU8 *, CmBufferUP *> m_tableSysRelations2;
 
     std::map<CmSurface2D *, SurfaceIndex *> m_tableCmIndex2;
@@ -328,8 +333,8 @@ protected:
     std::vector<CmBufferUP*>  m_buffersInCreationOrder;
     UMC::Mutex m_guard;
 
-    CmSurface2D * CreateCmSurface2D(void *pSrc, mfxU32 width, mfxU32 height, bool isSecondMode,
-                                    std::map<void *, CmSurface2D *> & tableCmRelations,
+    CmSurface2D * CreateCmSurface2D(const mfxHDLPair & hdl, mfxU32 width, mfxU32 height, bool isSecondMode,
+                                    std::map<mfxHDLPair, CmSurface2D *> & tableCmRelations,
                                     std::map<CmSurface2D *, SurfaceIndex *> & tableCmIndex);
 
     SurfaceIndex  * CreateUpBuffer(mfxU8 *pDst, mfxU32 memSize,


### PR DESCRIPTION

Issue: MDP-64809 VSMGWL-33362
Test: manual test

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>