### PR TITLE
Fix the name for oneVPL RT on Linux

### DIFF
--- a/api/mfx_dispatch/linux/mfxloader.cpp
+++ b/api/mfx_dispatch/linux/mfxloader.cpp
@@ -46,7 +46,7 @@ namespace MFX {
     #else
         #define LIBMFXSW "libmfxsw32.so.1"
         #define LIBMFXHW "libmfxhw32.so.1"
-        #define ONEVPLRT "libmfx-gen.so.1"
+        #define ONEVPLRT "libmfx-gen.so"
     #endif
 #elif defined(__x86_64__)
     #ifdef ANDROID
@@ -55,7 +55,7 @@ namespace MFX {
     #else
         #define LIBMFXSW "libmfxsw64.so.1"
         #define LIBMFXHW "libmfxhw64.so.1"
-        #define ONEVPLRT "libmfx-gen.so.1"
+        #define ONEVPLRT "libmfx-gen.so"
     #endif
 #else
     #error Unsupported architecture

--- a/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
+++ b/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
@@ -85,7 +85,7 @@ TEST_P(DispatcherLibsTestParametrized, ShouldEnumerateCorrectLibNames)
 #elif defined(__x86_64__)
     const std::string LIBMFXSW("libmfxsw64.so.1");
     const std::string LIBMFXHW("libmfxhw64.so.1");
-    const std::string ONEVPLRT("libmfx-gen.so.1");
+    const std::string ONEVPLRT("libmfx-gen.so");
 #endif
 
     std::string modules_dir(MFX_MODULES_DIR);


### PR DESCRIPTION
There isn't libmfx-gen.so.1 when building the library from
https://github.com/oneapi-src/oneVPL-intel-gpu

Install the project...
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "Debug"
-- Up-to-date: /usr/lib/x86_64-linux-gnu/libmfx-gen.so.1.2.3
-- Up-to-date: /usr/lib/x86_64-linux-gnu/libmfx-gen.so.1.2
-- Up-to-date: /usr/lib/x86_64-linux-gnu/libmfx-gen.so
-- Up-to-date: /usr/lib/x86_64-linux-gnu/pkgconfig/libmfx-gen.pc