### PR TITLE
Update output params in QueryIOSurf for VDBX SFC CSC

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -555,6 +555,9 @@ mfxStatus VideoDECODEAV1::QueryIOSurf(VideoCORE* core, mfxVideoParam* par, mfxFr
         request->Type = MFX_MEMTYPE_SYSTEM_MEMORY | MFX_MEMTYPE_FROM_DECODE;
     }
 
+    sts = UpdateCscOutputFormat(par, request);
+    MFX_CHECK_STS(sts);
+
     request->Type |= par->IOPattern & MFX_IOPATTERN_OUT_OPAQUE_MEMORY ?
         MFX_MEMTYPE_OPAQUE_FRAME : MFX_MEMTYPE_EXTERNAL_FRAME;
 

--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -781,6 +781,9 @@ mfxStatus VideoDECODEH265::QueryIOSurf(VideoCORE *core, mfxVideoParam *par, mfxF
     mfxStatus sts = QueryIOSurfInternal(platform, type, &params, request);
     MFX_CHECK_STS(sts);
 
+    sts = UpdateCscOutputFormat(&params, request);
+    MFX_CHECK_STS(sts);
+
     if (isInternalManaging)
     {
         request->NumFrameSuggested = request->NumFrameMin = (mfxU16)CalculateAsyncDepth(platform, par);

--- a/_studio/mfx_lib/shared/include/mfx_common_int.h
+++ b/_studio/mfx_lib/shared/include/mfx_common_int.h
@@ -35,6 +35,8 @@ mfxStatus CheckFrameInfoCodecs(mfxFrameInfo  *info, mfxU32 codecId = MFX_CODEC_A
 mfxStatus CheckVideoParamEncoders(mfxVideoParam *in, bool IsExternalFrameAllocator, eMFXHWType type);
 mfxStatus CheckVideoParamDecoders(mfxVideoParam *in, bool IsExternalFrameAllocator, eMFXHWType type);
 
+mfxStatus UpdateCscOutputFormat(mfxVideoParam *par, mfxFrameAllocRequest *request);
+
 mfxStatus CheckAudioParamEncoders(mfxAudioParam *in);
 mfxStatus CheckAudioParamCommon(mfxAudioParam *in);
 mfxStatus CheckAudioParamDecoders(mfxAudioParam *in);


### PR DESCRIPTION
Update output params in QueryIOSurf when output color format changed;
enable for AV1/HEVC

Issue: MDP-65929
Test: manually