### PR TITLE
VDBOX+SFC for 1->1 transcode scenarios

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -1079,12 +1079,8 @@ mfxStatus VideoDECODEH264::RunThread(ThreadTaskInfo* info, mfxU32 threadNumber)
 
         mfxI32 index = m_FrameAllocator->FindSurface(info->surface_out, m_isOpaq);
         pFrame = m_pH264VideoDecoder->FindSurface((UMC::FrameMemID)index);
+        MFX_CHECK(pFrame && pFrame->m_UID != -1, MFX_ERR_NOT_FOUND);
 
-        if (!pFrame || pFrame->m_UID == -1)
-        {
-            VM_ASSERT(false);
-            return MFX_ERR_NOT_FOUND;
-        }
 
         isDecoded = m_pH264VideoDecoder->CheckDecoding(pFrame);
     }
@@ -1597,11 +1593,7 @@ mfxStatus VideoDECODEH264::DecodeFrame(mfxFrameSurface1 *surface_out, UMC::H264D
     {
         index = m_FrameAllocator->FindSurface(surface_out, m_isOpaq);
         pFrame = m_pH264VideoDecoder->FindSurface((UMC::FrameMemID)index);
-        if (!pFrame)
-        {
-            VM_ASSERT(false);
-            return MFX_ERR_NOT_FOUND;
-        }
+        MFX_CHECK(pFrame, MFX_ERR_NOT_FOUND);        
     }
 
     int32_t const error = pFrame->GetError();

--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -1399,11 +1399,7 @@ mfxStatus VideoDECODEH265::DecodeFrame(mfxFrameSurface1 *surface_out, H265Decode
     {
         index = m_FrameAllocator->FindSurface(surface_out, m_isOpaq);
         pFrame = m_pH265VideoDecoder->FindSurface((UMC::FrameMemID)index);
-        if (!pFrame)
-        {
-            VM_ASSERT(false);
-            MFX_RETURN(MFX_ERR_NOT_FOUND);
-        }
+        MFX_CHECK(pFrame, MFX_ERR_NOT_FOUND);
     }
 
     surface_out->Data.Corrupted = 0;

--- a/_studio/shared/src/mfx_umc_alloc_wrapper.cpp
+++ b/_studio/shared/src/mfx_umc_alloc_wrapper.cpp
@@ -788,6 +788,7 @@ mfxStatus mfx_UMC_FrameAllocator::SetCurrentMFXSurface(mfxFrameSurface1 *surf, b
                 m_extSurfaces[m_curIndex].FrameSurface = surf;
                 break;
             }
+
             if ( (NULL != m_extSurfaces[i].FrameSurface) &&
                   (0 == m_extSurfaces[i].FrameSurface->Data.Locked) &&
                   (m_extSurfaces[i].FrameSurface->Data.MemId == surf->Data.MemId) &&
@@ -798,7 +799,23 @@ mfxStatus mfx_UMC_FrameAllocator::SetCurrentMFXSurface(mfxFrameSurface1 *surf, b
                 m_extSurfaces[m_curIndex].FrameSurface = surf;
                 break;
             }
-        } // for (mfxU32 i = 0; i < m_extSurfaces.size(); i++)
+        }
+
+        // Still not found. It may happen if decoder gets 'surf' surface which on app size belongs to
+        // a pool bigger than m_extSurfaces/m_frameDataInternal pools which decoder is aware.
+        if (m_curIndex == -1)
+        {
+            for (mfxU32 i = 0; i < m_extSurfaces.size(); i++)
+            {
+                // So attemping to find an expired slot in m_extSurfaces
+                if (!m_extSurfaces[i].isUsed && (0 == m_frameDataInternal.GetSurface(i).Data.Locked))
+                {
+                    m_curIndex = i;
+                    m_extSurfaces[m_curIndex].FrameSurface = surf;
+                    break;
+                }
+            }
+        }
     }
     else
     {

--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -160,8 +160,8 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
 |-dc::nv12\|rgb4\|yuy2\|p010\|y210\|y410\|p016\|y216 | Forces decoder output to use provided chroma mode<br>NOTE: chroma transform VPP may be automatically enabled if -ec/-dc parameters are provided|
 |-angle 180| Enables 180 degrees picture rotation user module before encoding|
 | -opencl|Uses implementation of rotation plugin (enabled with -angle option) through Intel(R) OpenCL|
-  |-w|    Destination picture width, invokes VPP resize|
-|  -h|  Destination picture height, invokes VPP resize|
+|-w| Destination picture width, invokes VPP resize or decoder fixed function resize engine (if -dec_postproc specified) |
+|-h| Destination picture height, invokes VPP resize or decoder fixed function resize engine (if -dec_postproc specified)|
 |-field_processing t2t\|t2b\|b2t\|b2b\|fr2fr | Field Copy feature|
   |-WeightedPred::default\|implicit|  Enables weighted prediction usage|
 |  -WeightedBiPred::default\|implicit|     Enambles weighted bi-prediction usage|

--- a/samples/sample_common/include/sample_utils.h
+++ b/samples/sample_common/include/sample_utils.h
@@ -683,7 +683,8 @@ private:
             MFX_EXTBUFF_FEI_PPS,
             MFX_EXTBUFF_FEI_SPS,
             MFX_EXTBUFF_LOOKAHEAD_CTRL,
-            MFX_EXTBUFF_LOOKAHEAD_STAT
+            MFX_EXTBUFF_LOOKAHEAD_STAT,
+            MFX_EXTBUFF_DEC_VIDEO_PROCESSING
         };
 
         auto it = std::find_if(std::begin(allowed), std::end(allowed),

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -77,6 +77,20 @@ namespace TranscodingSample
 }
 #endif
 
