### PR TITLE
Allow "-o::raw null" option

### DIFF
--- a/doc/samples/readme-multi-transcode_linux.md
+++ b/doc/samples/readme-multi-transcode_linux.md
@@ -68,10 +68,10 @@ ParFile is extension of what can be achieved by setting pipeline in the command 
 
 |Option|Description|
 |---|---|
- |-i::h265\|h264\|mpeg2\|vc1\|mvc\|jpeg\|vp9\|av1 <file-name>| Set input file and decoder type|
+ |-i::h265\|h264\|mpeg2\|vc1\|mvc\|jpeg\|vp9\|av1 \<file-name\>| Set input file and decoder type|
  |-i::i420\|nv12 <file-name>| Set raw input file and color format|
   |-i::rgb4_frame | Set input rgb4 file for compositon. File should contain just one single frame (-vpp_comp_src_h and -vpp_comp_src_w should be specified as well).|
- | -o::h265\|h264\|mpeg2\|mvc\|jpeg\|vp9\|raw <file-name>|  Set output file and encoder type|
+ | -o::h265\|h264\|mpeg2\|mvc\|jpeg\|vp9\|raw \<file-name\>\|null |  Set output file and encoder type. \'null\' keyword as file-name disables output file writing|
  | -sw\|-hw\|-hw_d3d11\|-hw_d3d9 SDK implementation to use:<br>-hw - platform-specific on default display adapter (default)<br>-hw_d3d11 - platform-specific via d3d11 <br>-hw_d3d9 - platform-specific via d3d9<br>-sw - software|
  | -mfe_frames| <N> maximum number of frames to be combined in multi-frame encode pipeline               0 - default for platform will be used|
   |-mfe_mode 0\|1\|2\|3| multi-frame encode operation mode - should be the same for all sessions<br>0, MFE operates as DEFAULT mode, decided by SDK if MFE enabled<br>1, MFE is disabled<br>2, MFE operates as AUTO mode<br>3, MFE operates as MANUAL mode|

--- a/samples/sample_multi_transcode/include/pipeline_transcode.h
+++ b/samples/sample_multi_transcode/include/pipeline_transcode.h
@@ -619,6 +619,7 @@ namespace TranscodingSample
         virtual mfxStatus ProcessOutputBitstream(mfxBitstreamWrapper* pBitstream);
         virtual mfxStatus ResetInput();
         virtual mfxStatus ResetOutput();
+        virtual bool      IsNulOutput();
 
     protected:
         std::unique_ptr<CSmplBitstreamReader> m_pFileReader;

--- a/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
+++ b/samples/sample_multi_transcode/src/sample_multi_transcode.cpp
@@ -447,11 +447,14 @@ mfxStatus Launcher::Init(int argc, msdk_char *argv[])
             MSDK_CHECK_STATUS(sts, "m_pExtBSProcArray.back()->SetReader failed");
         }
 
-        std::unique_ptr<CSmplBitstreamWriter> writer(new CSmplBitstreamWriter());
-        sts = writer->Init(m_InputParamsArray[i].strDstFile);
+        if (msdk_strncmp(MSDK_STRING("null"), m_InputParamsArray[i].strDstFile, msdk_strlen(MSDK_STRING("null"))))
+        {
+            std::unique_ptr<CSmplBitstreamWriter> writer(new CSmplBitstreamWriter());
+            sts = writer->Init(m_InputParamsArray[i].strDstFile);
 
-        sts = m_pExtBSProcArray.back()->SetWriter(writer);
-        MSDK_CHECK_STATUS(sts, "m_pExtBSProcArray.back()->SetWriter failed");
+            sts = m_pExtBSProcArray.back()->SetWriter(writer);
+            MSDK_CHECK_STATUS(sts, "m_pExtBSProcArray.back()->SetWriter failed");
+        }
 
         if (Sink == m_InputParamsArray[i].eMode)
         {

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -134,8 +134,9 @@ void TranscodingSample::PrintHelp()
     msdk_printf(MSDK_STRING("  -i::i420|nv12 <file-name>\n"));
     msdk_printf(MSDK_STRING("                 Set raw input file and color format\n"));
     msdk_printf(MSDK_STRING("  -i::rgb4_frame Set input rgb4 file for compositon. File should contain just one single frame (-vpp_comp_src_h and -vpp_comp_src_w should be specified as well).\n"));
-    msdk_printf(MSDK_STRING("  -o::h265|h264|mpeg2|mvc|jpeg|vp9|raw <file-name>\n"));
+    msdk_printf(MSDK_STRING("  -o::h265|h264|mpeg2|mvc|jpeg|vp9|raw <file-name>|null\n"));
     msdk_printf(MSDK_STRING("                Set output file and encoder type\n"));
+    msdk_printf(MSDK_STRING("                \'null\' keyword as file-name disables output file writing \n"));
     msdk_printf(MSDK_STRING("  -sw|-hw|-hw_d3d11|-hw_d3d9\n"));
     msdk_printf(MSDK_STRING("                SDK implementation to use: \n"));
     msdk_printf(MSDK_STRING("                      -hw - platform-specific on default display adapter (default)\n"));
@@ -1676,6 +1677,7 @@ mfxStatus CmdProcessor::ParseParamsForOneSession(mfxU32 argc, msdk_char *argv[])
             {
                 return MFX_ERR_UNSUPPORTED;
             }
+
             VAL_CHECK(i+1 == argc, i, argv[i]);
             i++;
             SIZE_CHECK((msdk_strlen(argv[i])+1) > MSDK_ARRAY_LEN(InputParams.strDstFile));


### PR DESCRIPTION
This might be beneficial for N decoders benchmarking

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>