### PR TITLE
[Decode]Enable CSC via sfc pipeline

### DIFF
--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -249,7 +249,7 @@ mfxStatus VideoDECODEH265::Init(mfxVideoParam *par)
         {
             MFX_CHECK(m_vPar.mfx.FrameInfo.PicStruct == MFX_PICSTRUCT_PROGRESSIVE, MFX_ERR_UNSUPPORTED);
         }
-        MFX_CHECK(par->mfx.FrameInfo.FourCC == videoProcessing->Out.FourCC, MFX_ERR_UNSUPPORTED);//This is to avoid CSC cases, will remove once CSC is fully tested
+
 		bool is_fourcc_supported = false;
         if (m_core->GetHWType() < MFX_HW_TGL_LP)
         {

--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1335,8 +1335,7 @@ mfxStatus MFX_JPEG_Utility::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoPa
             const short unsigned MHW_SFC_MAX_HEIGHT        = 4096;
             const short unsigned MHW_SFC_MAX_WIDTH         = 4096;
 
-            if ( (MFX_HW_VAAPI == (core->GetVAType())) &&
-                 (MFX_PICSTRUCT_PROGRESSIVE == in->mfx.FrameInfo.PicStruct) &&
+            if ( (MFX_PICSTRUCT_PROGRESSIVE == in->mfx.FrameInfo.PicStruct) &&
                  (in->IOPattern & MFX_IOPATTERN_OUT_VIDEO_MEMORY) &&
                  // FtrSFCPipe is not supported on BDW, and there is a known issue on SCL
                  (core->GetHWType() > MFX_HW_SCL) &&

--- a/_studio/shared/src/mfx_umc_alloc_wrapper.cpp
+++ b/_studio/shared/src/mfx_umc_alloc_wrapper.cpp
@@ -711,12 +711,14 @@ mfxStatus mfx_UMC_FrameAllocator::SetCurrentMFXSurface(mfxFrameSurface1 *surf, b
         return MFX_ERR_MORE_SURFACE;
 
     // check input surface
+    if (!(m_sfcVideoPostProcessing && (surf->Info.FourCC != m_surface_info.FourCC)))// if csc is done via sfc, will not do below checks
+    {
+        if ((surf->Info.BitDepthLuma ? surf->Info.BitDepthLuma : 8) != (m_surface_info.BitDepthLuma ? m_surface_info.BitDepthLuma : 8))
+            return MFX_ERR_INVALID_VIDEO_PARAM;
 
-    if ((surf->Info.BitDepthLuma ? surf->Info.BitDepthLuma : 8) != (m_surface_info.BitDepthLuma ? m_surface_info.BitDepthLuma : 8))
-        return MFX_ERR_INVALID_VIDEO_PARAM;
-
-    if ((surf->Info.BitDepthChroma ? surf->Info.BitDepthChroma : 8) != (m_surface_info.BitDepthChroma ? m_surface_info.BitDepthChroma : 8))
-        return MFX_ERR_INVALID_VIDEO_PARAM;
+        if ((surf->Info.BitDepthChroma ? surf->Info.BitDepthChroma : 8) != (m_surface_info.BitDepthChroma ? m_surface_info.BitDepthChroma : 8))
+            return MFX_ERR_INVALID_VIDEO_PARAM;
+    }
 
     if (   surf->Info.FourCC == MFX_FOURCC_P010
         || surf->Info.FourCC == MFX_FOURCC_P210


### PR DESCRIPTION
Fixes Intel-Media-SDK#2580
HEVC/AV1/JPEG SFC CSC is supported

Signed-off-by: Shawn Li <shawn.li@intel.com>