### PR TITLE
ci: enable github actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,109 @@
+name: ubuntu
+
+on: [ push, pull_request ]
+
+env:
+  CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+
+jobs:
+  ubuntu-20-04-clang11:
+    runs-on: ubuntu-20.04
+    env:
+      CC: /usr/bin/clang-10
+      CXX: /usr/bin/clang++-10
+      ASM: /usr/bin/clang-10
+    steps:
+    - name: checkout libmfx
+      uses: actions/checkout@v2
+      with:
+        path: libmfx
+    - name: checkout libva
+      uses: actions/checkout@v2
+      with:
+        repository: intel/libva
+        path: libva
+    - name: install prerequisites
+      run: sudo apt-get install -y
+        cmake
+        libdrm-dev
+        libegl1-mesa-dev
+        libgl1-mesa-dev
+        libx11-dev
+        libx11-xcb-dev
+        libxcb-dri3-dev
+        libxcb-present-dev
+        libxext-dev
+        libxfixes-dev
+        libwayland-dev
+        ocl-icd-opencl-dev
+        make
+    - name: print tools versions
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+    - name: build libva
+      run: |
+        cd libva
+        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        make -j$(nproc)
+        sudo make install
+    - name: build libmfx
+      run: |
+        cd libmfx
+        mkdir build && cd build
+        cmake -DBUILD_ALL=ON -DENABLE_ALL=ON -DENABLE_ITT=OFF -DCMAKE_C_FLAGS_RELEASE="$CFLAGS" -DCMAKE_CXX_FLAGS_RELEASE="$CFLAGS"  ..
+        make -j$(nproc)
+        make test
+        sudo make install
+
+  ubuntu-20-04-gcc10:
+    runs-on: ubuntu-20.04
+    env:
+      CC: /usr/bin/gcc-10
+      CXX: /usr/bin/g++-10
+      ASM: /usr/bin/gcc-10
+    steps:
+    - name: checkout libmfx
+      uses: actions/checkout@v2
+      with:
+        path: libmfx
+    - name: checkout libva
+      uses: actions/checkout@v2
+      with:
+        repository: intel/libva
+        path: libva
+    - name: install prerequisites
+      run: sudo apt-get install -y
+        cmake
+        libdrm-dev
+        libegl1-mesa-dev
+        libgl1-mesa-dev
+        libx11-dev
+        libx11-xcb-dev
+        libxcb-dri3-dev
+        libxcb-present-dev
+        libxext-dev
+        libxfixes-dev
+        libwayland-dev
+        ocl-icd-opencl-dev
+        make
+    - name: print tools versions
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+    - name: build libva
+      run: |
+        cd libva
+        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        make -j$(nproc)
+        sudo make install
+    - name: build libmfx
+      run: |
+        cd libmfx
+        mkdir build && cd build
+        cmake -DBUILD_ALL=ON -DENABLE_ALL=ON -DENABLE_ITT=OFF -DCMAKE_C_FLAGS_RELEASE="$CFLAGS" -DCMAKE_CXX_FLAGS_RELEASE="$CFLAGS"  ..
+        make -j$(nproc)
+        make test
+        sudo make install


### PR DESCRIPTION
Run on my side (you need to merge in PR to see it triggerred): https://github.com/dvrogozh/MediaSDK/actions/runs/429344132

As of now runs ~10 mins. Covers gcc-10 and clang-10 on ubuntu 20.04. Misses build of sample_opencl_plugin.