### PR TITLE
av1d: set MINIMAL_DATA_SIZE to 3

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
@@ -43,7 +43,7 @@ namespace UMC_AV1_DECODER
 
     const uint8_t FRAME_MARKER = 0x2;
 
-    const uint8_t MINIMAL_DATA_SIZE = 4;
+    const uint8_t MINIMAL_DATA_SIZE = 3;
 
     const uint8_t INTER_REFS                    = 7;
     const uint8_t TOTAL_REFS                    = 8;


### PR DESCRIPTION
The mininal OBU FRAME HEADER size is 3 when showing an existing frame.
The repeated frame will be ignored if not set MINIMAL_DATA_SIZE to 3
when running a command below:

ffmpeg -hwaccel qsv -c:v av1_qsv -i av1-show-existing-frame.ivf -vf
'hwdownload,format=nv12' output.yuv