### PR TITLE
[Jpegd]Enable HW to decode jpeg rgb444 on Linux

### DIFF
--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -1151,6 +1151,16 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
         ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].output_color_properties.color_range = VA_SOURCE_RANGE_FULL);
         break;
     case MFX_FOURCC_NV12:
+        m_pipelineParam[0].output_color_standard = VAProcColorStandardBT601;
+        if(refFourcc == MFX_FOURCC_RGBP)
+        {
+            ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].output_color_properties.color_range = VA_SOURCE_RANGE_FULL);
+        }
+        else
+        {
+            ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].output_color_properties.color_range = VA_SOURCE_RANGE_REDUCED);
+        }
+        break;
     default:
         m_pipelineParam[0].output_color_standard = VAProcColorStandardBT601;
         ENABLE_VPP_VIDEO_SIGNAL(m_pipelineParam[0].output_color_properties.color_range = VA_SOURCE_RANGE_REDUCED);


### PR DESCRIPTION
1. Modify JPEG RGB444 from partial acceleration to hardware
acceleration decode
2. Modify output format’s color_range to VA_SOURCE_RANGE_FULL

Cmd:./sample_decode jpeg -i /home/gta/IMG_0425.bmp_RGB_444_100.jpg -o test.yuv -hw
Issue: MDP-66601 & MDP-66823
Test: manually
