### PR TITLE
Move default memType for win from d3d9 to d3d11

### DIFF
--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -72,7 +72,7 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
  |-i::i420\|nv12 <file-name>| Set raw input file and color format|
   |-i::rgb4_frame | Set input rgb4 file for compositon. File should contain just one single frame (-vpp_comp_src_h and -vpp_comp_src_w should be specified as well).|
  | -o::h265\|h264\|mpeg2\|mvc\|jpeg\|vp9\|raw <file-name>|  Set output file and encoder type|
- | -sw\|-hw\|-hw_d3d11| SDK implementation to use:<br>-hw - platform-specific on default display adapter (default)<br>-hw_d3d11 - platform-specific via d3d11<br>-sw - software|
+ | -sw\|-hw\|-hw_d3d11\|-hw_d3d9 SDK implementation to use:<br>-hw - platform-specific on default display adapter (default)<br>-hw_d3d11 - platform-specific via d3d11 <br>-hw_d3d9 - platform-specific via d3d9<br>-sw - software|
  | -mfe_frames| <N> maximum number of frames to be combined in multi-frame encode pipeline               0 - default for platform will be used|
   |-mfe_mode 0\|1\|2\|3| multi-frame encode operation mode - should be the same for all sessions<br>0, MFE operates as DEFAULT mode, decided by SDK if MFE enabled<br>1, MFE is disabled<br>2, MFE operates as AUTO mode<br>3, MFE operates as MANUAL mode|
   |-mfe_timeout <N\> | multi-frame encode timeout in milliseconds - set per sessions control|

--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -268,7 +268,7 @@ mfxStatus CDecodingPipeline::GetImpl(const sInputParams & params, mfxIMPL & impl
     // If d3d11 surfaces are used ask the library to run acceleration through D3D11
     // feature may be unsupported due to OS or MSDK API version
 
-    if (D3D11_MEMORY == params.memType)
+    if (D3D11_MEMORY == params.memType || D3D11_MEMORY == m_memType)
         impl |= MFX_IMPL_VIA_D3D11;
 
     return MFX_ERR_NONE;
@@ -348,7 +348,11 @@ mfxStatus CDecodingPipeline::Init(sInputParams *pParams)
         switch (pParams->mode)
         {
         case MODE_PERFORMANCE:
-            m_memType = pParams->bUseHWLib? D3D9_MEMORY : SYSTEM_MEMORY;
+#if defined(_WIN32) || defined(_WIN64)
+            m_memType = pParams->bUseHWLib ? D3D11_MEMORY : SYSTEM_MEMORY;
+#elif defined(LIBVA_SUPPORT)
+            m_memType = pParams->bUseHWLib ? D3D9_MEMORY : SYSTEM_MEMORY;
+#endif
             break;
         case MODE_RENDERING:
             m_memType = D3D9_MEMORY;

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -136,10 +136,11 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("  -i::rgb4_frame Set input rgb4 file for compositon. File should contain just one single frame (-vpp_comp_src_h and -vpp_comp_src_w should be specified as well).\n"));
     msdk_printf(MSDK_STRING("  -o::h265|h264|mpeg2|mvc|jpeg|vp9|raw <file-name>\n"));
     msdk_printf(MSDK_STRING("                Set output file and encoder type\n"));
-    msdk_printf(MSDK_STRING("  -sw|-hw|-hw_d3d11\n"));
+    msdk_printf(MSDK_STRING("  -sw|-hw|-hw_d3d11|-hw_d3d9\n"));
     msdk_printf(MSDK_STRING("                SDK implementation to use: \n"));
     msdk_printf(MSDK_STRING("                      -hw - platform-specific on default display adapter (default)\n"));
-    msdk_printf(MSDK_STRING("                      -hw_d3d11 - platform-specific via d3d11\n"));
+    msdk_printf(MSDK_STRING("                      -hw_d3d11 - platform-specific via d3d11 (d3d11 is default for win)\n"));
+    msdk_printf(MSDK_STRING("                      -hw_d3d9 - platform-specific via d3d9\n"));
     msdk_printf(MSDK_STRING("                      -sw - software\n"));
 #if defined(LINUX32) || defined(LINUX64)
     msdk_printf(MSDK_STRING("   -device /path/to/device - set graphics device for processing\n"));
@@ -1551,6 +1552,9 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
     }
     // default implementation
     InputParams.libType = MFX_IMPL_HARDWARE_ANY;
+#if defined(_WIN32) || defined(_WIN64)
+    InputParams.libType = MFX_IMPL_HARDWARE_ANY | MFX_IMPL_VIA_D3D11;
+#endif
     InputParams.bUseOpaqueMemory = false;
     InputParams.eModeExt = Native;
 
@@ -1674,11 +1678,19 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
         }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-hw")))
         {
+#if defined(_WIN32) || defined(_WIN64)
+            InputParams.libType = MFX_IMPL_HARDWARE_ANY | MFX_IMPL_VIA_D3D11;
+#elif defined(LIBVA_SUPPORT)
             InputParams.libType = MFX_IMPL_HARDWARE_ANY;
+#endif
         }
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-hw_d3d11")))
         {
             InputParams.libType = MFX_IMPL_HARDWARE_ANY | MFX_IMPL_VIA_D3D11;
+        }
+        else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-hw_d3d9")))
+        {
+            InputParams.libType = MFX_IMPL_HARDWARE_ANY | MFX_IMPL_VIA_D3D9;
         }
 #if (defined(LINUX32) || defined(LINUX64))
         else if (0 == msdk_strcmp(argv[i], MSDK_STRING("-device")))


### PR DESCRIPTION
Issue: None
Test: manually

Note: there where the system memory was by default, it remained as is