### PR TITLE
[av1d] add support av1d multiple sequence headers with different resolution

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -914,6 +914,11 @@ mfxStatus VideoDECODEAV1::SubmitFrame(mfxBitstream* bs, mfxFrameSurface1* surfac
                  m_video_par.AsyncDepth = static_cast<mfxU16>(vp.async_depth);
             }
 
+            if (umcFrameRes == UMC::UMC_NTF_NEW_RESOLUTION)
+            {
+                MFX_RETURN(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+            }
+
             if (umcRes == UMC::UMC_ERR_INVALID_STREAM)
             {
                 umcRes = UMC::UMC_OK;


### PR DESCRIPTION
If there is a new av1 sequence header connected to old one with different resolution, MSDK lib will return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM.

Signed-off-by: ZefuLI <zefu.li@intel.com>