### PR TITLE
Revert "[hevce] Disable bit depth conversion"

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -2568,14 +2568,6 @@ public:
         CheckBD(pCO3->TargetBitDepthLuma == 10);
 
         MFX_CHECK(!invalid, MFX_ERR_UNSUPPORTED);
-
-        auto&  fi = par.mfx.FrameInfo;
-        mfxU32 changed = 0;
-        changed += pCO3->TargetBitDepthLuma && SetIf(pCO3->TargetBitDepthLuma, !IsOn(par.mfx.LowPower) && pCO3->TargetBitDepthLuma != fi.BitDepthLuma, 0);
-        changed += pCO3->TargetBitDepthChroma && SetIf(pCO3->TargetBitDepthChroma, !IsOn(par.mfx.LowPower) && pCO3->TargetBitDepthChroma != fi.BitDepthChroma, 0);
-
-        MFX_CHECK(!changed, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
-
         return MFX_ERR_NONE;
     }
 


### PR DESCRIPTION
Reverts Intel-Media-SDK/MediaSDK#2635 because internal beh_hevce_sei_hdr-plugin_hevcehw test fails 