### PR TITLE
[H264d] check the index of view reference

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_slice_decoder_decode_pic.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_dec_slice_decoder_decode_pic.cpp
@@ -631,7 +631,11 @@ void H264Slice::ReOrderRefPicList(H264DecoderFrame **pRefPicList,
                 }
             }
             picViewIdxLXPred = picViewIdxLX;
-
+            if (picViewIdxLX >= UMC::H264_MAX_NUM_VIEW_REF)
+            {
+                m_pCurrentFrame->SetErrorFlagged(ERROR_FRAME_MAJOR);
+                continue;
+            }
             // get the target view
             if (m_SliceHeader.nal_ext.mvc.anchor_pic_flag)
             {


### PR DESCRIPTION
The bitstream shall not contain data that result in picViewIdxLX
less than 0.

Test: manually