### PR TITLE
vaapi: recognize VA_FOURCC_XYUV VAImage

### DIFF
--- a/_studio/shared/src/libmfx_allocator_vaapi.cpp
+++ b/_studio/shared/src/libmfx_allocator_vaapi.cpp
@@ -579,7 +579,11 @@ mfxStatus mfxDefaultAllocatorVAAPI::SetFrameData(const VAImage &va_image, mfxU32
         break;
 
     case VA_FOURCC_AYUV:
-        if (mfx_fourcc != va_image.format.fourcc) return MFX_ERR_LOCK_MEMORY;
+    /* Set AYUV mfxFrameData by XYUV VAImage */
+#ifdef VA_FOURCC_XYUV
+    case VA_FOURCC_XYUV:
+#endif
+        if (mfx_fourcc != MFX_FOURCC_AYUV) return MFX_ERR_LOCK_MEMORY;
 
         {
             ptr->V = p_buffer + va_image.offsets[0];


### PR DESCRIPTION
    In FFmpeg, VA_FOURCC_XYUV is used for 4:4:4 8bit content when vaapi is
    used for hardware acceleration, hence we will have to use VA_FOURCC_XYUV too
    for 4:4:4 8bit content when qsv is used on Linux because qsv is based on
    vaapi, and map VA_FOURCC_XYUV to MFX_FOURCC_AYUV in FFmpeg. So mapping
    VA_FOURCC_XYUV is needed in the SDK.
    
    $ ffmpeg -y -hwaccel qsv -i in444.mp4 -vf "hwdownload,format=vuyx" -f
    null - 