### PR TITLE
Revert "[HEVCe] Use long start code for IDR frame"

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_packer.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_packer.cpp
@@ -463,8 +463,6 @@ void Packer::PackNALU(BitstreamWriter& bs, NALU const & h)
         || h.nal_unit_type == PPS_NUT
         || h.nal_unit_type == AUD_NUT
         || h.nal_unit_type == PREFIX_SEI_NUT
-        || h.nal_unit_type == IDR_W_RADL
-        || h.nal_unit_type == IDR_N_LP
         || h.long_start_code;
 
     if (bLongSC)


### PR DESCRIPTION
This reverts commit cf9a1927289ae1133df768d06677d8c477555fd4.