### PR TITLE
[Decode CSC] return unsupport status when query unsupport output format

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_common_int.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_common_int.cpp
@@ -343,7 +343,7 @@ mfxStatus UpdateCscOutputFormat(mfxVideoParam *par, mfxFrameAllocRequest *reques
             request->Info.Shift = 0;
             break;
         default:
-            return MFX_ERR_INVALID_VIDEO_PARAM;
+            return MFX_ERR_UNSUPPORTED;
         }
 
         request->Info.BitDepthChroma = request->Info.BitDepthLuma;


### PR DESCRIPTION
MFX_EMFX_ERR_INVALID_VIDEO_PARAM seems to be incorrect status;
return MFX_ERR_UNSUPPORTED when output format is unsupported.

request from: #2780 