### PR TITLE
ci: fix detection of clang-11

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
         path: libva
     - name: install toolchain
       run: |
-        if sudo apt-cache search --names-only ^clang-11$ | grep -q clang-11; then \
+        if [[ -e $CC && -e $CXX ]]; then \
           echo "clang-11 already presents in the image"; \
         else \
           echo "clang-11 missed in the image, installing from llvm"; \


### PR DESCRIPTION
Github images added clang-11 package, but somehow /usr/bin/clang-11
is missed. So, we better check that target is available rather than
package.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>