### PR TITLE
[h264la]: do not link to dispatcher (libmfx)

### DIFF
--- a/_studio/mfx_lib/plugin/CMakeLists.txt
+++ b/_studio/mfx_lib/plugin/CMakeLists.txt
@@ -180,7 +180,6 @@ if( DEFINED H264LA_ENCODER_GUID )
     genx
     asc
     enctools_hw
-    mfx
     mctf_hw
     mfx_trace
     ${ITT_LIBRARIES}


### PR DESCRIPTION
Runtime libraries should not depend on the
dispatcher library.

Thus, don't link h264la runtime plugin library to the
dispatcher.

This fixes a compile error when compiling only the runtime
libraries and no dispatcher is installed yet.

-DBUILD_RUNTIME=ON -DBUILD_DISPATCHER=OFF

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>