### PR TITLE
[VPP] Fix increasing num of input channels doesn't work

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -5869,17 +5869,16 @@ mfxStatus ConfigureExecuteParams(
                         mfxExtVPPComposite* extComp = (mfxExtVPPComposite*) videoParam.ExtParam[i];
                         StreamCount = extComp->NumInputStream;
 
-                        if (!executeParams.dstRects.empty())
+                        if (executeParams.dstRects.empty())
                         {
-                            if (executeParams.dstRects.size() < StreamCount)
-                                return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM;
+                            executeParams.initialStreamNum = StreamCount;
                         }
+                        else
+                        {
+                            MFX_CHECK(StreamCount <= executeParams.initialStreamNum, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+                        }
+                        executeParams.dstRects.resize(StreamCount);
 
-                        if (executeParams.dstRects.size() != StreamCount)
-                        {
-                            executeParams.dstRects.clear();
-                            executeParams.dstRects.resize(StreamCount);
-                        }
 #if MFX_VERSION > 1023
                         executeParams.iTilesNum4Comp = extComp->NumTiles;
 #endif

--- a/_studio/shared/include/mfx_vpp_interface.h
+++ b/_studio/shared/include/mfx_vpp_interface.h
@@ -286,6 +286,7 @@ namespace MfxHwVideoProcessing
                ,iBackgroundColor(0)
                ,iTilesNum4Comp(0)
                ,execIdx(NO_INDEX)
+               ,initialStreamNum(0)
                ,statusReportID(0)
                ,bFieldWeaving(false)
                ,iFieldProcessingMode(0)
@@ -413,6 +414,7 @@ namespace MfxHwVideoProcessing
         mfxU64         iBackgroundColor;
         mfxU32         iTilesNum4Comp;
         mfxU32         execIdx; //index call of execute for current frame, actual for composition
+        mfxU32         initialStreamNum;
 
         mfxU32         statusReportID;
 


### PR DESCRIPTION
Fix: https://github.com/Intel-Media-SDK/MediaSDK/issues/2721

Number of input composite layers can be dynamically changed at runtime, but should not exceed the initial counts.
Signed off by: jay.yang@intel.com