### PR TITLE
Fix framerate check in frame info

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -133,7 +133,7 @@ mfxStatus CheckFrameInfoCommon(mfxFrameInfo  *info, mfxU32 /* codecId */)
 
     MFX_CHECK(info->ChromaFormat <= MFX_CHROMAFORMAT_YUV444,  MFX_ERR_INVALID_VIDEO_PARAM);
 
-    MFX_CHECK((info->FrameRateExtN == 0 && info->FrameRateExtD == 0) || (info->FrameRateExtN != 0 && info->FrameRateExtD != 0), MFX_ERR_INVALID_VIDEO_PARAM);
+    MFX_CHECK(!(info->FrameRateExtN != 0 && info->FrameRateExtD == 0), MFX_ERR_INVALID_VIDEO_PARAM);
 
     MFX_CHECK((!info->AspectRatioW && !info->AspectRatioH) || (info->AspectRatioW && info->AspectRatioH), MFX_ERR_INVALID_VIDEO_PARAM);
 


### PR DESCRIPTION
The framerate check logic was incorrectly translated to
the MFX_CHECK trace in commit 2f54a3458c5b (#2397).

That is, the previous logic allowed 0/1 and 0/0 as valid
framerates.  The only disallowed framerate is when the
denominator is zero (0) with a non-zero numerator (e.g. 30/0).

Fixes #2489

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>