### PR TITLE
[samples]: Enable vacopy for sample_encode and sample_decode.

### DIFF
--- a/samples/sample_common/include/vaapi_device.h
+++ b/samples/sample_common/include/vaapi_device.h
@@ -56,10 +56,15 @@ public:
     virtual void      UpdateTitle(double fps) { }
     virtual void      SetMondelloInput(bool isMondelloInputEnabled) { }
 
+    virtual mfxStatus SetupUserSurface(mfxFrameSurface1 * pSurface);
+    virtual mfxStatus CopyVAFrame(mfxFrameSurface1 * pSurface, bool bUserToVA, mfxI32 nVACopyMode);
+
     inline drmRenderer* getRenderer() { return m_rndr; }
 protected:
     DRMLibVA m_DRMLibVA;
     drmRenderer * m_rndr;
+    VASurfaceID m_sysSurfaceID;
+    SurfaceInfo	m_sysSurfInfo;
 private:
     // no copies allowed
     CVAAPIDeviceDRM(const CVAAPIDeviceDRM &);

--- a/samples/sample_common/include/vaapi_utils.h
+++ b/samples/sample_common/include/vaapi_utils.h
@@ -114,6 +114,10 @@ namespace MfxLoader
                                                   VAConfigID config_id);
         typedef VAStatus (*vaDestroyContext_type) (VADisplay dpy,
                                                    VAContextID context);
+        typedef VAStatus (*vaCopy_type) (VADisplay dpy,
+                                         VACopyObject * dst,
+                                         VACopyObject * src,
+                                         VACopyOption option);
 
         VA_Proxy();
         ~VA_Proxy();
@@ -139,6 +143,7 @@ namespace MfxLoader
         const vaCreateContext_type          vaCreateContext;
         const vaDestroyConfig_type          vaDestroyConfig;
         const vaDestroyContext_type         vaDestroyContext;
+        const vaCopy_type					vaCopy;
     };
 #endif
 
@@ -430,6 +435,18 @@ namespace MfxLoader
 
 } // namespace MfxLoader
 
+typedef struct _SurfaceInfo
+{
+    uint32_t    width;
+    uint32_t    height;
+    uint32_t    fourCC;
+    uint32_t    format;
+    uint32_t    memtype;
+    uint32_t    alignsize;
+    void        *pBuf;
+    uint8_t     *pBufBase;
+    uintptr_t   ptrb;
+} SurfaceInfo;
 
 class CLibVA
 {
@@ -448,6 +465,22 @@ public:
         VASurfaceID /*srf1*/,
         VADisplay dpy2,
         VASurfaceID srf2);
+
+#if defined(LIBVA_DRM_SUPPORT)
+	VAStatus AcquireUserSurface(
+		VADisplay va_dpy,
+		VASurfaceID *p_surface_id,
+		SurfaceInfo &surf);
+
+	VAStatus ReleaseUserSurface(
+		VADisplay va_dpy,
+		VASurfaceID *p_surface_id);
+
+	VAStatus VACopy(VADisplay va_dpy,
+		VASurfaceID in_surface_id,
+		VASurfaceID out_surface_id,
+		mfxI32 vacopy_mode);
+#endif
 
     inline int getBackendType() { return m_type; }
     VADisplay GetVADisplay() { return m_va_dpy; }

--- a/samples/sample_decode/include/pipeline_decode.h
+++ b/samples/sample_decode/include/pipeline_decode.h
@@ -127,6 +127,10 @@ struct sInputParams
     mfxI32  libvaBackend;
 #endif // defined(MFX_LIBVA_SUPPORT)
 
+#if defined(LIBVA_DRM_SUPPORT)
+    mfxI32 nVACopy;
+#endif
+
 #if defined(LINUX32) || defined(LINUX64)
     std::string strDevicePath;
 #endif
@@ -251,6 +255,10 @@ protected: // functions
 
     virtual mfxStatus ReallocCurrentSurface(const mfxFrameInfo & info);
 
+#if defined(LIBVA_DRM_SUPPORT)
+    virtual mfxStatus WriteFrameWithVACopy(mfxFrameSurface1* frame, mfxI32 nVACopyMode);
+#endif
+
 protected: // variables
     CSmplYUVWriter                         m_FileWriter;
     std::unique_ptr<CSmplBitstreamReader>  m_FileReader;
@@ -331,6 +339,10 @@ protected: // variables
     mfxI32                  m_libvaBackend;
     bool                    m_bPerfMode;
 #endif // defined(MFX_LIBVA_SUPPORT)
+
+#if defined(LIBVA_DRM_SUPPORT)
+    mfxI32                  m_nVACopy;
+#endif
 
     bool                    m_bResetFileWriter;
     bool                    m_bResetFileReader;

--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -117,6 +117,9 @@ struct sInputParams
 #if defined(LINUX32) || defined(LINUX64)
     std::string strDevicePath;
 #endif
