### PR TITLE
[smt] Process StopSession when timeout is set

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -570,6 +570,7 @@ mfxStatus CTranscodingPipeline::DecodeOneFrame(ExtendedSurface *pExtSurface)
                 if (m_bForceStop)
                 {
                     lock.unlock();
+                    m_nTimeout = 0;
                     // add surfaces in queue for all sinks
                     NoMoreFramesSignal();
                     return MFX_WRN_VALUE_NOT_CHANGED;


### PR DESCRIPTION
Currently loop in CTranscodingPipeline::Decode() ignores m_bForceStop
flag.

Issue: MDP-65336