### PR TITLE
sample_encode: vp9 supports tile encoding from mfx version 1029

### DIFF
--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -578,7 +578,7 @@ mfxStatus CEncodingPipeline::InitMfxEncParams(sInputParams *pInParams)
             hevcTiles->NumTileRows = pInParams->nEncTileRows;
             hevcTiles->NumTileColumns = pInParams->nEncTileCols;
         }
-#if MFX_VERSION >= MFX_VERSION_NEXT
+#if (MFX_VERSION >= 1029)
         else if (m_mfxEncParams.mfx.CodecId == MFX_CODEC_VP9)
         {
             auto vp9Param = m_mfxEncParams.AddExtBuffer<mfxExtVP9Param>();


### PR DESCRIPTION
Without this patch, -trows and -tcols are ignored actually

$ sample_encode vp9 -i input.yuv -w 3840 -h 2160 -trows 2 -tcols 2 -o \
out.ivf