+mfxFrameInfo GetFrameInfo(const MfxVideoParamsWrapper& param)
+{
+    mfxFrameInfo frameInfo = param.mfx.FrameInfo;
+    auto decPostProc = param.GetExtBuffer<mfxExtDecVideoProcessing>();
+    if(decPostProc)
+    {
+        frameInfo.Width = decPostProc->Out.Width;
+        frameInfo.Height = decPostProc->Out.Height;
+        frameInfo.CropW = decPostProc->Out.CropW;
+        frameInfo.CropH = decPostProc->Out.CropH;
+    }
+
+    return frameInfo;
+}
 
 // set structure to define values
 sInputParams::sInputParams() : __sInputParams()
@@ -339,8 +353,8 @@ mfxStatus CTranscodingPipeline::VPPPreInit(sInputParams *pParams)
             m_mfxVppParams.vpp.In.PicStruct = MFX_PICSTRUCT_UNKNOWN;
         }
 
-        if ( (m_mfxDecParams.mfx.FrameInfo.CropW != pParams->nDstWidth && pParams->nDstWidth) ||
-             (m_mfxDecParams.mfx.FrameInfo.CropH != pParams->nDstHeight && pParams->nDstHeight) ||
+        if ( (GetFrameInfo(m_mfxDecParams).CropW != pParams->nDstWidth && pParams->nDstWidth) ||
+             (GetFrameInfo(m_mfxDecParams).CropH != pParams->nDstHeight && pParams->nDstHeight) ||
              (pParams->bEnableDeinterlacing) || (pParams->DenoiseLevel!=-1) || (pParams->DetailLevel!=-1) || (pParams->FRCAlgorithm) ||
              (bVppCompInitRequire) || (pParams->fieldProcessingMode) ||
 #ifdef ENABLE_MCTF
@@ -2268,13 +2282,12 @@ mfxStatus CTranscodingPipeline::InitDecMfxParams(sInputParams *pInParams)
         m_mfxDecParams.mfx.FrameInfo.FourCC=pInParams->DecoderFourCC;
         m_mfxDecParams.mfx.FrameInfo.ChromaFormat=FourCCToChroma(pInParams->DecoderFourCC);
     }
+
 #if MFX_VERSION >= 1022
     /* SFC usage if enabled */
-    if ((pInParams->bDecoderPostProcessing) &&
-        (MFX_CODEC_AVC == m_mfxDecParams.mfx.CodecId) && /* Only for AVC */
-        (MFX_PICSTRUCT_PROGRESSIVE == m_mfxDecParams.mfx.FrameInfo.PicStruct)) /* ...And only for progressive!*/
+    if (pInParams->bDecoderPostProcessing)
     {
-        auto decPostProc = m_mfxEncParams.AddExtBuffer<mfxExtDecVideoProcessing>();
+        auto decPostProc = m_mfxDecParams.AddExtBuffer<mfxExtDecVideoProcessing>();
         decPostProc->In.CropX = 0;
         decPostProc->In.CropY = 0;
         decPostProc->In.CropW = m_mfxDecParams.mfx.FrameInfo.CropW;
@@ -2282,14 +2295,15 @@ mfxStatus CTranscodingPipeline::InitDecMfxParams(sInputParams *pInParams)
 
         decPostProc->Out.FourCC = m_mfxDecParams.mfx.FrameInfo.FourCC;
         decPostProc->Out.ChromaFormat = m_mfxDecParams.mfx.FrameInfo.ChromaFormat;
-        decPostProc->Out.Width = MSDK_ALIGN16(pInParams->nVppCompDstW);
-        decPostProc->Out.Height = MSDK_ALIGN16(pInParams->nVppCompDstH);
         decPostProc->Out.CropX = 0;
         decPostProc->Out.CropY = 0;
-        decPostProc->Out.CropW = pInParams->nVppCompDstW;
-        decPostProc->Out.CropH = pInParams->nVppCompDstH;
+        decPostProc->Out.CropW = pInParams->eModeExt == VppComp ? pInParams->nVppCompDstW : pInParams->nDstWidth;
+        decPostProc->Out.CropH = pInParams->eModeExt == VppComp ? pInParams->nVppCompDstH : pInParams->nDstHeight;
+        decPostProc->Out.Width = MSDK_ALIGN16(decPostProc->Out.CropW);
+        decPostProc->Out.Height = MSDK_ALIGN16(decPostProc->Out.CropH);
     }
-#endif //MFX_VERSION >= 1022
+#endif
+
     return MFX_ERR_NONE;
 }// mfxStatus CTranscodingPipeline::InitDecMfxParams()
 
