### PR TITLE
[core] SetHandle returns DEVICE_FAILED on unsupported systems

### DIFF
--- a/_studio/shared/src/libmfx_core_vaapi.cpp
+++ b/_studio/shared/src/libmfx_core_vaapi.cpp
@@ -548,7 +548,7 @@ mfxStatus VAAPIVideoCORE_T<Base>::SetHandle(
             * to get device ID and find out platform type
             */
             const auto devItem = getDeviceItem(m_Display);
-            MFX_CHECK_WITH_ASSERT(MFX_HW_UNKNOWN != devItem.platform, MFX_ERR_UNDEFINED_BEHAVIOR);
+            MFX_CHECK(MFX_HW_UNKNOWN != devItem.platform, MFX_ERR_DEVICE_FAILED);
 
             m_HWType         = devItem.platform;
             m_GTConfig       = devItem.config;

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -2050,6 +2050,7 @@ If the specified system handle is a COM interface, the reference counter of the 
 --- | ---
 `MFX_ERR_NONE` | The function completed successfully.
 `MFX_ERR_UNDEFINED_BEHAVIOR` | The same handle is redefined. For example, the function has been called twice with the same handle type or internal handle has been created by the SDK before this function call.
+`MFX_ERR_DEVICE_FAILED` | The SDK cannot initialize using the handle.
 
 **Change History**
 


### PR DESCRIPTION
Fixes: #2230

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>