### PR TITLE
[jpegd] Skip searching segment mark among JM-SOS according to the length

### DIFF
--- a/_studio/shared/umc/codec/jpeg_dec/src/umc_jpeg_frame_constructor.cpp
+++ b/_studio/shared/umc/codec/jpeg_dec/src/umc_jpeg_frame_constructor.cpp
@@ -239,8 +239,6 @@ int32_t JpegFrameConstructor::GetMarker(MediaData * pSource, MediaData * pDst)
     case JM_EOI:
     case JM_TEM:
         break;
-    case JM_SOS:
-        break;
     default:   // marker's segment.
         {
             if (size >= 2)


### PR DESCRIPTION
This is to fix a potetial issue when decoding fuzzer clip, if OxFF exists in
SOS segment, will cause calculation error, lead to incorrect memcpy call