@@ -2307,7 +2321,7 @@ void CTranscodingPipeline::FillFrameInfoForEncoding(mfxFrameInfo& info, sInputPa
     }
     else
     {
-        MSDK_MEMCPY_VAR(info, &m_mfxDecParams.mfx.FrameInfo, sizeof(mfxFrameInfo));
+        info = GetFrameInfo(m_mfxDecParams);
     }
 
     if (pInParams->dEncoderFrameRateOverride)
@@ -2759,7 +2773,7 @@ mfxStatus CTranscodingPipeline::InitPreEncMfxParams(sInputParams *pInParams)
     }
     else
     {
-        MSDK_MEMCPY_VAR(param.mfx.FrameInfo, &m_mfxDecParams.mfx.FrameInfo, sizeof(mfxFrameInfo));
+        param.mfx.FrameInfo = GetFrameInfo(m_mfxDecParams);
     }
 
     mfxU16 InPatternFromParent = (mfxU16) ((MFX_IOPATTERN_OUT_VIDEO_MEMORY == m_mfxDecParams.IOPattern) ?
@@ -2852,7 +2866,7 @@ mfxStatus CTranscodingPipeline::InitVppMfxParams(sInputParams *pInParams)
     }
 
     // input frame info
-    MSDK_MEMCPY_VAR(m_mfxVppParams.vpp.In, &m_mfxDecParams.mfx.FrameInfo, sizeof(mfxFrameInfo));
+    m_mfxVppParams.vpp.In = GetFrameInfo(m_mfxDecParams);
 
     if (m_mfxVppParams.vpp.In.Width * m_mfxVppParams.vpp.In.Height == 0)
     {
@@ -3146,7 +3160,7 @@ mfxStatus CTranscodingPipeline::InitPluginMfxParams(sInputParams *pInParams)
     }
     else
     {
-        MSDK_MEMCPY_VAR(m_mfxPluginParams.vpp.In, &m_mfxDecParams.mfx.FrameInfo, sizeof(mfxFrameInfo));
+        m_mfxPluginParams.vpp.In = GetFrameInfo(m_mfxDecParams);
     }
 
     // fill output frame info
