### PR TITLE
Introduce API 1.35

### DIFF
--- a/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h264/src/mfx_h264_dec_decode.cpp
@@ -454,7 +454,7 @@ mfxStatus VideoDECODEH264::Init(mfxVideoParam *par)
 
     umcVideoParams.lpMemoryAllocator = &m_MemoryAllocator;
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
     umcVideoParams.m_ignore_level_constrain = par->mfx.IgnoreLevelConstrain;
 #endif
 

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -23,6 +23,10 @@
 
 #include "mfxdefs.h"
 
+#ifndef MFX_DEPRECATED_OFF
+#define MFX_DEPRECATED_OFF
+#endif
+
 #ifdef MFX_VA
     #if defined(LINUX32) || defined(LINUX64)
         #include <va/va_version.h>

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_dec.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_dec.h
@@ -85,13 +85,13 @@ public:
         H264_LEVEL_51   = 51,
         H264_LEVEL_52   = 52,
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         H264_LEVEL_6    = 60,
         H264_LEVEL_61   = 61,
         H264_LEVEL_62   = 62,
 #endif
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         H264_LEVEL_MAX  = 62,
 #else
         H264_LEVEL_MAX  = 52,

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -725,7 +725,7 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         case H264VideoDecoderParams::H264_LEVEL_52:
             MaxDPBMbs = 184320;
             break;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:
@@ -793,14 +793,14 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         // can be used to calculate the DPB size.
         case H264VideoDecoderParams::H264_LEVEL_51:
         case H264VideoDecoderParams::H264_LEVEL_52:
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
             level_idc = H264VideoDecoderParams::H264_LEVEL_6;
 #else
             level_idc = INTERNAL_MAX_LEVEL;
 #endif
             break;
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_bitstream_headers.cpp
@@ -337,7 +337,7 @@ H264HeadersBitstream::H264HeadersBitstream(uint8_t * const pb, const uint32_t ma
 
 inline bool CheckLevel(uint8_t level_idc, bool ignore_level_constrain = false)
 {
-#if (MFX_VERSION < MFX_VERSION_NEXT)
+#if (MFX_VERSION < 1035)
     std::ignore = ignore_level_constrain;
 #endif
 
@@ -367,7 +367,7 @@ inline bool CheckLevel(uint8_t level_idc, bool ignore_level_constrain = false)
     case H264VideoDecoderParams::H264_LEVEL_9:
         return true;
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
     case H264VideoDecoderParams::H264_LEVEL_6:
     case H264VideoDecoderParams::H264_LEVEL_61:
     case H264VideoDecoderParams::H264_LEVEL_62:

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
@@ -928,7 +928,7 @@ UMC::Status MFX_Utility::DecodeHeader(UMC::TaskSupplier * supplier, UMC::H264Vid
     if (!lpInfo->m_pData->GetDataSize())
         return UMC::UMC_ERR_NOT_ENOUGH_DATA;
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
     lpInfo->m_ignore_level_constrain = out->mfx.IgnoreLevelConstrain;
 #endif
     umcRes = supplier->PreInit(lpInfo);
@@ -1087,7 +1087,7 @@ mfxStatus MFX_Utility::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *
 
         }
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         out->mfx.IgnoreLevelConstrain = in->mfx.IgnoreLevelConstrain;
 #endif
 
@@ -1111,7 +1111,7 @@ mfxStatus MFX_Utility::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *
         case MFX_LEVEL_AVC_5:
         case MFX_LEVEL_AVC_51:
         case MFX_LEVEL_AVC_52:
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
         case MFX_LEVEL_AVC_6:
         case MFX_LEVEL_AVC_61:
         case MFX_LEVEL_AVC_62:
@@ -1339,7 +1339,7 @@ mfxStatus MFX_Utility::Query(VideoCORE *core, mfxVideoParam *in, mfxVideoParam *
                     case MFX_LEVEL_AVC_5:
                     case MFX_LEVEL_AVC_51:
                     case MFX_LEVEL_AVC_52:
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
                     case MFX_LEVEL_AVC_6:
                     case MFX_LEVEL_AVC_61:
                     case MFX_LEVEL_AVC_62:

--- a/api/include/mfxaudio.h
+++ b/api/include/mfxaudio.h
@@ -32,26 +32,26 @@ extern "C"
 #endif
 
 /* AudioCORE */
-mfxStatus MFX_CDECL MFXAudioCORE_SyncOperation(mfxSession session, mfxSyncPoint syncp, mfxU32 wait);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioCORE_SyncOperation(mfxSession session, mfxSyncPoint syncp, mfxU32 wait);
 
 /* AudioENCODE */
-mfxStatus MFX_CDECL MFXAudioENCODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
-mfxStatus MFX_CDECL MFXAudioENCODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
-mfxStatus MFX_CDECL MFXAudioENCODE_Init(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_Reset(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_Close(mfxSession session);
-mfxStatus MFX_CDECL MFXAudioENCODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_EncodeFrameAsync(mfxSession session, mfxAudioFrame *frame, mfxBitstream *bs, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Init(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Reset(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_EncodeFrameAsync(mfxSession session, mfxAudioFrame *frame, mfxBitstream *bs, mfxSyncPoint *syncp);
 
 /* AudioDECODE */
-mfxStatus MFX_CDECL MFXAudioDECODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
-mfxStatus MFX_CDECL MFXAudioDECODE_DecodeHeader(mfxSession session, mfxBitstream *bs, mfxAudioParam* par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Init(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Reset(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Close(mfxSession session);
-mfxStatus MFX_CDECL MFXAudioDECODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
-mfxStatus MFX_CDECL MFXAudioDECODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream *bs, mfxAudioFrame *frame, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_DecodeHeader(mfxSession session, mfxBitstream *bs, mfxAudioParam* par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Init(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Reset(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream *bs, mfxAudioFrame *frame, mfxSyncPoint *syncp);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/api/include/mfxdefs.h
+++ b/api/include/mfxdefs.h
@@ -21,7 +21,7 @@
 #define __MFXDEFS_H__
 
 #define MFX_VERSION_MAJOR 1
-#define MFX_VERSION_MINOR 34
+#define MFX_VERSION_MINOR 35
 
 // MFX_VERSION_NEXT is always +1 from last public release
 // may be enforced by MFX_VERSION_USE_LATEST define
@@ -102,6 +102,52 @@ extern "C"
 #endif /* _WIN32 */
 
 #define MFX_INFINITE 0xFFFFFFFF
+
+#if !defined(MFX_DEPRECATED_OFF) && (MFX_VERSION >= 1034)
+#define MFX_DEPRECATED_OFF
+#endif
+
+#ifndef MFX_DEPRECATED_OFF
+  #if defined(__cplusplus) && __cplusplus >= 201402L
+    #define MFX_DEPRECATED [[deprecated]]
+    #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg [[deprecated]]
+    #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+  #elif defined(__clang__)
+    #define MFX_DEPRECATED __attribute__((deprecated))
+    #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg __attribute__((deprecated))
+    #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+  #elif defined(__INTEL_COMPILER)
+    #if (defined(_WIN32) || defined(_WIN64))
+      #define MFX_DEPRECATED __declspec(deprecated)
+      #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg
+      #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg) __pragma(deprecated(arg))
+    #elif defined(__linux__)
+      #define MFX_DEPRECATED __attribute__((deprecated))
+      #if defined(__cplusplus)
+        #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg __attribute__((deprecated))
+      #else
+        #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg
+      #endif
+      #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+    #endif
+  #elif defined(_MSC_VER) && _MSC_VER > 1200 // VS 6 doesn't support deprecation
+    #define MFX_DEPRECATED __declspec(deprecated)
+    #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg
+    #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg) __pragma(deprecated(arg))
+  #elif defined(__GNUC__)
+    #define MFX_DEPRECATED __attribute__((deprecated))
+    #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg __attribute__((deprecated))
+    #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+  #else
+    #define MFX_DEPRECATED
+    #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg
+    #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+  #endif
+#else
+  #define MFX_DEPRECATED
+  #define MFX_DEPRECATED_ENUM_FIELD_INSIDE(arg) arg
+  #define MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(arg)
+#endif
 
 typedef unsigned char       mfxU8;
 typedef char                mfxI8;

--- a/api/include/mfxenc.h
+++ b/api/include/mfxenc.h
@@ -55,15 +55,15 @@ typedef struct _mfxENCOutput{
 MFX_PACK_END()
 
 
-mfxStatus MFX_CDECL MFXVideoENC_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
-mfxStatus MFX_CDECL MFXVideoENC_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest *request);
-mfxStatus MFX_CDECL MFXVideoENC_Init(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoENC_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Init(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Close(mfxSession session);
 
-mfxStatus MFX_CDECL MFXVideoENC_ProcessFrameAsync(mfxSession session, mfxENCInput *in, mfxENCOutput *out, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_ProcessFrameAsync(mfxSession session, mfxENCInput *in, mfxENCOutput *out, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoENC_GetVideoParam(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_GetVideoParam(mfxSession session, mfxVideoParam *par);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/api/include/mfxfei.h
+++ b/api/include/mfxfei.h
@@ -29,7 +29,7 @@ extern "C"
 #endif /* __cplusplus */
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16    Qp;
@@ -61,7 +61,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc; /* size of allocated memory in number of macroblocks */
@@ -74,7 +74,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -87,7 +87,7 @@ MFX_PACK_END()
 /* PreENC output */
 /* Layout is exactly the same as mfxExtFeiEncMVs, this buffer may be removed in future */
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -100,7 +100,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -131,7 +131,7 @@ MFX_PACK_END()
 
 /* 1  ENC_PAK input */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16    SearchPath;
@@ -160,7 +160,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -178,7 +178,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -222,7 +222,7 @@ For example, MV for right top 4x4 sub block is stored in 5-th element of the arr
 ========================
 */
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -235,7 +235,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -257,7 +257,7 @@ enum {
 };
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     /* dword 0-2 */
     mfxU32    Header;  /* MFX_PAK_OBJECT_HEADER */
     mfxU32    MVDataLength;
@@ -330,7 +330,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -341,7 +341,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32      MaxFrameSize; /* in bytes */
     mfxU32      NumPasses;    /* up to 8 */
@@ -353,7 +353,7 @@ MFX_PACK_END()
 #if (MFX_VERSION >= 1025)
 /* FEI repack status */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32          NumPasses;
     mfxU16          reserved[58];
@@ -433,7 +433,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32  reserved1[3];
     mfxU32  NumMBAlloc;
@@ -447,7 +447,7 @@ MFX_PACK_END()
 
 /* SPS, PPS, Slice Header */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16    SPSId;
@@ -459,7 +459,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16    SPSId;
@@ -486,7 +486,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16    NumSlice; /* actual number of slices in the picture */
@@ -521,7 +521,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16  DisableHME;  /* 0 - enable, any other value means disable */
@@ -567,7 +567,7 @@ enum {
 
 /* should be attached to mfxVideoParam during initialization to indicate FEI function */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxFeiFunction  Func;
     mfxU16  SingleFieldProcessing;

--- a/api/include/mfxfeihevc.h
+++ b/api/include/mfxfeihevc.h
@@ -29,7 +29,7 @@ extern "C"
 #if (MFX_VERSION >= 1027)
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
 
     mfxU16  SearchPath;
@@ -70,7 +70,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer  Header;
     mfxU32        VaBufferID;
     mfxU32        Pitch;
@@ -82,7 +82,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer  Header;
     mfxU32        VaBufferID;
     mfxU32        Pitch;
@@ -104,7 +104,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
     mfxU32  VaBufferID;
     mfxU32  Pitch;
@@ -116,7 +116,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32      MaxFrameSize; /* in bytes */
     mfxU32      NumPasses;    /* up to 8 */
@@ -126,7 +126,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32          NumPasses;
     mfxU16          reserved[58];
@@ -162,7 +162,7 @@ typedef struct  {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer  Header;
     mfxU32        VaBufferID;
     mfxU32        Pitch;
@@ -233,7 +233,7 @@ typedef struct  {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer  Header;
     mfxU32        VaBufferID;
     mfxU32        Pitch;
@@ -252,7 +252,7 @@ typedef struct {
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer  Header;
     mfxU32        VaBufferID;
     mfxU32        Pitch;

--- a/api/include/mfxpak.h
+++ b/api/include/mfxpak.h
@@ -60,15 +60,15 @@ typedef struct {
 MFX_PACK_END()
 
 typedef struct _mfxSession *mfxSession;
-mfxStatus MFX_CDECL MFXVideoPAK_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
-mfxStatus MFX_CDECL MFXVideoPAK_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest request[2]);
-mfxStatus MFX_CDECL MFXVideoPAK_Init(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoPAK_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest request[2]);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Init(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Close(mfxSession session);
 
-mfxStatus MFX_CDECL MFXVideoPAK_ProcessFrameAsync(mfxSession session, mfxPAKInput *in, mfxPAKOutput *out,  mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_ProcessFrameAsync(mfxSession session, mfxPAKInput *in, mfxPAKOutput *out,  mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoPAK_GetVideoParam(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_GetVideoParam(mfxSession session, mfxVideoParam *par);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/api/include/mfxplugin.h
+++ b/api/include/mfxplugin.h
@@ -193,21 +193,21 @@ typedef struct mfxPlugin{
 MFX_PACK_END()
 
 
-mfxStatus MFX_CDECL MFXVideoUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
-mfxStatus MFX_CDECL MFXVideoUSER_Unregister(mfxSession session, mfxU32 type);
-mfxStatus MFX_CDECL MFXVideoUSER_GetPlugin(mfxSession session, mfxU32 type, mfxPlugin *par);
-mfxStatus MFX_CDECL MFXVideoUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Unregister(mfxSession session, mfxU32 type);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_GetPlugin(mfxSession session, mfxU32 type, mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
-mfxStatus MFX_CDECL MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, mfxU32 version, const mfxChar *path, mfxU32 len);
-mfxStatus MFX_CDECL MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, mfxU32 version, const mfxChar *path, mfxU32 len);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
 
-mfxStatus MFX_CDECL MFXAudioUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
-mfxStatus MFX_CDECL MFXAudioUSER_Unregister(mfxSession session, mfxU32 type);
-mfxStatus MFX_CDECL MFXAudioUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Unregister(mfxSession session, mfxU32 type);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
-mfxStatus MFX_CDECL MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/api/include/mfxsession.h
+++ b/api/include/mfxsession.h
@@ -40,7 +40,7 @@ mfxStatus MFX_CDECL MFXDisjoinSession(mfxSession session);
 mfxStatus MFX_CDECL MFXCloneSession(mfxSession session, mfxSession *clone);
 mfxStatus MFX_CDECL MFXSetPriority(mfxSession session, mfxPriority priority);
 mfxStatus MFX_CDECL MFXGetPriority(mfxSession session, mfxPriority *priority);
-mfxStatus MFX_CDECL MFXDoWork(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXDoWork(mfxSession session);
 
 #ifdef __cplusplus
 }

--- a/api/include/mfxstructures.h
+++ b/api/include/mfxstructures.h
@@ -389,11 +389,14 @@ MFX_PACK_END()
 enum {
     MFX_IOPATTERN_IN_VIDEO_MEMORY   = 0x01,
     MFX_IOPATTERN_IN_SYSTEM_MEMORY  = 0x02,
-    MFX_IOPATTERN_IN_OPAQUE_MEMORY  = 0x04,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_IOPATTERN_IN_OPAQUE_MEMORY)  = 0x04,
     MFX_IOPATTERN_OUT_VIDEO_MEMORY  = 0x10,
     MFX_IOPATTERN_OUT_SYSTEM_MEMORY = 0x20,
-    MFX_IOPATTERN_OUT_OPAQUE_MEMORY = 0x40
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_IOPATTERN_OUT_OPAQUE_MEMORY) = 0x40
 };
+
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_IOPATTERN_IN_OPAQUE_MEMORY);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_IOPATTERN_OUT_OPAQUE_MEMORY);
 
 /* CodecId */
 enum {
@@ -447,7 +450,7 @@ enum {
     MFX_LEVEL_AVC_5                         =50,
     MFX_LEVEL_AVC_51                        =51,
     MFX_LEVEL_AVC_52                        =52,
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
+#if (MFX_VERSION >= 1035)
     MFX_LEVEL_AVC_6                         =60,
     MFX_LEVEL_AVC_61                        =61,
     MFX_LEVEL_AVC_62                        =62,
@@ -1133,7 +1136,7 @@ enum {
 
     MFX_MEMTYPE_INTERNAL_FRAME  = 0x0001,
     MFX_MEMTYPE_EXTERNAL_FRAME  = 0x0002,
-    MFX_MEMTYPE_OPAQUE_FRAME    = 0x0004,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_MEMTYPE_OPAQUE_FRAME)    = 0x0004,
     MFX_MEMTYPE_EXPORT_FRAME    = 0x0008,
     MFX_MEMTYPE_SHARED_RESOURCE = MFX_MEMTYPE_EXPORT_FRAME,
 #if (MFX_VERSION >= 1025)
@@ -1142,6 +1145,8 @@ enum {
     MFX_MEMTYPE_RESERVED2       = 0x1000
 #endif
 };
+
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_MEMTYPE_OPAQUE_FRAME);
 
 MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
@@ -2302,7 +2307,7 @@ enum {
 
 /* Multi-Frame Initialization parameters */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
 
     mfxU16      MFMode;
@@ -2314,7 +2319,7 @@ MFX_PACK_END()
 
 /* Multi-Frame Run-time controls */
 MFX_PACK_BEGIN_USUAL_STRUCT()
-typedef struct {
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
 
     mfxU32      Timeout;      /* timeout in millisecond */

--- a/api/include/mfxvideo++.h
+++ b/api/include/mfxvideo++.h
@@ -49,7 +49,7 @@ public:
     virtual mfxStatus SetPriority( mfxPriority priority) { return MFXSetPriority(m_session, priority);}
     virtual mfxStatus GetPriority( mfxPriority *priority) { return MFXGetPriority(m_session, priority);}
 
-    virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator) { return MFXVideoCORE_SetBufferAllocator(m_session, allocator); }
+    MFX_DEPRECATED virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator) { return MFXVideoCORE_SetBufferAllocator(m_session, allocator); }
     virtual mfxStatus SetFrameAllocator(mfxFrameAllocator *allocator) { return MFXVideoCORE_SetFrameAllocator(m_session, allocator); }
     virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl) { return MFXVideoCORE_SetHandle(m_session, type, hdl); }
     virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *hdl) { return MFXVideoCORE_GetHandle(m_session, type, hdl); }

--- a/api/include/mfxvideo.h
+++ b/api/include/mfxvideo.h
@@ -53,7 +53,7 @@ typedef struct {
 MFX_PACK_END()
 
 /* VideoCORE */
-mfxStatus MFX_CDECL MFXVideoCORE_SetBufferAllocator(mfxSession session, mfxBufferAllocator *allocator);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoCORE_SetBufferAllocator(mfxSession session, mfxBufferAllocator *allocator);
 mfxStatus MFX_CDECL MFXVideoCORE_SetFrameAllocator(mfxSession session, mfxFrameAllocator *allocator);
 mfxStatus MFX_CDECL MFXVideoCORE_SetHandle(mfxSession session, mfxHandleType type, mfxHDL hdl);
 mfxStatus MFX_CDECL MFXVideoCORE_GetHandle(mfxSession session, mfxHandleType type, mfxHDL *hdl);
@@ -95,7 +95,7 @@ mfxStatus MFX_CDECL MFXVideoVPP_Close(mfxSession session);
 mfxStatus MFX_CDECL MFXVideoVPP_GetVideoParam(mfxSession session, mfxVideoParam *par);
 mfxStatus MFX_CDECL MFXVideoVPP_GetVPPStat(mfxSession session, mfxVPPStat *stat);
 mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsync(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp);
-mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/api/mfx_dispatch/linux/CMakeLists.txt
+++ b/api/mfx_dispatch/linux/CMakeLists.txt
@@ -57,6 +57,7 @@ add_definitions( -DMFX_MODULES_DIR="${MFX_MODULES_DIR}" )
 message( STATUS "MFX_MODULES_DIR=${MFX_MODULES_DIR}" )
 
 add_definitions(-DUNIX)
+add_definitions(-DMFX_DEPRECATED_OFF)
 
 if( CMAKE_SYSTEM_NAME MATCHES Linux )
   add_definitions(-D__USE_LARGEFILE64 -D_FILE_OFFSET_BITS=64 -DLINUX -DLINUX32)

--- a/api/mfx_dispatch/windows/libmfx_vs2015.vcxproj
+++ b/api/mfx_dispatch/windows/libmfx_vs2015.vcxproj
@@ -143,7 +143,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;MFX_VA;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;MFX_VA;MFX_DEPRECATED_OFF;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
@@ -180,7 +180,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;MFX_VA;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;MFX_VA;MFX_DEPRECATED_OFF;_ALLOW_MSC_VER_MISMATCH;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_ALLOW_RUNTIME_LIBRARY_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>

--- a/doc/MFE-Overview.md
+++ b/doc/MFE-Overview.md
@@ -306,8 +306,10 @@ Encoder initialization changes
 
 Extended buffers added:
 
-`mfxExtMultiFrameParams`
+`mfxExtMultiFrameParam`
 ----------------------
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 *Definition:*
 ```
@@ -321,7 +323,7 @@ Extended buffers added:
 
      mfxU16      reserved[58];
 
- } mfxExtMultiFrameParams;
+ } mfxExtMultiFrameParam;
 ```
 *Description:*
 
@@ -359,6 +361,8 @@ Frame Management
 ================
 
 New structure added
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 *Definition:*
 ```

--- a/doc/header-template.md
+++ b/doc/header-template.md
@@ -1,7 +1,7 @@
 ![](./pic/intel_logo.png)
 
 #**Title**
-Media SDK API Version 1.34
+Media SDK API Version 1.35
 
 <div style="page-break-before:always" />
 

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -1,7 +1,7 @@
 ﻿![](./pic/intel_logo.png)
 
 # **Media SDK Developer Reference**
-## Media SDK API Version 1.34
+## Media SDK API Version 1.35
 
 <div style="page-break-before:always" />
 
@@ -315,7 +315,9 @@ Notice revision #20110804
 
 Intel® Media Software Development Kit – SDK, further referred to as the SDK, is a software development library that exposes the media acceleration capabilities of Intel platforms for decoding, encoding and video processing. The API library covers a wide range of Intel platforms.
 
-This document describes the SDK API.
+This document describes the SDK API. 
+
+SDK version 1.35 supposed to be last in 1.xx series. Successor API is oneVPL https://docs.oneapi.com/versions/latest/onevpl/index.html
 
 ## Document Conventions
 
@@ -1745,6 +1747,8 @@ This function is available since SDK API 1.0.
 
 ### <a id='MFXDoWork'>MFXDoWork</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 [mfxStatus](#mfxStatus) `MFXDoWork(mfxSession session);`
@@ -2084,6 +2088,8 @@ This function obtains system handles previously set by the [MFXVideoCORE_SetHand
 This function is available since SDK API 1.0.
 
 ### <a id='MFXVideoCORE_SetBufferAllocator'>MFXVideoCORE_SetBufferAllocator</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -7791,6 +7797,8 @@ This structure is available since SDK API 1.24.
 
 ## <a id='mfxExtMultiFrameParam'>mfxExtMultiFrameParam</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -7822,6 +7830,8 @@ Multi Frame submission will gather frames from several [joined](#MFXJoinSession)
 This structure is available since SDK API 1.25.
 
 ## <a id='mfxExtMultiFrameControl'>mfxExtMultiFrameControl</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -8309,7 +8319,7 @@ SDK API 1.8 added HEVC level and tier definitions.
 
 SDK API 1.34 added AV1 level definitions.
 
-SDK API **TBD** added H.264 level 6-6.2 definitions.
+SDK API 1.35 added H.264 level 6-6.2 definitions.
 
 ## <a id='CodecProfile'>CodecProfile</a>
 
@@ -8737,10 +8747,10 @@ The `IOPattern` enumerator itemizes memory access patterns for SDK functions. Us
 --- | ---
 `MFX_IOPATTERN_IN_VIDEO_MEMORY` | Input to SDK functions is a video memory surface
 `MFX_IOPATTERN_IN_SYSTEM_MEMORY` | Input to SDK functions is a linear buffer directly in system memory or in system memory through an external allocator
-`MFX_IOPATTERN_IN_OPAQUE_MEMORY` | Input to SDK functions maps at runtime to either a system memory buffer or a video memory surface.
+`MFX_IOPATTERN_IN_OPAQUE_MEMORY` | Input to SDK functions maps at runtime to either a system memory buffer or a video memory surface. *Deprecated in 1.35 and removed starting from 2.0*
 `MFX_IOPATTERN_OUT_VIDEO_MEMORY` | Output to SDK functions is a video memory surface
 `MFX_IOPATTERN_OUT_SYSTEM_MEMORY` | Output to SDK functions is a linear buffer directly in system memory or in system memory through an external allocator
-`MFX_IOPATTERN_OUT_OPAQUE_MEMORY` | Output to SDK functions maps at runtime to either a system memory buffer or a video memory surface.
+`MFX_IOPATTERN_OUT_OPAQUE_MEMORY` | Output to SDK functions maps at runtime to either a system memory buffer or a video memory surface. *Deprecated in 1.35 and removed starting from 2.0*
 
 **Change History**
 

--- a/doc/mediasdkfei-man.md
+++ b/doc/mediasdkfei-man.md
@@ -400,6 +400,8 @@ In each function description, only commonly used status codes are documented. Th
 
 ## MFXVideoENC_Init
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```
@@ -428,6 +430,8 @@ This function initializes **ENC** class of functions. [mfxFeiFunction](#mfxFeiFu
 This function is available since SDK API 1.9.
 
 ## MFXVideoENC_Reset
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -458,6 +462,8 @@ This function is available since SDK API 1.9.
 
 ## MFXVideoENC_Close
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```
@@ -485,6 +491,8 @@ This function closes **ENC** class of functions.
 This function is available since SDK API 1.9.
 
 ## <a id='MFXVideoENC_ProcessFrameAsync'>MFXVideoENC_ProcessFrameAsync</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -522,6 +530,8 @@ This function is available since SDK API 1.9.
 
 ## <a id='MFXVideoPAK_QueryIOSurf'>MFXVideoPAK_QueryIOSurf</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 `mfxStatus MFXVideoPAK_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest request[2]);`
@@ -555,6 +565,8 @@ This function is available since SDK API 1.23.
 
 ## MFXVideoPAK_Init
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```
@@ -584,6 +596,8 @@ The function initializes **PAK** class of functions. [mfxFeiFunction](#mfxFeiFun
 This function is available since SDK API 1.9.
 
 ## MFXVideoPAK_Reset
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -617,6 +631,8 @@ This function is available since SDK API 1.9.
 
 ## MFXVideoPAK_Close
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```
@@ -644,6 +660,8 @@ The function closes **PAK** class of functions.
 This function is available since SDK API 1.9.
 
 ## <a id='MFXVideoPAK_ProcessFrameAsync'>MFXVideoPAK_ProcessFrameAsync</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -681,6 +699,8 @@ This function is available since SDK API 1.9.
 In the following structures all reserved fields must be zero.
 
 ## <a id='mfxExtFeiPreEncCtrl'>mfxExtFeiPreEncCtrl</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -761,6 +781,8 @@ This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiPreEncMVPredictors'>mfxExtFeiPreEncMVPredictors</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -798,6 +820,8 @@ This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiEncQP'>mfxExtFeiEncQP</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -832,6 +856,8 @@ This structure is available since SDK API 1.9.
 SDK API 1.23 renames `NumQPAlloc` and `QP` fields to `NumMBAlloc` and `MB` respectively.
 
 ## <a id='mfxExtFeiPreEncMV'>mfxExtFeiPreEncMV</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -868,6 +894,9 @@ This structure is used during runtime and should be attached to the [mfxENCOutpu
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiPreEncMBStat'>mfxExtFeiPreEncMBStat</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -927,6 +956,8 @@ This structure is used during runtime and should be attached to the [mfxENCOutpu
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiEncFrameCtrl'>mfxExtFeiEncFrameCtrl</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -997,6 +1028,8 @@ This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiEncMVPredictors'>mfxExtFeiEncMVPredictors</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -1039,6 +1072,8 @@ This structure is used during runtime and should be attached to the **mfxEncodeC
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiEncMBCtrl'>mfxExtFeiEncMBCtrl</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -1097,6 +1132,8 @@ SDK API 1.23 adds `DirectBiasAdjustment, GlobalMotionBiasAdjustment` and `MVCost
 
 ## <a id='mfxExtFeiEncMV'>mfxExtFeiEncMV</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -1130,6 +1167,8 @@ This extension buffer holds output MVs for ENCODE and ENC usage models and input
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiEncMBStat'>mfxExtFeiEncMBStat</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -1172,6 +1211,8 @@ This extension buffer holds output MB statistics for ENCODE and ENC usage models
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiPakMBCtrl'>mfxExtFeiPakMBCtrl</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -1308,6 +1349,8 @@ This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiSPS'>mfxExtFeiSPS</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```C
@@ -1342,6 +1385,8 @@ See the ISO*/IEC* 14496-10 specification for more information on SPS parameters 
 This structure is available since SDK API 1.9.
 
 ## <a id='mfxExtFeiPPS'>mfxExtFeiPPS</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -1407,6 +1452,8 @@ This structure is available since SDK API 1.9.
 The SDK API 1.23 adds `FrameType`,`DpbBefore`,`DpbAfter` fields and removes `ReferenceFrames` field.
 
 ## <a id='mfxExtFeiSliceHeader'>mfxExtFeiSliceHeader</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 
@@ -1481,6 +1528,8 @@ See the ISO*/IEC* 14496-10 specification for more information on slice parameter
 This structure is available since SDK API 1.9.
 
 ## mfxExtFeiParam
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 

--- a/doc/mediasdkhevcfei-man.md
+++ b/doc/mediasdkhevcfei-man.md
@@ -153,6 +153,8 @@ In the following structures all reserved fields must be zeroed by application if
 
 ## <a id='mfxExtFeiHevcEncFrameCtrl'>mfxExtFeiHevcEncFrameCtrl</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```
@@ -213,6 +215,9 @@ This structure is available since SDK API 1.27
 
 
 ## <a id='mfxExtFeiHevcEncMVPredictors'>mfxExtFeiHevcEncMVPredictors</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```
@@ -306,6 +311,8 @@ This structure is available since SDK API 1.27
 
 ## <a id='mfxExtFeiHevcEncQP'>mfxExtFeiHevcEncQP</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```
@@ -364,6 +371,8 @@ This structure is available since SDK API 1.27
 
 ## <a id='mfxExtFeiHevcEncCtuCtrl'>mfxExtFeiHevcEncCtuCtrl</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```
@@ -410,6 +419,8 @@ This structure is available since SDK API 1.27
 
 ## <a id='mfxExtFeiHevcRepackCtrl'>mfxExtFeiHevcRepackCtrl</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Definition**
 
 ```
@@ -441,6 +452,8 @@ This structure is available since SDK API 1.27.
 
 
 ## <a id='mfxExtFeiHevcRepackStat'>mfxExtFeiHevcRepackStat</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Definition**
 

--- a/doc/mediasdkusr-man.md
+++ b/doc/mediasdkusr-man.md
@@ -450,6 +450,8 @@ This class of functions allows applications to specify user-defined functions to
 
 ### <a id='MFXVideoUSER_ProcessFrameAsync'>MFXVideoUSER_ProcessFrameAsync</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```C
@@ -481,6 +483,8 @@ This asynchronous function calls back the user-defined functions to generate out
 This function is available since SDK API 1.1.
 
 ### <a id='MFXVideoUSER_Register'>MFXVideoUSER_Register</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -514,6 +518,8 @@ SDK API 1.8 extends functionality and allows registering of codec plug-ins. Befo
 
 ### <a id='MFXVideoUSER_Unregister'>MFXVideoUSER_Unregister</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```C
@@ -545,6 +551,8 @@ The application must call this function after all active tasks are completed.
 This function is available since SDK API 1.1.
 
 ### <a id='MFXVideoUSER_Load'>MFXVideoUSER_Load</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -582,6 +590,8 @@ See [Plug-in Distribution](#plugin_distribution) for more details on how the SDK
 This function is available since SDK API 1.8.
 
 ### <a id='MFXVideoUSER_LoadByPath'>MFXVideoUSER_LoadByPath</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 
@@ -623,6 +633,8 @@ This function is available since SDK API 1.13.
 
 ### <a id='MFXVideoUSER_UnLoad'>MFXVideoUSER_UnLoad</a>
 
+*Deprecated in 1.35 and removed starting from 2.0*
+
 **Syntax**
 
 ```C
@@ -651,6 +663,8 @@ The function unloads plug-in. Function does not check if plug-in has any task in
 This function is available since SDK API 1.8.
 
 ### <a id='MFXVideoUSER_GetPlugin'>MFXVideoUSER_GetPlugin</a>
+
+*Deprecated in 1.35 and removed starting from 2.0*
 
 **Syntax**
 

--- a/doc/samples/readme-decode_linux.md
+++ b/doc/samples/readme-decode_linux.md
@@ -62,6 +62,7 @@ The following command-line switches are optional:
  |  [-d]| enable decode error report|
    |[-jpeg_rgb] |RGB Chroma Type|
    |[-device /path/to/device]| set graphics device for processing. For example: `-device /dev/dri/renderD128`. If not specified, defaults to the first Intel device found on the system. |
+  | [-ignore_level_constrain] | ignore level constrain (AVC) |
 |Output format parameters:||
  |  [-i420] | pipeline output format: NV12, output file format: I420|
   | [-nv12] | pipeline output format: NV12, output file format: NV12|

--- a/samples/sample_common/props/winsdk_win32.props
+++ b/samples/sample_common/props/winsdk_win32.props
@@ -4,7 +4,7 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MfxDefinitions>NOMINMAX;</MfxDefinitions>
+    <MfxDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;</MfxDefinitions>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/samples/sample_common/props/winsdk_x64.props
+++ b/samples/sample_common/props/winsdk_x64.props
@@ -4,7 +4,7 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MfxDefinitions>NOMINMAX;</MfxDefinitions>
+    <MfxDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;</MfxDefinitions>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/samples/sample_decode/sample_decode.vcxproj
+++ b/samples/sample_decode/sample_decode.vcxproj
@@ -94,7 +94,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)\include;$(ProjectDir)\..\..\api\include;$(INTELMEDIASDKROOT)\include;$(ProjectDir)\..\sample_common\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;_WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;_WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -122,7 +122,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)\include;$(ProjectDir)\..\..\api\include;$(INTELMEDIASDKROOT)\include;$(ProjectDir)\..\sample_common\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;_WIN64;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;_WIN64;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -146,7 +146,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)\include;$(ProjectDir)\..\..\api\include;$(INTELMEDIASDKROOT)\include;$(ProjectDir)\..\sample_common\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;_WIN32;WIN32;NDEBUG;_CONSOLE;SAVE_RECON;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;_WIN32;WIN32;NDEBUG;_CONSOLE;SAVE_RECON;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -177,7 +177,7 @@
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)\include;$(ProjectDir)\..\..\api\include;$(INTELMEDIASDKROOT)\include;$(ProjectDir)\..\sample_common\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;WIN64;NDEBUG;_CONSOLE;SAVE_RECON;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;MFX_DEPRECATED_OFF;WIN64;NDEBUG;_CONSOLE;SAVE_RECON;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/samples/sample_decode/src/sample_decode.cpp
+++ b/samples/sample_decode/src/sample_decode.cpp
@@ -73,7 +73,7 @@ void PrintHelp(msdk_char *strAppName, const msdk_char *strErrorMessage)
     msdk_printf(MSDK_STRING("                                              '-device /dev/dri/renderD128'\n"));
     msdk_printf(MSDK_STRING("                                 If not specified, defaults to the first Intel device found on the system\n"));
 #endif
-#if (MFX_VERSION >= MFX_VERSION_NEXT)   
+#if (MFX_VERSION >= 1035)   
     msdk_printf(MSDK_STRING("   [-ignore_level_constrain] - ignore level constrain\n"));
 #endif
     msdk_printf(MSDK_STRING("   [-disable_film_grain] - disable film grain application(valid only for av1)\n"));

--- a/tools/asg-hevc/asg-hevc.vcxproj
+++ b/tools/asg-hevc/asg-hevc.vcxproj
@@ -84,7 +84,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN32;WIN32;_DEBUG;NOMINMAX; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN32;WIN32;_DEBUG;NOMINMAX;MFX_DEPRECATED_OFF; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -101,7 +101,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN32;WIN32;NDEBUG;NOMINMAX; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN32;WIN32;NDEBUG;NOMINMAX;MFX_DEPRECATED_OFF; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -131,7 +131,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN64;WIN64;_DEBUG;NOMINMAX; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN64;WIN64;_DEBUG;NOMINMAX;MFX_DEPRECATED_OFF; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -150,7 +150,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN64;WIN64;NDEBUG;NOMINMAX; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MFX_VERSION_USE_LATEST;_WIN64;WIN64;NDEBUG;NOMINMAX;MFX_DEPRECATED_OFF; _UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>

--- a/tools/tracer/CMakeLists.txt
+++ b/tools/tracer/CMakeLists.txt
@@ -71,6 +71,7 @@ set_target_properties(mfx-tracer PROPERTIES   VERSION ${mfx_version_major}.${mfx
 set_target_properties(mfx-tracer PROPERTIES SOVERSION ${mfx_version_major})
 
 target_link_libraries( mfx-tracer ${CMAKE_DL_LIBS})
+target_compile_options(mfx-tracer PRIVATE -Wno-deprecated-declarations)
 
 install(TARGETS mfx-tracer LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Add MFX_DEPRECATED and add deprecation attributes in API headers
Add AVC 6-6.2 levels

closes: #2612

Co-authored-by: Oleg Nabiullin <oleg.nabiullin@intel.com>