+#if defined(LIBVA_DRM_SUPPORT)
+    mfxI32 nVACopy;
+#endif
 #if (defined(_WIN64) || defined(_WIN32)) && (MFX_VERSION >= 1031)
     bool bPrefferdGfx;
     bool bPrefferiGfx;
@@ -369,6 +372,9 @@ protected:
 #if defined(LINUX32) || defined(LINUX64)
     std::string m_strDevicePath; //path to device for processing
 #endif
+#if defined(LIBVA_DRM_SUPPORT)
+    mfxI32 m_nVACopy;
+#endif
 
     std::vector<mfxPayload*> m_UserDataUnregSEI;
 
@@ -439,6 +445,10 @@ protected:
     virtual MFXVideoENCODE* GetFirstEncoder(){return m_pmfxENC;}
 
     virtual mfxU32 FileFourCC2EncFourCC(mfxU32 fcc);
+
+#if defined(LIBVA_DRM_SUPPORT)
+    virtual mfxStatus LoadFrameWithVACopy(mfxFrameSurface1* pSurf, mfxI32 nVACopyMode);
+#endif
 
     void InitExtMVCBuffers(mfxExtMVCSeqDesc *mvcBuffer) const;
 };

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -1631,6 +1631,11 @@ mfxStatus CEncodingPipeline::Init(sInputParams *pParams)
 #if defined(LINUX32) || defined(LINUX64)
     m_strDevicePath = pParams->strDevicePath;
 #endif
+
+#if defined(LIBVA_DRM_SUPPORT)
+    m_nVACopy = pParams->nVACopy;
+#endif
+
     mfxInitParamlWrap initPar;
 
     // we set version to 1.0 and later we will query actual version of the library which will got leaded
@@ -2009,18 +2014,29 @@ void CEncodingPipeline::FreeFileWriters()
 
 mfxStatus CEncodingPipeline::FillBuffers()
 {
+    mfxStatus sts = MFX_ERR_NONE;
+
     if (m_nPerfOpt)
     {
         for (mfxU32 i = 0; i < m_nPerfOpt; i++)
         {
             mfxFrameSurface1* surface = m_pmfxVPP ? &m_pVppSurfaces[i] : &m_pEncSurfaces[i];
-
-            mfxStatus sts = m_pMFXAllocator->Lock(m_pMFXAllocator->pthis, surface->Data.MemId, &surface->Data);
-            MSDK_CHECK_STATUS(sts, "m_pMFXAllocator->Lock failed");
-            sts = m_FileReader.LoadNextFrame(surface);
-            MSDK_CHECK_STATUS(sts, "m_FileReader.LoadNextFrame failed");
-            sts = m_pMFXAllocator->Unlock(m_pMFXAllocator->pthis, surface->Data.MemId, &surface->Data);
-            MSDK_CHECK_STATUS(sts, "m_pMFXAllocator->Unlock failed");
+#if defined(LIBVA_DRM_SUPPORT)
+            if (m_nVACopy != -1) // vacopy mode
+            {
+                sts = LoadFrameWithVACopy(surface, m_nVACopy);
+                MSDK_CHECK_STATUS(sts, "LoadFrameWithVACopy failed");
+            }
+            else
+#endif
+            {
+                sts = m_pMFXAllocator->Lock(m_pMFXAllocator->pthis, surface->Data.MemId, &surface->Data);
+                MSDK_CHECK_STATUS(sts, "m_pMFXAllocator->Lock failed");
+                sts = m_FileReader.LoadNextFrame(surface);
+                MSDK_CHECK_STATUS(sts, "m_FileReader.LoadNextFrame failed");
+                sts = m_pMFXAllocator->Unlock(m_pMFXAllocator->pthis, surface->Data.MemId, &surface->Data);
+                MSDK_CHECK_STATUS(sts, "m_pMFXAllocator->Unlock failed");
+            }
         }
     }
     return MFX_ERR_NONE;
@@ -2631,6 +2647,40 @@ mfxStatus CEncodingPipeline::Run()
     return sts;
 }
 
