### PR TITLE
[hevce] Disable bit depth conversion

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -2569,6 +2569,14 @@ public:
         CheckBD(pCO3->TargetBitDepthLuma == 10);
 
         MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
+
+        auto&  fi = par.mfx.FrameInfo;
+        mfxU32 changed = 0;
+        changed += pCO3->TargetBitDepthLuma && SetIf(pCO3->TargetBitDepthLuma, !IsOn(par.mfx.LowPower) && pCO3->TargetBitDepthLuma != fi.BitDepthLuma, 0);
+        changed += pCO3->TargetBitDepthChroma && SetIf(pCO3->TargetBitDepthChroma, !IsOn(par.mfx.LowPower) && pCO3->TargetBitDepthChroma != fi.BitDepthChroma, 0);
+
+        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
+
         return MFX_ERR_NONE;
     }
 


### PR DESCRIPTION
VME driver doesn't support 10b->8b and 8b->10b conversions.

Issue: MDP-65185
Test: manually