### PR TITLE
[HEVCd] Added HDR SEI info parsing for HEVC decoding

### DIFF
--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -1384,6 +1384,26 @@ void VideoDECODEH265::FillOutputSurface(mfxFrameSurface1 **surf_out, mfxFrameSur
             info->FrameType |= MFX_FRAMETYPE_REF;
    }
 
+    mfxExtMasteringDisplayColourVolume* dispaly_colour = (mfxExtMasteringDisplayColourVolume*)GetExtendedBuffer(surface_out->Data.ExtParam, surface_out->Data.NumExtParam, MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME);
+    if (dispaly_colour && pFrame->m_mastering_display.payLoadSize > 0)
+    {
+        for (size_t i = 0; i < 3; i++)
+        {
+            dispaly_colour->DisplayPrimariesX[i] = (mfxU16)pFrame->m_mastering_display.SEI_messages.mastering_display.display_primaries[i][0];
+            dispaly_colour->DisplayPrimariesY[i] = (mfxU16)pFrame->m_mastering_display.SEI_messages.mastering_display.display_primaries[i][1];
+        }
+        dispaly_colour->WhitePointX = (mfxU16)pFrame->m_mastering_display.SEI_messages.mastering_display.white_point[0];
+        dispaly_colour->WhitePointY = (mfxU16)pFrame->m_mastering_display.SEI_messages.mastering_display.white_point[1];
+        dispaly_colour->MaxDisplayMasteringLuminance = (mfxU32)pFrame->m_mastering_display.SEI_messages.mastering_display.max_luminance;
+        dispaly_colour->MinDisplayMasteringLuminance = (mfxU32)pFrame->m_mastering_display.SEI_messages.mastering_display.min_luminance;
+    }
+    mfxExtContentLightLevelInfo* content_light = (mfxExtContentLightLevelInfo*)GetExtendedBuffer(surface_out->Data.ExtParam, surface_out->Data.NumExtParam, MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO);
+    if (content_light && pFrame->m_content_light_level_info.payLoadSize > 0)
+    {
+        content_light->MaxContentLightLevel = (mfxU16)pFrame->m_content_light_level_info.SEI_messages.content_light_level_info.max_content_light_level;
+        content_light->MaxPicAverageLightLevel = (mfxU16)pFrame->m_content_light_level_info.SEI_messages.content_light_level_info.max_pic_average_light_level;
+    }
+
 }
 
 // Wait until a frame is ready to be output and set necessary surface flags

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
@@ -351,6 +351,10 @@ protected:
     int32_t pic_timing(const HeaderSet<H265SeqParamSet> & sps, int32_t current_sps, H265SEIPayLoad *spl);
     // Parse recovery point SEI data
     int32_t recovery_point(const HeaderSet<H265SeqParamSet> & sps, int32_t current_sps, H265SEIPayLoad *spl);
+    // Parse mastering display colour volume SEI data
+    int32_t mastering_display_colour_volume(const HeaderSet<H265SeqParamSet>& sps, int32_t current_sps, H265SEIPayLoad* spl);
+    // Parse content light level info SEI data
+    int32_t content_light_level_info(const HeaderSet<H265SeqParamSet>& sps, int32_t current_sps, H265SEIPayLoad* spl);
 
     // Skip unrecognized SEI message payload
     int32_t reserved_sei_message(const HeaderSet<H265SeqParamSet> & sps, int32_t current_sps, H265SEIPayLoad *spl);

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
@@ -328,6 +328,7 @@ typedef enum
     SEI_KNEE_FUNCTION_INFO                          = 141,
     SEI_COLOUR_REMAPPING_INFO                       = 142,
     SEI_DEINTERLACED_FIELD_IDENTIFICATION           = 143,
+    SEI_CONTENT_LIGHT_LEVEL_INFO                    = 144,
 
     SEI_LAYERS_NOT_PRESENT                          = 160,
     SEI_INTER_LAYER_CONSTRAINED_TILE_SETS           = 161,
