### PR TITLE
[Decode][hevcd] Add hevc FrameRate parameters parsing from VideoParamSet

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_dec_defs.h
@@ -665,6 +665,7 @@ public:
     H265HRD* getHrdParameters   ( unsigned i )             { return &m_hrdParameters[ i ]; }
     H265ProfileTierLevel* getPTL() { return &m_pcPTL; }
     H265TimingInfo* getTimingInfo() { return &m_timingInfo; }
+    const H265TimingInfo* getTimingInfo() const { return &m_timingInfo; }
 };
 
 typedef uint32_t IntraType;

--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_mfx_utils.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_mfx_utils.h
@@ -31,7 +31,7 @@ namespace UMC_HEVC_DECODER
 namespace MFX_Utility
 {
     // Initialize mfxVideoParam structure based on decoded bitstream header values
-    UMC::Status FillVideoParam(const H265SeqParamSet * seq, mfxVideoParam *par, bool full);
+    UMC::Status FillVideoParam(const H265VideoParamSet * vps, const H265SeqParamSet * seq, mfxVideoParam *par, bool full);
 
     // Returns implementation platform
     eMFXPlatform GetPlatform_H265(VideoCORE * core, mfxVideoParam * par);

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
@@ -258,13 +258,7 @@ UMC::Status MFXTaskSupplier_H265::FillVideoParam(mfxVideoParam *par, bool full)
     if (!seq)
         return UMC::UMC_ERR_FAILED;
 
-    if (vps != nullptr && (vps->getTimingInfo()->vps_timing_info_present_flag || full))
-    {
-        par->mfx.FrameInfo.FrameRateExtD = vps->getTimingInfo()->vps_num_units_in_tick;
-        par->mfx.FrameInfo.FrameRateExtN = vps->getTimingInfo()->vps_time_scale;
-    }
-
-    if (MFX_Utility::FillVideoParam(seq, par, full) != UMC::UMC_OK)
+    if (MFX_Utility::FillVideoParam(vps, seq, par, full) != UMC::UMC_OK)
         return UMC::UMC_ERR_FAILED;
 
     return UMC::UMC_OK;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
@@ -252,9 +252,17 @@ void MFXTaskSupplier_H265::SetVideoParams(mfxVideoParam * par)
 
 UMC::Status MFXTaskSupplier_H265::FillVideoParam(mfxVideoParam *par, bool full)
 {
+    const H265VideoParamSet * vps = GetHeaders()->m_VideoParams.GetCurrentHeader();
     const H265SeqParamSet * seq = GetHeaders()->m_SeqParams.GetCurrentHeader();
+
     if (!seq)
         return UMC::UMC_ERR_FAILED;
+
+    if (vps != nullptr && (vps->getTimingInfo()->vps_timing_info_present_flag || full))
+    {
+        par->mfx.FrameInfo.FrameRateExtD = vps->getTimingInfo()->vps_num_units_in_tick;
+        par->mfx.FrameInfo.FrameRateExtN = vps->getTimingInfo()->vps_time_scale;
+    }
 
     if (MFX_Utility::FillVideoParam(seq, par, full) != UMC::UMC_OK)
         return UMC::UMC_ERR_FAILED;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -389,11 +389,6 @@ UMC::Status FillVideoParam(const H265SeqParamSet * seq, mfxVideoParam *par, bool
         par->mfx.FrameInfo.FrameRateExtD = seq->getTimingInfo()->vps_num_units_in_tick;
         par->mfx.FrameInfo.FrameRateExtN = seq->getTimingInfo()->vps_time_scale;
     }
-    else
-    {
-        par->mfx.FrameInfo.FrameRateExtD = 0;
-        par->mfx.FrameInfo.FrameRateExtN = 0;
-    }
 
     par->mfx.CodecProfile = (mfxU16)seq->m_pcPTL.GetGeneralPTL()->profile_idc;
     par->mfx.CodecLevel = (mfxU16)seq->m_pcPTL.GetGeneralPTL()->level_idc;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -345,7 +345,7 @@ bool CheckFourcc(mfxU32 fourcc, mfxU16 codecProfile, mfxFrameInfo const* frameIn
 }
 
 // Initialize mfxVideoParam structure based on decoded bitstream header values
-UMC::Status FillVideoParam(const H265SeqParamSet * seq, mfxVideoParam *par, bool full)
+UMC::Status FillVideoParam(const H265VideoParamSet * vps, const H265SeqParamSet * seq, mfxVideoParam *par, bool full)
 {
     par->mfx.CodecId = MFX_CODEC_HEVC;
 
@@ -384,7 +384,12 @@ UMC::Status FillVideoParam(const H265SeqParamSet * seq, mfxVideoParam *par, bool
         par->mfx.FrameInfo.AspectRatioH = 0;
     }
 
-    if (seq->getTimingInfo()->vps_timing_info_present_flag || full)
+    if (vps != nullptr && (vps->getTimingInfo()->vps_timing_info_present_flag || full))
+    {
+        par->mfx.FrameInfo.FrameRateExtD = vps->getTimingInfo()->vps_num_units_in_tick;
+        par->mfx.FrameInfo.FrameRateExtN = vps->getTimingInfo()->vps_time_scale;
+    }
+    else if (seq->getTimingInfo()->vps_timing_info_present_flag || full)
     {
         par->mfx.FrameInfo.FrameRateExtD = seq->getTimingInfo()->vps_num_units_in_tick;
         par->mfx.FrameInfo.FrameRateExtN = seq->getTimingInfo()->vps_time_scale;


### PR DESCRIPTION
In HEVC MFXVideoDECODE_DecodeHeader(), the framerate is calculated from SPS, but the framerate should combine the info from VPS and SPS according to the spec. This PR fixes this. 