### PR TITLE
[Hevcd] Check the integrity of the SEI

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_sei.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_sei.cpp
@@ -61,6 +61,8 @@ int32_t H265HeadersBitstream::sei_message(const HeaderSet<H265SeqParamSet> & sps
         /* fixed-pattern bit string using 8 bits written equal to 0xFF */
         GetNBits(m_pbs, m_bitOffset, 8, code);
         payloadSize += 255;
+        if (CheckBSLeft())
+            throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
         PeakNextBits(m_pbs, m_bitOffset, 8, code);
     }
 


### PR DESCRIPTION
NALU contain NAL_UT_SEI_SUFFIX header, but part of
Supplemental enhancement information is missing

Issue: MDP-67689
Test: manually