### PR TITLE
[smt] Fix the unsupported issue of transcoding from I420/nv12 to HEVC

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -550,7 +550,8 @@ mfxStatus CTranscodingPipeline::DecodeOneFrame(ExtendedSurface *pExtSurface)
         {
             pExtSurface->pSurface = GetFreeSurface(false, MSDK_SURFACE_WAIT_INTERVAL);
             sts = m_pBSProcessor->GetInputFrame(pExtSurface->pSurface);
-            MFX_CHECK_STS(sts);
+            if(sts != MFX_ERR_NONE)
+                return sts;
         }
         else if (MFX_WRN_DEVICE_BUSY == sts)
         {
@@ -3793,6 +3794,10 @@ mfxStatus CTranscodingPipeline::Init(sInputParams *pParams,
             return sts;
         else
             MSDK_CHECK_STATUS(sts,"DecodePreInit failed");
+    }
+    else
+    {
+        m_mfxDecParams.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
     }
 
     // VPP component initialization


### PR DESCRIPTION
1. MFX_ERR_UNSUPPORTED will be reported when transcoding from I420/nv12 to HEVC.
2. It will print MFX_ERR_MORE_DATA, but this error doesn't effect the result, So fix it.

Issue: VCD-2398, VCD-2486

Signed-off-by: Wang Dylan <dylan.wang@intel.com>