### PR TITLE
[jpegd] Improve processing of invalid headers

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -410,7 +410,12 @@ mfxStatus VideoDECODEMJPEG::DecodeHeader(VideoCORE *core, mfxBitstream *bs, mfxV
 {
     MFX_CHECK_NULL_PTR2(bs, par);
 
-    MFX_SAFE_CALL(CheckBitstream(bs));
+    mfxStatus sts = CheckBitstream(bs);
+    if (sts != MFX_ERR_NONE)
+    {
+        MFX_CHECK_INIT(sts == MFX_ERR_NULL_PTR);
+        MFX_RETURN(MFX_ERR_NULL_PTR);
+    }
 
     MFXMediaDataAdapter in(bs);
 
@@ -430,39 +435,29 @@ mfxStatus VideoDECODEMJPEG::DecodeHeader(VideoCORE *core, mfxBitstream *bs, mfxV
     umcVideoParams.lpMemoryAllocator = &tempAllocator;
 
     UMC::Status umcRes = decoder.Init(&umcVideoParams);
-    if (umcRes != UMC::UMC_OK)
-    {
-        return ConvertUMCStatusToMfx(umcRes);
-    }
+    MFX_CHECK_INIT(umcRes == UMC::UMC_OK);
 
     umcRes = decoder.DecodeHeader(&in);
 
     in.Save(bs);
 
-    if (umcRes == UMC::UMC_ERR_NOT_ENOUGH_DATA)
-        return MFX_ERR_MORE_DATA;
-
-    if (umcRes != UMC::UMC_OK)
-        return ConvertUMCStatusToMfx(umcRes);
+    MFX_CHECK_INIT(umcRes == UMC::UMC_OK);
 
     mfxVideoParam temp;
 
     umcRes = decoder.FillVideoParam(&temp, false);
-    if (umcRes != UMC::UMC_OK)
-        return ConvertUMCStatusToMfx(umcRes);
+    MFX_CHECK_INIT(umcRes == UMC::UMC_OK);
 
     if(jpegQT)
     {
         umcRes = decoder.FillQuantTableExtBuf(jpegQT);
-        if (umcRes != UMC::UMC_OK)
-            return ConvertUMCStatusToMfx(umcRes);
+        MFX_CHECK_INIT(umcRes == UMC::UMC_OK);
     }
 
     if(jpegHT)
     {
         umcRes = decoder.FillHuffmanTableExtBuf(jpegHT);
-        if (umcRes != UMC::UMC_OK)
-            return ConvertUMCStatusToMfx(umcRes);
+        MFX_CHECK_INIT(umcRes == UMC::UMC_OK);
     }
 
     decoder.Close();

--- a/_studio/shared/umc/codec/jpeg_dec/include/umc_mjpeg_mfx_decode_base.h
+++ b/_studio/shared/umc/codec/jpeg_dec/include/umc_mjpeg_mfx_decode_base.h
@@ -63,8 +63,6 @@ public:
     // Close decoding & free all allocated resources
     virtual Status Close(void);
 
-    ChromaType GetChromaType();
-
     virtual Status GetFrame(UMC::MediaDataEx *, UMC::FrameData** , const mfxU32  ) { return MFX_ERR_NONE; };
 
     virtual void SetFrameAllocator(FrameAllocator * frameAllocator);
@@ -87,7 +85,8 @@ public:
 
 protected:
 
-    JCOLOR GetColorType();
+    std::pair<JCOLOR, Status> GetColorType();
+    std::pair<ChromaType, Status> GetChromaType();
     virtual void AdjustFrameSize(mfxSize & size);
     // Allocate the destination frame
     virtual Status AllocateFrame() { return MFX_ERR_NONE; };
@@ -99,9 +98,9 @@ protected:
 
     FrameData               m_frameData;
     JCOLOR                  m_color;
-    uint16_t                  m_rotation;
+    uint16_t                m_rotation;
 
-    mfxSize                m_frameDims;
+    mfxSize                 m_frameDims;
     int                     m_frameSampling;
 
     // JPEG decoders allocated


### PR DESCRIPTION
1) Invalid input produces error codes, not asserts.
2) DecodeHeader() to use documented return status.