### PR TITLE
[HEVCe] Support B frames for all target usage with LowPower on

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
@@ -80,7 +80,7 @@ void Caps::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
     {
         auto& caps = Glob::EncodeCaps::Get(strg);
 
-        caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && (par.mfx.TargetUsage == 6 || par.mfx.TargetUsage == 7 || par.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC);
+        caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && par.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC;
         caps.msdk.bSingleSliceMultiTile = false;
 
         caps.YUV422ReconSupport &= (!caps.Color420Only && !IsOn(par.mfx.LowPower));


### PR DESCRIPTION
Previously #2440 got regression due to media driver's change to support B frame
for speed mode was not been merged into master branch yet at that moment. Since
media driver's related change has been merged into mater branch as
intel/media-driver@63ff905, this corresponding MSDK's change can work
functionally on speed mode.

Signed-off-by: Jeremy Shang <jeremy.shang@intel.com>