### PR TITLE
[Jpegd]JPEG RGB444 support HW decode on Linux

### DIFF
--- a/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/mjpeg/src/mfx_mjpeg_dec_decode.cpp
@@ -1060,11 +1060,13 @@ bool MFX_JPEG_Utility::IsNeedPartialAcceleration(VideoCORE * core, mfxVideoParam
         switch (par->mfx.FrameInfo.FourCC)
         {
             case MFX_FOURCC_NV12:
-                if (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
+                if ((par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_YCbCr &&
                         (par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV420  ||
                          par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV422H ||
                          par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV422V ||
-                         par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444 ))
+                         par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444 )) ||
+                    (par->mfx.JPEGColorFormat == MFX_JPEG_COLORFORMAT_RGB &&
+                        par->mfx.JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444))                  
                     return false;
                 else
                     return true;
@@ -1776,6 +1778,14 @@ void VideoDECODEMJPEGBase_HW::AdjustFourCC(mfxFrameInfo *requestFrameInfo, const
             VM_ASSERT(false);
             break;
         }
+    }
+    else if(info->JPEGColorFormat == MFX_JPEG_COLORFORMAT_RGB)
+    {
+        if(info->JPEGChromaFormat == MFX_CHROMAFORMAT_YUV444 && info->Rotation == MFX_ROTATION_0)
+        {
+            requestFrameInfo->FourCC = MFX_FOURCC_RGBP;
+            *needVpp = true;
+        }  
     }
 }
 

--- a/_studio/shared/src/libmfx_allocator_vaapi.cpp
+++ b/_studio/shared/src/libmfx_allocator_vaapi.cpp
@@ -148,6 +148,11 @@ static void FillSurfaceAttrs(std::vector<VASurfaceAttrib> &attrib, unsigned int 
             break;
         case MFX_FOURCC_RGBP:
             format = VA_RT_FORMAT_RGBP;
+            attrib.resize(attrib.size()+1);
+            attrib[1].type            = VASurfaceAttribUsageHint;
+            attrib[1].flags           = VA_SURFACE_ATTRIB_SETTABLE;
+            attrib[1].value.type      = VAGenericValueTypeInteger;
+            attrib[1].value.value.i   = VA_SURFACE_ATTRIB_USAGE_HINT_DECODER;           
             break;
         case MFX_FOURCC_RGB4:
         case MFX_FOURCC_BGR4:


### PR DESCRIPTION
Modify JPEG RGB444 from partial acceleration to hardware
acceleration decode

Cmd:./sample_decode jpeg -i /home/gta/IMG_0425.bmp_RGB_444_100.jpg -o test.yuv -hw
Issue: MDP-66601
Test: manually