### PR TITLE
Revert "Revert "[VP9e] Use vaSyncBuffer in VAAPIEncoder::QueryStatus""

### DIFF
--- a/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
+++ b/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_vaapi.cpp
@@ -1281,7 +1281,11 @@ mfxStatus VAAPIEncoder::QueryStatus(
 
     VASurfaceStatus surfSts = VASurfaceSkipped;
 
+#if VA_CHECK_VERSION(1,9,0)
+    vaSts = vaSyncBuffer(m_vaDisplay, codedBuffer, VA_TIMEOUT_INFINITE);
+#else
     vaSts = vaSyncSurface(m_vaDisplay, waitSurface);
+#endif
     MFX_CHECK_WITH_ASSERT(VA_STATUS_SUCCESS == vaSts, MFX_ERR_DEVICE_FAILED);
 
     {


### PR DESCRIPTION
Reverts Intel-Media-SDK/MediaSDK#2496