### PR TITLE
sample_decode:av1 add option to disable film grain application

### DIFF
--- a/samples/sample_decode/include/pipeline_decode.h
+++ b/samples/sample_decode/include/pipeline_decode.h
@@ -143,6 +143,7 @@ struct sInputParams
     msdk_char     strDstFile[MSDK_MAX_FILENAME_LEN];
     sPluginParams pluginParams;
 
+    bool bDisableFilmGrain;
 };
 
 struct CPipelineStatistics

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -959,6 +959,11 @@ mfxStatus CDecodingPipeline::InitMfxParams(sInputParams *pParams)
 
     m_mfxVideoParams.AsyncDepth = pParams->nAsyncDepth;
 
+#if (MFX_VERSION >= 1034)
+    if (m_mfxVideoParams.mfx.CodecId == MFX_CODEC_AV1)
+        m_mfxVideoParams.mfx.FilmGrain = pParams->bDisableFilmGrain ? 0 : m_mfxVideoParams.mfx.FilmGrain;
+#endif
+
     return MFX_ERR_NONE;
 }
 

--- a/samples/sample_decode/src/sample_decode.cpp
+++ b/samples/sample_decode/src/sample_decode.cpp
@@ -76,6 +76,7 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage)
 #if (MFX_VERSION >= MFX_VERSION_NEXT)   
     msdk_printf(MSDK_STRING("   [-ignore_level_constrain] - ignore level constrain\n"));
 #endif
+    msdk_printf(MSDK_STRING("   [-disable_film_grain] - disable film grain application(valid only for av1)\n"));
     msdk_printf(MSDK_STRING("\n"));
     msdk_printf(MSDK_STRING("JPEG Chroma Type:\n"));
     msdk_printf(MSDK_STRING("   [-jpeg_rgb] - RGB Chroma Type\n"));
@@ -661,6 +662,10 @@ mfxStatus ParseInputString(msdk_char* strInput[], mfxU8 nArgNum, sInputParams* p
             pParams->bIgnoreLevelConstrain = true;
         }
 #endif
+        else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-disable_film_grain")))
+        {
+            pParams->bDisableFilmGrain = true;
+        }
         else // 1-character options
         {
             switch (strInput[i][1])


### PR DESCRIPTION
Option -disable_film_grain is added to disable film grain application
even if apply_grain is 1 in a stream

Example:
sample_decode av1 -hw -vaapi -disable_film_grain -i av1-film_grain.ivf
-o /dev/null