### PR TITLE
[HEVC][10bit] Support encode 8bit from 10bit for sampe_encode and sample_multitranscode

### DIFF
--- a/doc/samples/readme-encode_linux.md
+++ b/doc/samples/readme-encode_linux.md
@@ -133,7 +133,9 @@ The following command-line switches are optional:
   | [-extbrc:<on,off,implicit>] | External BRC for AVC and HEVC encoders|
  |  [-ExtBrcAdaptiveLTR:<on,off>] | Set AdaptiveLTR for implicit extbrcExample: `./sample_encode h265 -i InputYUVFile -o OutputEncodedFile -w width -h height -hw -p 2fca99749fdb49aeb121a5b63ef568f7`|
   | [-vaapi] | work with vaapi surfaces <br>Example: `./sample_encode h264|mpeg2|mvc -i InputYUVFile -o OutputEncodedFile -w width -h height -angle 180 -g 300 -r 1`|
-  | [-viewoutput] | instruct the MVC encoder to output each view in separate bitstream buffer. Depending on the number of -o options behaves as follows:<br>1: two views are encoded in single file<br>2: two views are encoded in separate files<br>3: behaves like 2 -o opitons was used and then one -o<br>Example:<br>`./sample_encode mvc -i InputYUVFile_1 -i InputYUVFile_2 -o OutputEncodedFile_1 -o OutputEncodedFile_2 -viewoutput -w width -h height`
+  | [-viewoutput] | instruct the MVC encoder to output each view in separate bitstream buffer. Depending on the number of -o options behaves as follows:<br>1: two views are encoded in single file<br>2: two views are encoded in separate files<br>3: behaves like 2 -o opitons was used and then one -o<br>Example:<br>`./sample_encode mvc -i InputYUVFile_1 -i InputYUVFile_2 -o OutputEncodedFile_1 -o OutputEncodedFile_2 -viewoutput -w width -h height` |
+  | [-TargetBitDepthLuma] | Target encoding bit-depth for luma samples. May differ from source one. 0 mean default target bit-depth which is equal to source. <br>Example:<br>`./sample_encode h265 -i InputYUVFile_10_bit -o OutputEncodedFile_8_bit -w width -h height -lowpower:on -TargetBitDepthLuma 8 -TargetBitDepthChroma 8` |
+  | [-TargetBitDepthChroma] | Target encoding bit-depth for chroma samples. May differ from source one. 0 mean default target bit-depth which is equal to source. <br>Example:<br>`./sample_encode h265 -i InputYUVFile_10_bit -o OutputEncodedFile_8_bit -w width -h height -lowpower:on -TargetBitDepthLuma 8 -TargetBitDepthChroma 8` |
 
 User module options:
 

--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -181,6 +181,8 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
   |-vpp_comp_dump <null_render\>| Disabling rendering after VPP Composition. This is for performance measurements|
   |-dec_postproc |Resize after decoder using direct pipe (should be used in decoder session)|
 | -single_texture_d3d11|  single texture mode for d3d11 allocator|
+| -TargetBitDepthLuma | Target encoding bit-depth for luma samples. May differ from source one. 0 mean default target bit-depth which is equal to source |
+| -TargetBitDepthChroma | Target encoding bit-depth for chroma samples. May differ from source one. 0 mean default target bit-depth which is equal to source. |
 
 #### stat logging:
 

