### PR TITLE
sample_misc: Addin WAYLAND DMABUF support to render NV12 on Wayland.

### DIFF
--- a/builder/FindPackages.cmake
+++ b/builder/FindPackages.cmake
@@ -534,10 +534,9 @@ if( Linux )
       pkg_get_variable(WAYLAND_SCANNER_BIN_PATH wayland-scanner bindir)
       pkg_get_variable(WAYLAND_SCANNER_BIN wayland-scanner wayland_scanner)
       if ( WAYLAND_SCANNER_BIN_PATH AND WAYLAND_SCANNER_BIN )
-        find_file(
+        find_program(
             WAYLAND_SCANNER_BINARY_PATH ${WAYLAND_SCANNER_BIN}
-            PATHS ${WAYLAND_SCANNER_BIN_PATH}
-            NO_DEFAULT_PATH)
+            PATHS ${WAYLAND_SCANNER_BIN_PATH})
       endif()
     endif()
   endif()

--- a/builder/FindPackages.cmake
+++ b/builder/FindPackages.cmake
@@ -191,7 +191,11 @@ endfunction()
 function(configure_wayland_target target)
   configure_target(${ARGV0} "${PKG_WAYLAND_CLIENT_CFLAGS}" "${PKG_WAYLAND_CLIENT_LIBRARY_DIRS}")
 
-  set(SCOPE_CFLAGS "${SCOPE_CFLAGS} -DLIBVA_SUPPORT -DLIBVA_WAYLAND_SUPPORT" PARENT_SCOPE)
+  set(SCOPE_CFLAGS "${SCOPE_CFLAGS} -DLIBVA_SUPPORT -DLIBVA_WAYLAND_SUPPORT")
+  if(WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+    set(SCOPE_CFLAGS "${SCOPE_CFLAGS} -DWAYLAND_LINUX_DMABUF_SUPPORT")
+  endif()
+  set(SCOPE_CFLAGS "${SCOPE_CFLAGS}" PARENT_SCOPE)
   set(SCOPE_LINKFLAGS ${SCOPE_LINKFLAGS} PARENT_SCOPE)
   set(SCOPE_LIBS ${SCOPE_LIBS} drm_intel drm wayland-client PARENT_SCOPE)
 endfunction()
@@ -254,6 +258,9 @@ function(configure_universal_target target)
   if (PKG_WAYLAND_CLIENT_FOUND)
     configure_target(${ARGV0} "${PKG_WAYLAND_CLIENT_CFLAGS}" "${PKG_WAYLAND_CLIENT_LIBRARY_DIRS}")
     set(LOCAL_CFLAGS "${LOCAL_CFLAGS} -DLIBVA_WAYLAND_SUPPORT")
+    if(WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+      set(LOCAL_CFLAGS "${LOCAL_CFLAGS} -DWAYLAND_LINUX_DMABUF_SUPPORT")
+    endif()
   endif()
 
   set(SCOPE_CFLAGS "${SCOPE_CFLAGS} ${LOCAL_CFLAGS}" PARENT_SCOPE)
@@ -511,6 +518,28 @@ if( Linux )
   if( ENABLE_WAYLAND )
     pkg_check_modules(PKG_DRM_INTEL      REQUIRED libdrm_intel)
     pkg_check_modules(PKG_WAYLAND_CLIENT REQUIRED wayland-client)
+
+    pkg_check_modules(PKG_WAYLAND_SCANNER "wayland-scanner>=1.15")
+    pkg_check_modules(PKG_WAYLAND_PROTCOLS "wayland-protocols>=1.15")
+
+    if ( PKG_WAYLAND_SCANNER_FOUND AND PKG_WAYLAND_PROTCOLS_FOUND )
+      pkg_get_variable(WAYLAND_PROTOCOLS_PATH wayland-protocols pkgdatadir)
+      if(WAYLAND_PROTOCOLS_PATH)
+        find_file(
+            WAYLAND_LINUX_DMABUF_XML_PATH linux-dmabuf-unstable-v1.xml
+            PATHS ${WAYLAND_PROTOCOLS_PATH}/unstable/linux-dmabuf
+            NO_DEFAULT_PATH)
+      endif()
+
+      pkg_get_variable(WAYLAND_SCANNER_BIN_PATH wayland-scanner bindir)
+      pkg_get_variable(WAYLAND_SCANNER_BIN wayland-scanner wayland_scanner)
+      if ( WAYLAND_SCANNER_BIN_PATH AND WAYLAND_SCANNER_BIN )
+        find_file(
+            WAYLAND_SCANNER_BINARY_PATH ${WAYLAND_SCANNER_BIN}
+            PATHS ${WAYLAND_SCANNER_BIN_PATH}
+            NO_DEFAULT_PATH)
+      endif()
+    endif()
   endif()
 endif()
 

--- a/samples/sample_common/CMakeLists.txt
+++ b/samples/sample_common/CMakeLists.txt
@@ -3,5 +3,11 @@ include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}/../sample_misc/wayland/include
 )
 
