### PR TITLE
av1d: fix film grain

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_vpx_dec_common.cpp
@@ -107,7 +107,10 @@ namespace MFX_VPX_Utility
 
 #if defined(MFX_ENABLE_AV1_VIDEO_DECODE)
             if (codecId == MFX_CODEC_AV1)
+            {
                 p_out->mfx.CodecLevel = p_in->mfx.CodecLevel;
+                p_out->mfx.FilmGrain = p_in->mfx.FilmGrain;
+            }
 #endif
 
             if (p_in->mfx.NumThread < 128)
@@ -320,7 +323,10 @@ namespace MFX_VPX_Utility
 
 #if defined(MFX_ENABLE_AV1_VIDEO_DECODE)
             if (codecId == MFX_CODEC_AV1)
+            {
                 p_out->mfx.CodecLevel = MFX_LEVEL_AV1_2;
+                p_out->mfx.FilmGrain = 1;
+            }
 #endif
 
             p_out->mfx.NumThread = 1;


### PR DESCRIPTION
Currently the film grain synthesis is always disabled when apply_grain
is 1, the reason is p_in->mfx.FilmGrain is ignored when getting the
video parameters