--- a/samples/sample_common/src/parameters_dumper.cpp
+++ b/samples/sample_common/src/parameters_dumper.cpp
@@ -357,6 +357,10 @@ void CParametersDumper::SerializeExtensionBuffer(msdk_ostream& sstr,msdk_string 
             SERIALIZE_INFO(GPB);
             SERIALIZE_INFO(MaxFrameSizeI);
             SERIALIZE_INFO(MaxFrameSizeP);
+#if (MFX_VERSION >= 1027)
+            SERIALIZE_INFO(TargetBitDepthLuma);
+            SERIALIZE_INFO(TargetBitDepthChroma);
+#endif
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
             SERIALIZE_INFO(Log2MaxMvLengthHorizontal);
             SERIALIZE_INFO(Log2MaxMvLengthVertical);

--- a/samples/sample_encode/include/pipeline_encode.h
+++ b/samples/sample_encode/include/pipeline_encode.h
@@ -213,6 +213,8 @@ struct sInputParams
 
 #if (MFX_VERSION >= 1027)
     msdk_char *RoundingOffsetFile;
+    mfxU16 TargetBitDepthLuma;
+    mfxU16 TargetBitDepthChroma;
 #endif
     msdk_char DumpFileName[MSDK_MAX_FILENAME_LEN];
     msdk_char uSEI[MSDK_MAX_USER_DATA_UNREG_SEI_LEN];

--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -545,21 +545,6 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
     m_mfxEncParams.mfx.FrameInfo.PicStruct    = pInParams->nPicStruct;
     m_mfxEncParams.mfx.FrameInfo.Shift        = pInParams->shouldUseShifted10BitEnc;
 
-#if (MFX_VERSION >= 1027)
-    // set BitDepthLuma/BitDepthChroma in case of VME
-    if (!pInParams->enableQSVFF)
-    {
-        if (pInParams->TargetBitDepthLuma)
-        {
-            m_mfxEncParams.mfx.FrameInfo.BitDepthLuma = pInParams->TargetBitDepthLuma;
-        }
-        if (pInParams->TargetBitDepthChroma)
-        {
-            m_mfxEncParams.mfx.FrameInfo.BitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
-    }
-#endif
-
     // width must be a multiple of 16
     // height must be a multiple of 16 in case of frame picture and a multiple of 32 in case of field picture
     m_mfxEncParams.mfx.FrameInfo.Width  = MSDK_ALIGN16(pInParams->nDstWidth);
@@ -717,13 +702,12 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
 #endif
 
     // set up mfxCodingOption3
-	// VDEnc only support TargetBitDepthLuma/TargetBitDepthChroma
     if (pInParams->nGPB || pInParams->LowDelayBRC || pInParams->WeightedPred || pInParams->WeightedBiPred
         || pInParams->nPRefType || pInParams->IntRefCycleDist || pInParams->nAdaptiveMaxFrameSize
         || pInParams->nNumRefActiveP || pInParams->nNumRefActiveBL0 || pInParams->nNumRefActiveBL1
         || pInParams->ExtBrcAdaptiveLTR || pInParams->QVBRQuality || pInParams->WinBRCSize
 #if (MFX_VERSION >= 1027)
-        || ((pInParams->TargetBitDepthLuma || pInParams->TargetBitDepthChroma) && pInParams->enableQSVFF)
+        || pInParams->TargetBitDepthLuma || pInParams->TargetBitDepthChroma
 #endif
 #if (MFX_VERSION >= MFX_VERSION_NEXT)
         || pInParams->DeblockingAlphaTcOffset || pInParams->DeblockingBetaOffset
@@ -756,11 +740,8 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
 #endif
 
 #if (MFX_VERSION >= 1027)
-        if (pInParams->enableQSVFF)
-        {
-            codingOption3->TargetBitDepthLuma = pInParams->TargetBitDepthLuma;
-            codingOption3->TargetBitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
+        codingOption3->TargetBitDepthLuma = pInParams->TargetBitDepthLuma;
+        codingOption3->TargetBitDepthChroma = pInParams->TargetBitDepthChroma;
 #endif
         codingOption3->WinBRCSize = pInParams->WinBRCSize;
         codingOption3->WinBRCMaxAvgKbps = pInParams->WinBRCMaxAvgKbps;
@@ -879,21 +860,6 @@ mfxStatus CEncodingPipeline::InitMfxVppParams(sInputParams *pInParams)
     // Fill Shift bit
     m_mfxVppParams.vpp.In.Shift = pInParams->shouldUseShifted10BitVPP;
     m_mfxVppParams.vpp.Out.Shift = pInParams->shouldUseShifted10BitEnc; // This output should correspond to Encoder settings
-
-#if (MFX_VERSION >= 1027)
-    // Fill BitDepthLuma/BitDepthChroma in case of VME
-    if (!pInParams->enableQSVFF)
-    {
-        if (pInParams->TargetBitDepthLuma)
-        {
-            m_mfxVppParams.vpp.Out.BitDepthLuma = pInParams->TargetBitDepthLuma;
-        }
-        if (pInParams->TargetBitDepthChroma)
-        {
-            m_mfxVppParams.vpp.Out.BitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
-    }
-#endif
 
     // input frame info
 #if defined (ENABLE_V4L2_SUPPORT)
@@ -1772,14 +1738,10 @@ mfxStatus CEncodingPipeline::Init(sInputParams *pParams)
     }
 
     // create preprocessor if resizing was requested from command line
-    // or if different FourCC is set or if TargetBitDepthLuma/TargetBitDepthChroma set in VME
+    // or if different FourCC is set
     if (pParams->nWidth != pParams->nDstWidth ||
         pParams->nHeight != pParams->nDstHeight ||
-        FileFourCC2EncFourCC(pParams->FileInputFourCC) != pParams->EncodeFourCC
-#if (MFX_VERSION >= 1027)
-        || (!pParams->enableQSVFF && (pParams->TargetBitDepthLuma || pParams->TargetBitDepthChroma))
-#endif
-        )
+        FileFourCC2EncFourCC(pParams->FileInputFourCC) != pParams->EncodeFourCC)
     {
         bVpp = true;
         if (m_bIsFieldSplitting)

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -91,8 +91,8 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-num_active_BL0 numRefs] - number of maximum allowed references for B frames in L0 (for HEVC only)\n"));
     msdk_printf(MSDK_STRING("   [-num_active_BL1 numRefs] - number of maximum allowed references for B frames in L1 (for HEVC only)\n"));
 #if (MFX_VERSION >= 1027)
-    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
-    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one \n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one \n"));
 #endif
     msdk_printf(MSDK_STRING("   [-la] - use the look ahead bitrate control algorithm (LA BRC) (by default constant bitrate control method is used)\n"));
     msdk_printf(MSDK_STRING("           for H.264, H.265 encoder. Supported only with -hw option on 4th Generation Intel Core processors. \n"));

--- a/samples/sample_encode/src/sample_encode.cpp
+++ b/samples/sample_encode/src/sample_encode.cpp
@@ -90,6 +90,10 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage, ...)
     msdk_printf(MSDK_STRING("   [-num_active_P numRefs]   - number of maximum allowed references for P frames (for HEVC only)\n"));
     msdk_printf(MSDK_STRING("   [-num_active_BL0 numRefs] - number of maximum allowed references for B frames in L0 (for HEVC only)\n"));
     msdk_printf(MSDK_STRING("   [-num_active_BL1 numRefs] - number of maximum allowed references for B frames in L1 (for HEVC only)\n"));
+#if (MFX_VERSION >= 1027)
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+#endif
     msdk_printf(MSDK_STRING("   [-la] - use the look ahead bitrate control algorithm (LA BRC) (by default constant bitrate control method is used)\n"));
     msdk_printf(MSDK_STRING("           for H.264, H.265 encoder. Supported only with -hw option on 4th Generation Intel Core processors. \n"));
     msdk_printf(MSDK_STRING("           if [-icq] option is also enabled simultaneously, then LA_ICQ bitrate control algotithm will be used. \n"));
@@ -371,7 +375,29 @@ mfxStatus ParseAdditionalParams(msdk_char *strInput[], mfxU8 nArgNum, mfxU8& i, 
             PrintHelp(strInput[0], MSDK_STRING("overall fps is invalid"));
             return MFX_ERR_UNSUPPORTED;
         }
+	}
+#if (MFX_VERSION >= 1027)
+    else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-TargetBitDepthLuma")))
+    {
+        VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+
+        if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->TargetBitDepthLuma))
+        {
+            PrintHelp(strInput[0], MSDK_STRING("TargetBitDepthLuma is invalid"));
+            return MFX_ERR_UNSUPPORTED;
+        }
     }
