### PR TITLE
[HEVCe] Change supported target bitdepth with LowPower ON

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_rext.cpp
@@ -148,8 +148,16 @@ void RExt::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
 
             mfxU32 invalid = 0;
 
-            invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthLuma);
-            invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthChroma);
+            if (IsOn(par.mfx.LowPower))
+            {
+                invalid += CheckOrZero<mfxU16, 10, 0>(pCO3->TargetBitDepthLuma);
+                invalid += CheckOrZero<mfxU16, 10, 0>(pCO3->TargetBitDepthChroma);
+            }
+            else
+            {
+                invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthLuma);
+                invalid += CheckOrZero<mfxU16, 12, 0>(pCO3->TargetBitDepthChroma);
+            }
 
             MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
             return MFX_ERR_NONE;


### PR DESCRIPTION
In case of HEVC REXT format, HEVC encoder with LowPower ON cannot support
target bitDepth bigger than 10.