### PR TITLE
[vpp] Removed SelectThreadDependencyPattern call

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -3584,9 +3584,6 @@ int RunGpu(
     res = device->CreateThreadSpace(tsWidth, tsHeight, threadSpace);
     CHECK_CM_ERR(res);
 
-    res = threadSpace->SelectThreadDependencyPattern(CM_NONE_DEPENDENCY);
-    CHECK_CM_ERR(res);
-
     SurfaceIndex *idxInput = 0;
     SurfaceIndex *idxOutput = 0;
     res = input->GetIndex(idxInput);


### PR DESCRIPTION
SelectThreadDependencyPattern is very CPU time expensive on dGPU.
CM_NONE_DEPENDENCY is a default mode so we can just drop the call.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>