### PR TITLE
[AV1d] Enable dynamic gpu session priority for av1 decoder

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -687,6 +687,11 @@ mfxStatus VideoDECODEAV1::DecodeFrameCheck(mfxBitstream* bs, mfxFrameSurface1* s
     MFX_CHECK(m_core, MFX_ERR_UNDEFINED_BEHAVIOR);
     MFX_CHECK(m_decoder, MFX_ERR_NOT_INITIALIZED);
 
+    //gpu session priority
+    UMC_AV1_DECODER::AV1DecoderParams* av1DecoderParams = m_decoder->GetAv1DecoderParams();
+    if (av1DecoderParams->pVideoAccelerator != nullptr)
+        av1DecoderParams->pVideoAccelerator->m_ContextPriority = m_core->GetSession()->m_priority;
+
     mfxStatus sts = SubmitFrame(bs, surface_work, surface_out);
 
     if (sts == MFX_ERR_MORE_DATA || sts == MFX_ERR_MORE_SURFACE)

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
@@ -131,6 +131,8 @@ namespace UMC_AV1_DECODER
 
         virtual bool QueryFrames() = 0;
 
+        AV1DecoderParams* GetAv1DecoderParams() {return &params;}
+
     protected:
 
         static UMC::Status FillVideoParam(SequenceHeader const&, UMC_AV1_DECODER::AV1DecoderParams&);

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_va_packer_vaapi.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_va_packer_vaapi.h
@@ -58,6 +58,7 @@ namespace UMC_AV1_DECODER
     private:
         void PackPicParams(VADecPictureParameterBufferAV1&, AV1DecoderFrame const&);
         void PackTileControlParams(VASliceParameterBufferAV1&, TileLocation const&);
+        void PackPriorityParams();
     };
 
 } // namespace UMC_AV1_DECODER

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
@@ -116,6 +116,36 @@ namespace UMC_AV1_DECODER
 
         std::copy(tileControlParams.begin(), tileControlParams.end(), tileControlParam);
         compBufTile->SetDataSize(tileControlInfoSize);
+
+        if(m_va->m_MaxContextPriority)
+            PackPriorityParams();
+    }
+
+    void PackerVA::PackPriorityParams()
+    {
+        mfxPriority priority = m_va->m_ContextPriority;
+        UMCVACompBuffer *GpuPriorityBuf;
+        VAContextParameterUpdateBuffer* GpuPriorityBuf_Av1Decode = (VAContextParameterUpdateBuffer *)m_va->GetCompBuffer(VAContextParameterUpdateBufferType, &GpuPriorityBuf, sizeof(VAContextParameterUpdateBuffer));
+        if (!GpuPriorityBuf_Av1Decode)
+            throw av1_exception(MFX_ERR_MEMORY_ALLOC);
+
+        memset(GpuPriorityBuf_Av1Decode, 0, sizeof(VAContextParameterUpdateBuffer));
+        GpuPriorityBuf_Av1Decode->flags.bits.context_priority_update = 1;
+
+        if(priority == MFX_PRIORITY_LOW)
+        {
+            GpuPriorityBuf_Av1Decode->context_priority.bits.priority = 0;
+        }
+        else if (priority == MFX_PRIORITY_HIGH)
+        {
+            GpuPriorityBuf_Av1Decode->context_priority.bits.priority = m_va->m_MaxContextPriority;
+        }
+        else
+        {
+            GpuPriorityBuf_Av1Decode->context_priority.bits.priority = m_va->m_MaxContextPriority/2;
+        }
+
+        GpuPriorityBuf->SetDataSize(sizeof(VAContextParameterUpdateBuffer));
     }
 
     void PackerVA::PackPicParams(VADecPictureParameterBufferAV1& picParam, AV1DecoderFrame const& frame)

--- a/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_va_packer.cpp
+++ b/_studio/shared/umc/codec/vp9_dec/src/umc_vp9_va_packer.cpp
@@ -116,7 +116,7 @@ void PackerVA::PackPriorityParams()
     UMCVACompBuffer *GpuPriorityBuf;
     VAContextParameterUpdateBuffer* GpuPriorityBuf_Vp9Decode = (VAContextParameterUpdateBuffer *)m_va->GetCompBuffer(VAContextParameterUpdateBufferType, &GpuPriorityBuf, sizeof(VAContextParameterUpdateBuffer));
     if (!GpuPriorityBuf_Vp9Decode)
-        throw vp9_exception(MFX_ERR_MEMORY_ALLOC);;
+        throw vp9_exception(MFX_ERR_MEMORY_ALLOC);
 
     memset(GpuPriorityBuf_Vp9Decode, 0, sizeof(VAContextParameterUpdateBuffer));
     GpuPriorityBuf_Vp9Decode->flags.bits.context_priority_update = 1;


### PR DESCRIPTION
Enable dynamic gpu session priority feature for av1 decoder.

Signed-off-by: Wang Dylan <dylan.wang@intel.com>