### PR TITLE
Fix  3 AV1 decode issues with system memory

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
@@ -164,7 +164,7 @@ namespace UMC_AV1_DECODER
 
         uint32_t                        counter;
         AV1DecoderParams                params;
-        AV1DecoderFrame*                Poutput; // store frame need to be output
+        std::vector<AV1DecoderFrame*>   outputed_frames; // tore frames need to be output
         AV1DecoderFrame*                Curr; // store current frame for Poutput
         AV1DecoderFrame*                Curr_temp; // store current frame insist double updateDPB
         uint32_t                        Repeat_show; // show if current frame is repeated frame

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
@@ -239,8 +239,17 @@ namespace UMC_AV1_DECODER
         if (fh.show_existing_frame)
         {
             pFrame = frameDPB[fh.frame_to_show_map_idx];
+            //Increase referernce here, and will be decreased when
+            //CompleteDecodedFrames not show_frame case.
             pFrame->IncrementReference();
             VM_ASSERT(pFrame);
+
+            //Add one more Reference, and add it into outputted frame list
+            //When QueryFrame finished and update status in outputted frame
+            //list, then it will be released in CompleteDecodedFrames.
+            pFrame->IncrementReference();
+            outputed_frames.push_back(pFrame);
+
             FrameHeader const& refFH = pFrame->GetFrameHeader();
 
             if (!refFH.showable_frame)
@@ -693,6 +702,8 @@ namespace UMC_AV1_DECODER
                 }
                 else
                 {
+                    // For no display case, decrease reference here which is increased
+                    // in pFrame->IncrementReference() in show_existing_frame case.
                     Curr->DecrementReference();
                 }
             }

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_frame.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_frame.cpp
@@ -148,7 +148,6 @@ namespace UMC_AV1_DECODER
 
             data[surf].reset(new UMC::FrameData{});
             *data[surf] = *fd;
-            data[surf]->m_locked = true;
         }
         else
         {
@@ -160,7 +159,6 @@ namespace UMC_AV1_DECODER
 
             data[SURFACE_DISPLAY].reset(new UMC::FrameData{});
             *data[SURFACE_DISPLAY] = *fd;
-            data[SURFACE_DISPLAY]->m_locked = true;
             data[SURFACE_RECON] = data[SURFACE_DISPLAY];
         }
     }


### PR DESCRIPTION
Following 3 issues are fixed in this PR:
1) error buffer status, which cause buffer be unmmaped twice.
2) For all key frame stream,  buffer be overwrited when it is still be used by APP side.
3) When non display frame be repeated, frame should wait for it be repeated, then release.