+if(WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+  include_directories(
+    ${CMAKE_BINARY_DIR}/samples/sample_misc/wayland
+  )
+endif()
+
 make_library( shortname universal static )
 set( defs "" )

--- a/samples/sample_decode/CMakeLists.txt
+++ b/samples/sample_decode/CMakeLists.txt
@@ -4,6 +4,12 @@ include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+if (WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+  include_directories(
+    ${CMAKE_BINARY_DIR}/samples/sample_misc/wayland
+  )
+endif()
+
 list( APPEND LIBS_VARIANT sample_common )
 
 set(DEPENDENCIES libmfx dl pthread)

--- a/samples/sample_misc/wayland/CMakeLists.txt
+++ b/samples/sample_misc/wayland/CMakeLists.txt
@@ -12,4 +12,35 @@ set(DEPENDENCIES  libva libdrm wayland-client)
 
 make_library(mfx_wayland none shared )
 
+if (WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+  execute_process(
+	  COMMAND "${WAYLAND_SCANNER_BINARY_PATH}"
+              "client-header" "${WAYLAND_LINUX_DMABUF_XML_PATH}"
+              "samples/sample_misc/wayland/linux-dmabuf-unstable-v1.h"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      RESULT_VARIABLE WAYLAND_SCANNER_RESULT)
+  if (WAYLAND_SCANNER_RESULT)
+    message(ERROR "Failed to generate linux-dmabuf-unstable-v1.h")
+    return()
+  endif()
+
+  execute_process(
+      COMMAND "${WAYLAND_SCANNER_BINARY_PATH}"
+              "private-code" "${WAYLAND_LINUX_DMABUF_XML_PATH}"
+              "samples/sample_misc/wayland/linux-dmabuf-unstable-v1.c"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      RESULT_VARIABLE WAYLAND_SCANNER_RESULT)
+  if (WAYLAND_SCANNER_RESULT)
+    message(ERROR "Failed to generate linux-dmabuf-unstable-v1.c")
+    return()
+  endif()
+
+  include_directories(
+    ${CMAKE_BINARY_DIR}/samples/sample_misc/wayland
+  )
+  target_sources(
+    ${target}
+    PRIVATE ${CMAKE_BINARY_DIR}/samples/sample_misc/wayland/linux-dmabuf-unstable-v1.c)
+endif()
+
 install( TARGETS ${target} LIBRARY DESTINATION ${MFX_SAMPLES_INSTALL_LIB_DIR} )

--- a/samples/sample_misc/wayland/CMakeLists.txt
+++ b/samples/sample_misc/wayland/CMakeLists.txt
@@ -20,8 +20,7 @@ if (WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
       RESULT_VARIABLE WAYLAND_SCANNER_RESULT)
   if (WAYLAND_SCANNER_RESULT)
-    message(ERROR "Failed to generate linux-dmabuf-unstable-v1.h")
-    return()
+    message(FATAL_ERROR "Failed to generate linux-dmabuf-unstable-v1.h")
   endif()
 
   execute_process(
@@ -31,8 +30,7 @@ if (WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
       RESULT_VARIABLE WAYLAND_SCANNER_RESULT)
   if (WAYLAND_SCANNER_RESULT)
-    message(ERROR "Failed to generate linux-dmabuf-unstable-v1.c")
-    return()
+    message(FATAL_ERROR "Failed to generate linux-dmabuf-unstable-v1.c")
   endif()
 
   include_directories(

--- a/samples/sample_misc/wayland/include/class_wayland.h
+++ b/samples/sample_misc/wayland/include/class_wayland.h
@@ -33,6 +33,9 @@ extern "C"
 #include "mfxstructures.h"
 #include "mfx_buffering.h"
 #include "sample_defs.h"
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+#include "linux-dmabuf-unstable-v1.h"
+#endif
 
 typedef struct buffer wld_buffer;
 
@@ -90,6 +93,9 @@ class Wayland: public CBuffering {
         struct wl_surface * GetSurface() { return m_surface; }
         struct wl_shell_surface * GetShellSurface() { return m_shell_surface; }
         struct wl_callback * GetCallback() { return m_callback; }
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+	struct zwp_linux_dmabuf_v1 * GetDMABuf() { return m_dmabuf; }
+#endif
         void SetCompositor(struct wl_compositor *compositor)
         {
             m_compositor = compositor;
@@ -106,6 +112,12 @@ class Wayland: public CBuffering {
         {
             m_drm = drm;
         }
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+	void SetDMABuf(struct zwp_linux_dmabuf_v1 *dmabuf)
+        {
+            m_dmabuf = dmabuf;
+        }
+#endif
         void DrmHandleDevice(const char* device);
         void DrmHandleAuthenticated();
         void RegistryGlobal(struct wl_registry *registry
@@ -139,6 +151,9 @@ class Wayland: public CBuffering {
         struct wl_shell_surface *m_shell_surface;
         struct wl_callback *m_callback;
         struct wl_event_queue *m_event_queue;
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+	struct zwp_linux_dmabuf_v1 * m_dmabuf;
+#endif
         volatile int m_pending_frame;
         struct ShmPool *m_shm_pool;
         int m_display_fd;

--- a/samples/sample_misc/wayland/src/class_wayland.cpp
+++ b/samples/sample_misc/wayland/src/class_wayland.cpp
@@ -60,6 +60,9 @@ Wayland::Wayland()
     , m_shell_surface(NULL)
     , m_callback(NULL)
     , m_event_queue(NULL)
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+    , m_dmabuf(NULL)
+#endif
     , m_pending_frame(0)
     , m_shm_pool(NULL)
     , m_display_fd(-1)
@@ -418,6 +421,13 @@ void Wayland::RegistryGlobal(struct wl_registry *registry
             , 2));
             wl_drm_add_listener(m_drm, &drm_listener, this);
     }
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+    else if(0 == strcmp(interface, "zwp_linux_dmabuf_v1"))
+        m_dmabuf = static_cast<zwp_linux_dmabuf_v1*>(wl_registry_bind(registry
+            , name
+            , &zwp_linux_dmabuf_v1_interface
+            , 3));
+#endif
 }
 
 void Wayland::DrmHandleDevice(const char *name)

--- a/samples/sample_misc/wayland/src/class_wayland.cpp
+++ b/samples/sample_misc/wayland/src/class_wayland.cpp
@@ -26,6 +26,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 #include <sys/mman.h>
 extern "C" {
 #include <drm.h>
+#include <drm_fourcc.h>
 #include <xf86drm.h>
 #include <intel_bufmgr.h>
 }
@@ -350,20 +351,53 @@ struct wl_buffer * Wayland::CreatePrimeBuffer(uint32_t name
     , int32_t pitches[3])
 {
     struct wl_buffer * buffer = NULL;
-    if(NULL == m_drm)
-        return NULL;
 
-    buffer = wl_drm_create_prime_buffer(m_drm
-            , name
-            , width
-            , height
-            , format
-            , offsets[0]
-            , pitches[0]
-            , offsets[1]
-            , pitches[1]
-            , offsets[2]
-            , pitches[2]);
+#if defined(WAYLAND_LINUX_DMABUF_SUPPORT)
+    if (format == WL_DRM_FORMAT_NV12) {
+        if(NULL == m_dmabuf)
+            return NULL;
+
+        struct zwp_linux_buffer_params_v1 *dmabuf_params = NULL;
+        int i = 0;
+        uint64_t modifier = I915_FORMAT_MOD_Y_TILED;
+
+        dmabuf_params = zwp_linux_dmabuf_v1_create_params(m_dmabuf);
+        for(i = 0; i < 2; i++) {
+            zwp_linux_buffer_params_v1_add(dmabuf_params,
+                name,
+                i,
+                offsets[i],
+                pitches[i],
+                modifier >> 32,
+                modifier & 0xffffffff);
+        }
+
+        buffer = zwp_linux_buffer_params_v1_create_immed(dmabuf_params,
+                                                         width,
+                                                         height,
+                                                         format,
+                                                         0);
+
+        zwp_linux_buffer_params_v1_destroy(dmabuf_params);
+    } else
+#endif
+    {
+        if(NULL == m_drm)
+            return NULL;
+
+        buffer = wl_drm_create_prime_buffer(m_drm
+                , name
+                , width
+                , height
+                , format
+                , offsets[0]
+                , pitches[0]
+                , offsets[1]
+                , pitches[1]
+                , offsets[2]
+                , pitches[2]);
+    }
+
     return buffer;
 }
 

--- a/samples/sample_multi_transcode/CMakeLists.txt
+++ b/samples/sample_multi_transcode/CMakeLists.txt
@@ -6,6 +6,12 @@ include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}/../sample_plugins/rotate_cpu/include
 )
 
+if (WAYLAND_LINUX_DMABUF_XML_PATH AND WAYLAND_SCANNER_BINARY_PATH)
+  include_directories(
+    ${CMAKE_BINARY_DIR}/samples/sample_misc/wayland
+  )
+endif()
+
 list( APPEND LIBS_VARIANT sample_common )
 list( APPEND LIBS_NOVARIANT vpp_plugin )
 


### PR DESCRIPTION
Similar fix for [this](https://github.com/Intel-Media-SDK/MediaSDK/pull/2803).
However, this version will use wayland-scanner to auto generate the wayland binding code.