+    else if (0 == msdk_strcmp(strInput[i], MSDK_STRING("-TargetBitDepthChroma")))
+    {
+        VAL_CHECK(i + 1 >= nArgNum, i, strInput[i]);
+
+        if (MFX_ERR_NONE != msdk_opt_read(strInput[++i], pParams->TargetBitDepthChroma))
+        {
+            PrintHelp(strInput[0], MSDK_STRING("TargetBitDepthChroma is invalid"));
+            return MFX_ERR_UNSUPPORTED;
+        }
+    }
+#endif
     else
     {
         return MFX_ERR_NOT_FOUND;

--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -348,6 +348,11 @@ namespace TranscodingSample
         mfxU32 mfeTimeout;
 #endif
 
+#if (MFX_VERSION >= 1027)
+        mfxU16 TargetBitDepthLuma;
+        mfxU16 TargetBitDepthChroma;
+#endif
+
 #if defined(LIBVA_WAYLAND_SUPPORT)
         mfxU16 nRenderWinX;
         mfxU16 nRenderWinY;

--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -2619,29 +2619,15 @@ MFX_IOPATTERN_IN_VIDEO_MEMORY : MFX_IOPATTERN_IN_SYSTEM_MEMORY);
         m_mfxEncParams.AddExtBuffer<mfxExtMVCSeqDesc>();
 
 #if (MFX_VERSION >= 1027)
