### PR TITLE
Don't try to autheticate with render node

### DIFF
--- a/samples/sample_misc/wayland/src/class_wayland.cpp
+++ b/samples/sample_misc/wayland/src/class_wayland.cpp
@@ -433,8 +433,12 @@ void Wayland::DrmHandleDevice(const char *name)
             m_device_name << "\n";
         return;
     }
-    drmGetMagic(m_fd, &magic);
-    wl_drm_authenticate(m_drm, magic);
+
+    int type = drmGetNodeTypeFromFd(m_fd);
+    if (type != DRM_NODE_RENDER) {
+        drmGetMagic(m_fd, &magic);
+        wl_drm_authenticate(m_drm, magic);
+    }
 }
 
 void Wayland::DrmHandleAuthenticated()


### PR DESCRIPTION
Replicate similar libVA wayland change.
https://github.com/intel/libva/commit/283f776a9649dcef58b47958c1269499adfa1cd4

Platform: ADL-S, EHL, TGL
OS: Yocto native wayland weston
Tested:
    ./sample_decode h265 -i Puppies_3840x2160.265 -rwld -rgb4

Issue: #2592

Signed-off-by: Cheah, Vincent Beng Keat <vincent.beng.keat.cheah@intel.com>