### PR TITLE
[hevce] Only VDEnc mode is available on JSL & EHL

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1450,6 +1450,10 @@ public:
             ((hw == MFX_HW_CNL
               && par.mfx.TargetUsage >= 6
               && par.mfx.GopRefDist < 2) ||
+#if (MFX_VERSION >= 1031)
+             (hw == MFX_HW_EHL ||
+              hw == MFX_HW_JSL) ||
+#endif
              (hw >= MFX_HW_ICL &&
               (fcc == MFX_FOURCC_AYUV
 #if (MFX_VERSION >= 1027)


### PR DESCRIPTION
The SDK always use VDEnc mode for AVC & VP9 encoding on JSL & EHL by
default. To keep the hehavior consistent across codecs, use VDEnc mode
by default for HEVC encoding as well