### PR TITLE
Add the conversion from UMC::GRAY to MFX_FOURCC_YUV444

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_decode_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_decode_int.cpp
@@ -255,6 +255,7 @@ mfxU32 ConvertUMCColorFormatToFOURCC(UMC::ColorFormat format)
         case UMC::YUV411:  return MFX_FOURCC_YUV411;
         case UMC::YUV444:  return MFX_FOURCC_YUV444;
         case UMC::UYVY:    return MFX_FOURCC_UYVY;
+        case UMC::GRAY:    return MFX_FOURCC_YUV400;
 
         default:
             VM_ASSERT(!"Unknown color format");


### PR DESCRIPTION
There is only the conversion from MFX_FOURCC_YUV444 to UMC::GRAY.
It will cause UMC:GRAY is converted to MFX_FOURCC_NV12 and fire
the assertion in debug build.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>