@@ -1294,6 +1295,19 @@ struct H265SEIPayLoadBase
             uint8_t exact_match_flag;
             uint8_t broken_link_flag;
         }recovery_point;
+
+        struct MasteringDisplay
+        {
+            uint16_t display_primaries[3][2];
+            uint16_t white_point[2];
+            uint32_t max_luminance;
+            uint32_t min_luminance;
+        }mastering_display;
+
+        struct ContentLightLevelInfo {
+            uint16_t max_content_light_level;
+            uint16_t max_pic_average_light_level;
+        }content_light_level_info;
 
     }SEI_messages;
 

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_frame.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_frame.h
@@ -102,6 +102,8 @@ public:
     H265DecoderFrame *m_pFutureFrame;
 
     H265SEIPayLoad m_UserData;
+    H265SEIPayLoad m_mastering_display;
+    H265SEIPayLoad m_content_light_level_info;
 
     double           m_dFrameTime;
     bool             m_isOriginalPTS;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -2531,16 +2531,27 @@ H265DecoderFrame * TaskSupplier_H265::AllocateNewFrame(const H265Slice *pSlice)
         m_sei_messages->SetFrame(pFrame);
     }
 
-    H265SEIPayLoad * payload = m_Headers.m_SEIParams.GetHeader(SEI_PIC_TIMING_TYPE);
-    if (payload && pSlice->GetSeqParam()->frame_field_info_present_flag)
+    H265SEIPayLoad * pic_timing_payload = m_Headers.m_SEIParams.GetHeader(SEI_PIC_TIMING_TYPE);
+    if (pic_timing_payload && pSlice->GetSeqParam()->frame_field_info_present_flag)
     {
-        pFrame->m_DisplayPictureStruct_H265 = payload->SEI_messages.pic_timing.pic_struct;
+        pFrame->m_DisplayPictureStruct_H265 = pic_timing_payload->SEI_messages.pic_timing.pic_struct;
     }
     else
     {
         pFrame->m_DisplayPictureStruct_H265 = DPS_FRAME_H265;
     }
 
+    H265SEIPayLoad * mastering_display_payload = m_Headers.m_SEIParams.GetHeader(SEI_MASTERING_DISPLAY_COLOUR_VOLUME);
+    H265SEIPayLoad * content_light_payload = m_Headers.m_SEIParams.GetHeader(SEI_CONTENT_LIGHT_LEVEL_INFO);
+
+    if (mastering_display_payload)
+    {
+        pFrame->m_mastering_display = *mastering_display_payload;
+    }
+    if (content_light_payload)
+    {
+        pFrame->m_content_light_level_info = *content_light_payload;
+    }
 
     InitFrameCounter(pFrame, pSlice);
     return pFrame;


### PR DESCRIPTION
For #2597 

Attach the **MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME**  and **MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO** to outputSurface when you need this info for HEVC HDR transfer.

``` 
     mfxFrameSurface1& surf;
    // Mastering Display Colour Volume SEI info
    mfxExtMasteringDisplayColourVolume* pExtPar_MasteringDisplay = new mfxExtMasteringDisplayColourVolume{};
    pExtPar_MasteringDisplay->Header.BufferId = MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME;
    pExtPar_MasteringDisplay->Header.BufferSz = sizeof(mfxExtMasteringDisplayColourVolume);
    
    // Mastering Content Light Level info
    mfxExtContentLightLevelInfo* pExtPar_ContentLight = new mfxExtContentLightLevelInfo{};
    pExtPar_ContentLight->Header.BufferId = MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO;
    pExtPar_ContentLight->Header.BufferSz = sizeof(mfxExtContentLightLevelInfo);

    surf.Data.ExtParam[0] = reinterpret_cast<mfxExtBuffer*>(pExtPar_MasteringDisplay);
    surf.Data.ExtParam[1] = reinterpret_cast<mfxExtBuffer*>(pExtPar_ContentLight);
```