### PR TITLE
Revert "[VP9e] Use vaSyncBuffer in VAAPIEncoder::QueryStatus"

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -1281,11 +1281,7 @@ mfxStatus VAAPIEncoder::QueryStatus(
 
     VASurfaceStatus surfSts = VASurfaceSkipped;
 
-#if VA_CHECK_VERSION(1,9,0)
-    vaSts = vaSyncBuffer(m_vaDisplay, codedBuffer, VA_TIMEOUT_INFINITE);
-#else
     vaSts = vaSyncSurface(m_vaDisplay, waitSurface);
-#endif
     MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
     {


### PR DESCRIPTION
This reverts commit fa8db613c8ec13fdf572777436b330138cf8ccb6.
THis fixes: #2392