-    // set TargetBitDepthLuma/TargetBitDepthChroma for VDEnc as mfxExtCodingOption3, for VME as BitDepthLuma/BitDepthChroma(converting will done with vpp)
-    if (pInParams->enableQSVFF)
+    if (pInParams->TargetBitDepthLuma)
     {
         auto co3 = m_mfxEncParams.AddExtBuffer<mfxExtCodingOption3>();
-        if (pInParams->TargetBitDepthLuma && pInParams->enableQSVFF)
-        {
-            co3->TargetBitDepthLuma = pInParams->TargetBitDepthLuma;
-        }
-        if (pInParams->TargetBitDepthChroma)
-        {
-            co3->TargetBitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
+        co3->TargetBitDepthLuma = pInParams->TargetBitDepthLuma;
     }
-    else
+    if (pInParams->TargetBitDepthChroma)
     {
-        if (pInParams->TargetBitDepthLuma)
-        {
-            m_mfxEncParams.mfx.FrameInfo.BitDepthLuma = pInParams->TargetBitDepthLuma;
-        }
-        if (pInParams->TargetBitDepthChroma)
-        {
-            m_mfxEncParams.mfx.FrameInfo.BitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
+        auto co3 = m_mfxEncParams.AddExtBuffer<mfxExtCodingOption3>();
+        co3->TargetBitDepthChroma = pInParams->TargetBitDepthChroma;
     }
 #endif
 
@@ -2973,21 +2959,6 @@ mfxStatus CTranscodingPipeline::InitVppMfxParams(sInputParams *pInParams)
         m_mfxVppParams.vpp.Out.Height = MSDK_ALIGN16(m_mfxVppParams.vpp.Out.CropH);
         m_mfxVppParams.vpp.Out.Width  = MSDK_ALIGN16(m_mfxVppParams.vpp.Out.CropW);
     }
-
-#if (MFX_VERSION >= 1027)
-    // set BitDepthLuma/BitDepthChroma as vpp.Out for VME
-    if (!pInParams->enableQSVFF)
-    {
-        if (pInParams->TargetBitDepthLuma)
-        {
-            m_mfxVppParams.vpp.Out.BitDepthLuma = pInParams->TargetBitDepthLuma;
-        }
-        if (pInParams->TargetBitDepthChroma)
-        {
-            m_mfxVppParams.vpp.Out.BitDepthChroma = pInParams->TargetBitDepthChroma;
-        }
-    }
-#endif
 
     // configure and attach external parameters
     mfxStatus sts = AllocAndInitVppDoNotUse(pInParams);

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -293,6 +293,10 @@ void TranscodingSample::PrintHelp()
 #endif
     msdk_printf(MSDK_STRING("  -DisableQPOffset         Disable QP adjustment for GOP pyramid-level frames\n"));
     msdk_printf(MSDK_STRING("  -lowpower:<on,off>       Turn this option ON to enable QuickSync Fixed Function (low-power HW) encoding mode\n"));
+#if (MFX_VERSION >= 1027)
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+#endif
 #if MFX_VERSION >= 1022
     msdk_printf(MSDK_STRING("  -roi_file <roi-file-name>\n"));
     msdk_printf(MSDK_STRING("                Set Regions of Interest for each frame from <roi-file-name>\n"));
@@ -1307,6 +1311,28 @@ mfxStatus ParseAdditionalParams(msdk_char *argv[], mfxU32 argc, mfxU32& i, Trans
     {
         InputParams.bUseOpaqueMemory = true;
     }
+#if (MFX_VERSION >= 1027)
+    else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-TargetBitDepthLuma")))
+    {
+        VAL_CHECK(i + 1 >= argc, i, argv[i]);
+
+        if (MFX_ERR_NONE != msdk_opt_read(argv[++i], InputParams.TargetBitDepthLuma))
+        {
+            PrintError(MSDK_STRING("TargetBitDepthLuma param is invalid"));
+            return MFX_ERR_UNSUPPORTED;
+        }
+    }
+    else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-TargetBitDepthChroma")))
+    {
+        VAL_CHECK(i + 1 >= argc, i, argv[i]);
+
+        if (MFX_ERR_NONE != msdk_opt_read(argv[++i], InputParams.TargetBitDepthChroma))
+        {
+            PrintError(MSDK_STRING("TargetBitDepthChroma param is invalid"));
+            return MFX_ERR_UNSUPPORTED;
+        }
+    }
+#endif
     else
     {
         // no matching argument was found

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -294,8 +294,8 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("  -DisableQPOffset         Disable QP adjustment for GOP pyramid-level frames\n"));
     msdk_printf(MSDK_STRING("  -lowpower:<on,off>       Turn this option ON to enable QuickSync Fixed Function (low-power HW) encoding mode\n"));
 #if (MFX_VERSION >= 1027)
-    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
-    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one. (for VME is not supported and will be converted with vpp) \n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthLuma] - Encoding target bit depth for luma samples, by default same as source one.\n"));
+    msdk_printf(MSDK_STRING("   [-TargetBitDepthChroma] - Encoding target bit depth for chroma samples, by default same as source one.\n"));
 #endif
 #if MFX_VERSION >= 1022
     msdk_printf(MSDK_STRING("  -roi_file <roi-file-name>\n"));


### PR DESCRIPTION
Issue: MDP-66051
Test: manually

Usage examples:

sample_encode.exe:
VPP based bit-depth conversion (the conversion will be done due to the different forсс):
h265 -i Cactus_ProRes_1280x720_50f.p010.yuv -o out.hevc -w 1280 -h 720  -lowpower:off -p010 -ec::nv12
Encoder internal bit-depth conversion:
h265 -i Cactus_ProRes_1280x720_50f.p010.yuv -o out.hevc -w 1280 -h 720  -lowpower:on -TargetBitDepthLuma 8 -TargetBitDepthChroma 8 -p010


sample_multi_transcode.exe:
VPP based bit-depth conversion (the conversion will be done due to the different forсс):
-i::h265 off.hevc -f 60 -h 720 -lowpower:off -n 10  -w 1280 -hw_d3d11 -o::h265 out_out_off.h265 -ec::nv12 -dc::p010
Encoder internal bit-depth conversion:
-i::h265 on.hevc -f 60 -w 1280 -h 720 -lowpower:on -n 10 -hw_d3d11 -o::h265 out_out_on.h265 -TargetBitDepthLuma 8 -TargetBitDepthChroma 8
