### PR TITLE
Fix VDSFC bit mismatch for vaapi

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
@@ -731,6 +731,7 @@ void PackerVA::PackProcessingInfo(H264DecoderFrameInfo * sliceInfo)
 
     pipelineBuf->surface = m_va->GetSurfaceID(sliceInfo->m_pFrame->m_index); // should filled in packer
     pipelineBuf->additional_outputs = (VASurfaceID*)vpVA->GetCurrentOutputSurface();
+    // To keep output aligned, decode downsampling use this fixed combination of chroma sitting type
     pipelineBuf->input_color_properties.chroma_sample_location = VA_CHROMA_SITING_HORIZONTAL_LEFT | VA_CHROMA_SITING_VERTICAL_CENTER;
 }
 

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_va_packer.cpp
@@ -731,6 +731,7 @@ void PackerVA::PackProcessingInfo(H264DecoderFrameInfo * sliceInfo)
 
     pipelineBuf->surface = m_va->GetSurfaceID(sliceInfo->m_pFrame->m_index); // should filled in packer
     pipelineBuf->additional_outputs = (VASurfaceID*)vpVA->GetCurrentOutputSurface();
+    pipelineBuf->input_color_properties.chroma_sample_location = VA_CHROMA_SITING_HORIZONTAL_LEFT | VA_CHROMA_SITING_VERTICAL_CENTER;
 }
 
 void PackerVA::PackQmatrix(const UMC_H264_DECODER::H264ScalingPicParams * scaling)

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_vaapi.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_va_packer_vaapi.cpp
@@ -113,7 +113,8 @@ namespace UMC_HEVC_DECODER
         MFX_INTERNAL_CPY(pipelineBuf, &vpVA->m_pipelineParams, sizeof(VAProcPipelineParameterBuffer));
 
         pipelineBuf->surface = m_va->GetSurfaceID(sliceInfo->m_pFrame->m_index); // should filled in packer
-        pipelineBuf->additional_outputs = (VASurfaceID*)vpVA->GetCurrentOutputSurface();
+        // To keep output aligned, decode downsampling use this fixed combination of chroma sitting type
+        pipelineBuf->input_color_properties.chroma_sample_location = VA_CHROMA_SITING_HORIZONTAL_LEFT | VA_CHROMA_SITING_VERTICAL_CENTER;
     }
 
     void PackerVAAPI::PackPriorityParams()


### PR DESCRIPTION
value of chroma sample location was not set in lib

Issue: MDP-66020
Test: manually

