### PR TITLE
[hevce/swbrc] Fix the skipping of second fields

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_impl.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Intel Corporation
+// Copyright (c) 2019-2021 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -171,6 +171,7 @@ mfxStatus MFXVideoENCODEH265_HW::Init(mfxVideoParam *par)
 #endif
         //update slice qp before packing
         Reorder(queue, { FEATURE_PACKER, Packer::BLK_SubmitTask }, { FEATURE_EXT_BRC, ExtBRC::BLK_GetFrameCtrl });
+        Reorder(queue, { FEATURE_LEGACY, Legacy::BLK_SkipFrame }, { FEATURE_INTERLACE, Interlace::BLK_SkipFrame });
     }
 
     {
@@ -182,6 +183,10 @@ mfxStatus MFXVideoENCODEH265_HW::Init(mfxVideoParam *par)
             , { FEATURE_DDI_PACKER, IDDIPacker::BLK_QueryTask }
             , { FEATURE_EXT_BRC, ExtBRC::BLK_Update }
             , PLACE_AFTER);
+        Reorder(queue
+            , { FEATURE_EXT_BRC, ExtBRC::BLK_Update }
+            , { FEATURE_INTERLACE, Interlace::BLK_QueryTask }
+        , PLACE_AFTER);
     }
 
     return wrn;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_interlace.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_interlace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Intel Corporation
+// Copyright (c) 2019-2021 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,8 @@ namespace Base
     DECL_BLOCK(PatchRawInfo)\
     DECL_BLOCK(PrepareTask)\
     DECL_BLOCK(InsertPTSEI)\
+    DECL_BLOCK(SkipFrame)\
+    DECL_BLOCK(QueryTask)\
     DECL_BLOCK(PatchDDITask)\
     DECL_BLOCK(QueryIOSurf)
 #define DECL_FEATURE_NAME "Base_Interlace"
@@ -56,11 +58,13 @@ namespace Base
         virtual void QueryIOSurf(const FeatureBlocks& blocks, TPushQIS Push) override;
         virtual void InitInternal(const FeatureBlocks& blocks, TPushII Push) override;
         virtual void SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
+        virtual void QueryTask(const FeatureBlocks& /*blocks*/, TPushST Push) override;
 
         static bool IsField(mfxU16 PicStruct) { return  !!(PicStruct & MFX_PICSTRUCT_FIELD_SINGLE); }
         static bool IsBFF(mfxU16 PicStruct) { return !!(PicStruct & MFX_PICSTRUCT_FIELD_BFF); }
 
         std::array<mfxU8, 32> m_buf;
+        bool m_b2ndFieldRecode = false;
     };
 
 } //Base

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -1723,7 +1723,7 @@ void Legacy::SubmitTask(const FeatureBlocks& /*blocks*/, TPushST Push)
         }
 
         auto& core = Glob::VideoCore::Get(global);
-        bool  bL1  = (IsB(task.FrameType) && !task.isLDB && task.NumRefActive[1]);
+        bool  bL1  = (IsB(task.FrameType) && !task.isLDB && task.NumRefActive[1] && !task.b2ndField);
         auto  idx  = task.RefPicList[bL1][0];
 
         mfxFrameSurface1 surfSrc = {};


### PR DESCRIPTION
When the 1st field is skipped the 2nd one must be skipped too.
In this case the 2nd field should take the 1st one as a reference.

Issue: MDP-62788
Tested: manual