+#if defined(LIBVA_DRM_SUPPORT)
+mfxStatus CEncodingPipeline::LoadFrameWithVACopy(mfxFrameSurface1* pSurf, mfxI32 nVACopyMode)
+{
+    mfxStatus sts = MFX_ERR_NONE;
+   CVAAPIDeviceDRM* drmdev = dynamic_cast<CVAAPIDeviceDRM*>(m_hwdev); 
+
+    MSDK_CHECK_POINTER(pSurf, MFX_ERR_NOT_INITIALIZED);
+    MSDK_CHECK_POINTER(m_hwdev, MFX_ERR_NOT_INITIALIZED);
+
+    // setup system surface for gpu copy
+    sts = drmdev->SetupUserSurface(pSurf);
+    MSDK_CHECK_STATUS(sts, "m_hwdev->SetupUserSurface failed");
+
+    if (m_bQPFileMode)
+    {
+        mfxU16 w = pSurf->Info.CropW ? pSurf->Info.CropW : pSurf->Info.Width;
+        mfxU16 h = pSurf->Info.CropH ? pSurf->Info.CropH : pSurf->Info.Height;
+        mfxU32 vid = pSurf->Info.FrameId.ViewId;
+        sts = m_FileReader.SkipNframesFromBeginning(w, h, vid, m_QPFileReader.GetCurrentDisplayOrder());
+        MSDK_CHECK_STATUS(sts, "m_FileReader.SkipNframesFromBeginning failed");
+    }
+
+    // load raw data from file to user buffer
+    sts = m_FileReader.LoadNextFrame(pSurf);
+    MSDK_CHECK_STATUS(sts, "m_FileReader.LoadNextFrame failed");
+
+    // copy raw data from uer buffer to video surface with vaCopy
+    sts = drmdev->CopyVAFrame(pSurf, true, nVACopyMode);
+    MSDK_CHECK_STATUS(sts, "m_hwdev->CopyFrame failed");
+
+    return sts;
+}
+#endif
+
 mfxStatus CEncodingPipeline::LoadNextFrame(mfxFrameSurface1* pSurf)
 {
     mfxStatus sts = MFX_ERR_NONE;
@@ -2656,22 +2706,32 @@ mfxStatus CEncodingPipeline::LoadNextFrame(mfxFrameSurface1* pSurf)
         // read frame from file
         if (m_bExternalAlloc)
         {
-            mfxStatus sts1 = m_pMFXAllocator->Lock(m_pMFXAllocator->pthis, pSurf->Data.MemId, &(pSurf->Data));
-            MSDK_CHECK_STATUS(sts1, "m_pMFXAllocator->Lock failed");
-
-            if (m_bQPFileMode)
+#if defined(LIBVA_DRM_SUPPORT)
+            if (m_nVACopy != -1) //vacopy mode
             {
-                mfxU16 w = pSurf->Info.CropW ? pSurf->Info.CropW : pSurf->Info.Width;
-                mfxU16 h = pSurf->Info.CropH ? pSurf->Info.CropH : pSurf->Info.Height;
-                mfxU32 vid = pSurf->Info.FrameId.ViewId;
-                sts = m_FileReader.SkipNframesFromBeginning(w, h, vid, m_QPFileReader.GetCurrentDisplayOrder());
-                MSDK_CHECK_STATUS(sts, "m_FileReader.SkipNframesFromBeginning failed");
+                sts = LoadFrameWithVACopy(pSurf, m_nVACopy);
+                MSDK_CHECK_STATUS(sts, "LoadFrameWithVACopy failed");
             }
+            else
+#endif
+            {
+                mfxStatus sts1 = m_pMFXAllocator->Lock(m_pMFXAllocator->pthis, pSurf->Data.MemId, &(pSurf->Data));
+                MSDK_CHECK_STATUS(sts1, "m_pMFXAllocator->Lock failed");
 
-            sts = m_FileReader.LoadNextFrame(pSurf);
+                if (m_bQPFileMode)
+                {
+                    mfxU16 w = pSurf->Info.CropW ? pSurf->Info.CropW : pSurf->Info.Width;
+                    mfxU16 h = pSurf->Info.CropH ? pSurf->Info.CropH : pSurf->Info.Height;
+                    mfxU32 vid = pSurf->Info.FrameId.ViewId;
+                    sts = m_FileReader.SkipNframesFromBeginning(w, h, vid, m_QPFileReader.GetCurrentDisplayOrder());
+                    MSDK_CHECK_STATUS(sts, "m_FileReader.SkipNframesFromBeginning failed");
+                }
 
-            sts1 = m_pMFXAllocator->Unlock(m_pMFXAllocator->pthis, pSurf->Data.MemId, &(pSurf->Data));
-            MSDK_CHECK_STATUS(sts1, "m_pMFXAllocator->Unlock failed");
+                sts = m_FileReader.LoadNextFrame(pSurf);
+
+                sts1 = m_pMFXAllocator->Unlock(m_pMFXAllocator->pthis, pSurf->Data.MemId, &(pSurf->Data));
+                MSDK_CHECK_STATUS(sts1, "m_pMFXAllocator->Unlock failed");
+            }
         }
         else
         {


### PR DESCRIPTION
Add "-vacopy" option to command line for sample_encode and sample_decode
to use vaapi vaCopy interface for high efficiency raw data copy between
VA surface and user buffer.

Sample usage:
./sample_decode h264 -i in.264 -o out.yuv -n 5 -hw -vaapi -vacopy
./sample_encode h264 -i in.yuv -o out.264 -w 1280 -h 720 -n 5 -nv12 -hw -vaapi -vacopy

Signed-off-by: Zhong, Xiaoxia <xiaoxia.zhong@intel.com>