### PR TITLE
[h264d] Unmark the duplicated frame_num with the coming frame in DPB

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -598,6 +598,7 @@ protected:
     virtual void OnFullFrame(H264DecoderFrame * pFrame);
     virtual bool ProcessNonPairedField(H264DecoderFrame * pFrame) = 0;
 
+    void DPBSanitize(H264DecoderFrame * pDPBHead, const H264DecoderFrame * pFrame);
     void DBPUpdate(H264DecoderFrame * pFrame, int32_t field);
 
     virtual void AddFakeReferenceFrame(H264Slice * pSlice);


### PR DESCRIPTION
Fix the issue about some h264 streams which have a wrong way to calculate frame_num.

Issue: MDP-64211, MDP-48207
Signed-off-by: Wang Dylan <dylan.wang@intel.com>