### PR TITLE
Inherit AdaptiveMaxFrameSize from init to reset

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -5303,6 +5303,7 @@ void MfxHwH264Encode::InheritDefaultValues(
 
     InheritOption(extOptInit.NalHrdConformance,         extOptReset.NalHrdConformance);
     InheritOption(extOpt3Init.LowDelayBRC,              extOpt3Reset.LowDelayBRC);
+    InheritOption(extOpt3Init.AdaptiveMaxFrameSize,     extOpt3Reset.AdaptiveMaxFrameSize);
     InheritOption(parInit.mfx.RateControlMethod,        parReset.mfx.RateControlMethod);
     InheritOption(parInit.mfx.FrameInfo.FrameRateExtN,  parReset.mfx.FrameInfo.FrameRateExtN);
     InheritOption(parInit.mfx.FrameInfo.FrameRateExtD,  parReset.mfx.FrameInfo.FrameRateExtD);


### PR DESCRIPTION
AdaptiveMaxFrameSize should be inherited from init to reset