### PR TITLE
smt: enable SFC for hevc

### DIFF
--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -683,7 +683,8 @@ private:
             MFX_EXTBUFF_FEI_PPS,
             MFX_EXTBUFF_FEI_SPS,
             MFX_EXTBUFF_LOOKAHEAD_CTRL,
-            MFX_EXTBUFF_LOOKAHEAD_STAT
+            MFX_EXTBUFF_LOOKAHEAD_STAT,
+            MFX_EXTBUFF_DEC_VIDEO_PROCESSING
         };
 
         auto it = std::find_if(std::begin(allowed), std::end(allowed),

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -2176,8 +2176,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
                 PrintError(MSDK_STRING("-vpp_comp_dst_w %s is invalid"), argv[i]);
                 return MFX_ERR_UNSUPPORTED;
             }
-            if (InputParams.eModeExt != VppComp)
-                InputParams.eModeExt = VppComp;
         }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-vpp_comp_dst_h")))
         {
@@ -2188,8 +2186,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
                 PrintError(MSDK_STRING("-vpp_comp_dst_h %s is invalid"), argv[i]);
                 return MFX_ERR_UNSUPPORTED;
             }
-            if (InputParams.eModeExt != VppComp)
-                InputParams.eModeExt = VppComp;
         }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-vpp_comp_src_w")))
         {
@@ -2248,8 +2244,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-dec_postproc")))
         {
             InputParams.bDecoderPostProcessing = true;
-            if (InputParams.eModeExt != VppComp)
-                InputParams.eModeExt = VppComp;
         }
 #endif //MFX_VERSION >= 1022
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-n")))


### PR DESCRIPTION
Test: ./sample_multi_transcode -dec_postproc -i::h265 ../stream_4k.h265 -o::h265 stream_sfc_fhd.h264 -vpp_comp_dst_w 1920 -vpp_comp_dst_h 1080 -hw -ext_allocator [-lowpower:on]

-i::h265 ../stream4k.h265 -dec_postproc -vpp_comp_dst_w 1920 -vpp_comp_dst_h 1080 -hw -ext_allocator -o::sink
-i::source -o::h265 o1.h265 -ext_allocator
-i::source -o::h265 o2.h265 -ext_allocator

Don`t see visual artifacts.