### PR TITLE
Revert "[hevce] Initialize frame_only_constraint_flag based on PicStruct"

### DIFF
--- a/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
+++ b/_studio/mfx_lib/encode_hw/h265/src/mfx_h265_encode_hw_utils.cpp
@@ -1529,7 +1529,7 @@ void MfxVideoParam::SyncMfxToHeadersParam(mfxU32 numSlicesForSTRPSOpt)
     general.progressive_source_flag     = !!(mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
     general.interlaced_source_flag      = !(mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
     general.non_packed_constraint_flag  = 0;
-    general.frame_only_constraint_flag  = !(mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_FIELD_SINGLE);;
+    general.frame_only_constraint_flag  = 0;
     general.level_idc                   = (mfxU8)(mfx.CodecLevel & 0xFF) * 3;
 
     if (mfx.CodecProfile == MFX_PROFILE_HEVC_REXT

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
@@ -1241,8 +1241,6 @@ namespace Base
             , std::vector<SliceInfo>&>;
         TGetSlices GetSlices;
 
-        using TGetVPS = CallChain<mfxStatus, const Defaults::Param&, VPS&>;
-        TGetVPS GetVPS;
         using TGetSPS = CallChain<mfxStatus, const Defaults::Param&, const VPS&, SPS&>;
         TGetSPS GetSPS;
         using TGetPPS = CallChain<mfxStatus, const Defaults::Param&, const SPS&, PPS&>;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_interlace.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_interlace.cpp
@@ -234,20 +234,6 @@ void Interlace::Query1NoCaps(const FeatureBlocks& , TPushQ1 Push)
             return prev(par, task, bRAPIntra && !IsField(par.mvp.mfx.FrameInfo.PicStruct));
         });
 
-        defaults.GetVPS.Push([](
-            Defaults::TGetVPS::TExt prev
-            , const Defaults::Param& par
-            , VPS& vps)
-        {
-            auto sts = prev(par, vps);
-
-            vps.general.progressive_source_flag    = !!(par.mvp.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
-            vps.general.interlaced_source_flag     = !(par.mvp.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
-            vps.general.frame_only_constraint_flag = !IsField(par.mvp.mfx.FrameInfo.PicStruct);
-
-            return sts;
-        });
-
         defaults.GetSPS.Push([](
             Defaults::TGetSPS::TExt prev
             , const Defaults::Param& par
@@ -269,7 +255,6 @@ void Interlace::Query1NoCaps(const FeatureBlocks& , TPushQ1 Push)
 
             return sts;
         });
-
         defaults.GetWeakRef.Push([](
             Defaults::TGetWeakRef::TExt prev
             , const Defaults::Param& par

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -1006,9 +1006,7 @@ void Legacy::InitInternal(const FeatureBlocks& /*blocks*/, TPushII Push)
     {
         MFX_CHECK(!strg.Contains(Glob::VPS::Key), MFX_ERR_NONE);
         auto dflts = GetRTDefaults(strg);
-
-        auto sts = dflts.base.GetVPS(dflts, Glob::VPS::GetOrConstruct(strg));
-        MFX_CHECK_STS(sts);
+        SetVPS(dflts, Glob::VPS::GetOrConstruct(strg));
 
         return MFX_ERR_NONE;
     });
@@ -2575,6 +2573,53 @@ mfxU32 Legacy::GetMinBsSize(
     mfxU32 avgSize = TargetKbps(par.mfx) * 1000 * par.mfx.FrameInfo.FrameRateExtD / (par.mfx.FrameInfo.FrameRateExtN * 8);
 
     return std::max<mfxU32>(size, avgSize * 2);
+}
+
+void Legacy::SetVPS(
+    const Defaults::Param& dflts
+    , VPS& vps)
+{
+    auto&                  par       = dflts.mvp;
+    const mfxExtHEVCParam& HEVCParam = ExtBuffer::Get(par);
+    mfxU16                 NumTL     = dflts.base.GetNumTemporalLayers(dflts);
+    PTL&                   general   = vps.general;
+    SubLayerOrdering&      slo       = vps.sub_layer[NumTL - 1];
+
+    vps = VPS{};
+    vps.video_parameter_set_id                  = 0;
+    vps.reserved_three_2bits                    = 3;
+    vps.max_layers_minus1                       = 0;
+    vps.max_sub_layers_minus1                   = mfxU16(NumTL - 1);
+    vps.temporal_id_nesting_flag                = 1;
+    vps.reserved_0xffff_16bits                  = 0xFFFF;
+    vps.sub_layer_ordering_info_present_flag    = 0;
+
+    vps.timing_info_present_flag        = 1;
+    vps.num_units_in_tick               = par.mfx.FrameInfo.FrameRateExtD;
+    vps.time_scale                      = par.mfx.FrameInfo.FrameRateExtN;
+    vps.poc_proportional_to_timing_flag = 0;
+    vps.num_hrd_parameters              = 0;
+
+    general.profile_space                   = 0;
+    general.tier_flag                       = !!(par.mfx.CodecLevel & MFX_TIER_HEVC_HIGH);
+    general.profile_idc                     = mfxU8(par.mfx.CodecProfile);
+    general.profile_compatibility_flags     = 1 << (31 - general.profile_idc);
+    general.progressive_source_flag         = !!(par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
+    general.interlaced_source_flag          = !(par.mfx.FrameInfo.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
+    general.non_packed_constraint_flag      = 0;
+    general.frame_only_constraint_flag      = 0;
+    general.level_idc                       = mfxU8((par.mfx.CodecLevel & 0xFF) * 3);
+
+    if (par.mfx.CodecProfile == MFX_PROFILE_HEVC_REXT)
+    {
+        general.rext_constraint_flags_0_31  = (mfxU32)(HEVCParam.GeneralConstraintFlags & 0xffffffff);
+        general.rext_constraint_flags_32_42 = (mfxU32)(HEVCParam.GeneralConstraintFlags >> 32);
+    }
+
+    auto numReorderFrames = dflts.base.GetNumReorderFrames(dflts);
+    slo.max_dec_pic_buffering_minus1 = par.mfx.NumRefFrame;
+    slo.max_num_reorder_pics         = std::min<mfxU8>(numReorderFrames, slo.max_dec_pic_buffering_minus1);
+    slo.max_latency_increase_plus1   = 0;
 }
 
 typedef std::remove_reference<decltype(((mfxExtAVCRefListCtrl*)nullptr)->PreferredRefList[0])>::type TLCtrlRLE;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.h
@@ -216,6 +216,10 @@ namespace Base
             , const Defaults::Param& defPar
             , bool bExternalFrameAllocator);
 
+        void SetVPS(
+            const Defaults::Param& dflts
+            , VPS& vps);
+
         void SetSTRPS(
             const Defaults::Param& dflts
             , SPS& sps

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1815,60 +1815,10 @@ public:
         return (mfxU16)slices.size();
     }
 
-    static mfxStatus VPS(
-        Defaults::TGetVPS::TExt
-        , const Defaults::Param& dflts
-        , Base::VPS& vps)
-    {
-        auto&                  par       = dflts.mvp;
-        const mfxExtHEVCParam& HEVCParam = ExtBuffer::Get(par);
-        mfxU16                 NumTL     = dflts.base.GetNumTemporalLayers(dflts);
-        PTL&                   general   = vps.general;
-        SubLayerOrdering&      slo       = vps.sub_layer[NumTL - 1];
-
-        vps = Base::VPS{};
-        vps.video_parameter_set_id                  = 0;
-        vps.reserved_three_2bits                    = 3;
-        vps.max_layers_minus1                       = 0;
-        vps.max_sub_layers_minus1                   = mfxU16(NumTL - 1);
-        vps.temporal_id_nesting_flag                = 1;
-        vps.reserved_0xffff_16bits                  = 0xFFFF;
-        vps.sub_layer_ordering_info_present_flag    = 0;
-
-        vps.timing_info_present_flag        = 1;
-        vps.num_units_in_tick               = par.mfx.FrameInfo.FrameRateExtD;
-        vps.time_scale                      = par.mfx.FrameInfo.FrameRateExtN;
-        vps.poc_proportional_to_timing_flag = 0;
-        vps.num_hrd_parameters              = 0;
-
-        general.profile_space                   = 0;
-        general.tier_flag                       = !!(par.mfx.CodecLevel & MFX_TIER_HEVC_HIGH);
-        general.profile_idc                     = mfxU8(par.mfx.CodecProfile);
-        general.profile_compatibility_flags     = 1 << (31 - general.profile_idc);
-        general.progressive_source_flag         = 1;
-        general.interlaced_source_flag          = 0;
-        general.non_packed_constraint_flag      = 0;
-        general.frame_only_constraint_flag      = 1;
-        general.level_idc                       = mfxU8((par.mfx.CodecLevel & 0xFF) * 3);
-
-        if (par.mfx.CodecProfile == MFX_PROFILE_HEVC_REXT)
-        {
-            general.rext_constraint_flags_0_31  = (mfxU32)(HEVCParam.GeneralConstraintFlags & 0xffffffff);
-            general.rext_constraint_flags_32_42 = (mfxU32)(HEVCParam.GeneralConstraintFlags >> 32);
-        }
-
-        auto numReorderFrames = dflts.base.GetNumReorderFrames(dflts);
-        slo.max_dec_pic_buffering_minus1 = par.mfx.NumRefFrame;
-        slo.max_num_reorder_pics         = std::min<mfxU8>(numReorderFrames, slo.max_dec_pic_buffering_minus1);
-        slo.max_latency_increase_plus1   = 0;
-
-        return MFX_ERR_NONE;
-    }
-
     static mfxStatus SPS(
         Defaults::TGetSPS::TExt
         , const Defaults::Param& defPar
-        , const Base::VPS& vps
+        , const VPS& vps
         , Base::SPS& sps)
     {
         const std::map<mfxU32, mfxU32> arIdc =
@@ -2235,7 +2185,6 @@ public:
         PUSH_DEFAULT(NumTiles);
         PUSH_DEFAULT(TileSlices);
         PUSH_DEFAULT(Slices);
-        PUSH_DEFAULT(VPS);
         PUSH_DEFAULT(SPS);
         PUSH_DEFAULT(PPS);
         PUSH_DEFAULT(FrameNumRefActive);


### PR DESCRIPTION
Reverts Intel-Media-SDK/MediaSDK#2401 .  It caused VQ regression in internal validation