@@ -3396,7 +3410,7 @@ mfxStatus CTranscodingPipeline::CalculateNumberOfReqFrames(mfxFrameAllocRequest 
         // It takes 1 surface for overlay
         DecRequest.NumFrameMin = DecRequest.NumFrameSuggested = 1;
         DecRequest.Type = MFX_MEMTYPE_FROM_DECODE | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET | MFX_MEMTYPE_EXTERNAL_FRAME;
-        MSDK_MEMCPY(&DecRequest.Info, &m_mfxDecParams.mfx.FrameInfo, sizeof(mfxFrameInfo));
+        DecRequest.Info = GetFrameInfo(m_mfxDecParams);
         SumAllocRequest(*pSumRequest, DecRequest);
     }
 

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -324,8 +324,8 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("     NOTE: chroma transform VPP may be automatically enabled if -ec/-dc parameters are provided\n"));
     msdk_printf(MSDK_STRING("  -angle 180    Enables 180 degrees picture rotation user module before encoding\n"));
     msdk_printf(MSDK_STRING("  -opencl       Uses implementation of rotation plugin (enabled with -angle option) through Intel(R) OpenCL\n"));
-    msdk_printf(MSDK_STRING("  -w            Destination picture width, invokes VPP resize\n"));
-    msdk_printf(MSDK_STRING("  -h            Destination picture height, invokes VPP resize\n"));
+    msdk_printf(MSDK_STRING("  -w            Destination picture width, invokes VPP resize or decoder fixed function resize engine (if -dec_postproc specified)\n"));
+    msdk_printf(MSDK_STRING("  -h            Destination picture height, invokes VPP resize or decoder fixed function resize engine (if -dec_postproc specified)\n"));
     msdk_printf(MSDK_STRING("  -field_processing t2t|t2b|b2t|b2b|fr2fr - Field Copy feature\n"));
     msdk_printf(MSDK_STRING("  -WeightedPred::default|implicit       Enambles weighted prediction usage\n"));
     msdk_printf(MSDK_STRING("  -WeightedBiPred::default|implicit     Enambles weighted bi-prediction usage\n"));
@@ -2248,8 +2248,6 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-dec_postproc")))
         {
             InputParams.bDecoderPostProcessing = true;
-            if (InputParams.eModeExt != VppComp)
-                InputParams.eModeExt = VppComp;
         }
 #endif //MFX_VERSION >= 1022
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-n")))


### PR DESCRIPTION
The changes introduces supports of 1->1, 1->N transcode with SFC (previously
only N->1 was supported).
Plus it fixes the bug on library side where decoders couldn't accept surfaces
allocated in addition to what decoder::QueryIOSurf() requested.

Test: ./sample_multi_transcode -dec_postproc -i::h264 in.h264 -o::h264 out.h264 -w 1280 -h 720 -hw

or via par file
-dec_postproc -i::h264 in.h264 -o::h264 out.h264 -w 1280 -h 720 -hw -o::sink
-i::source -o::h265 o1.h265
-i::source -o::h265 o2.h265

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>