### PR TITLE
[hevce] Use VDEnc by default for A2RGB10 input

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1459,6 +1459,7 @@ public:
 #if (MFX_VERSION >= 1027)
                || fcc == MFX_FOURCC_Y410
 #endif
+               || fcc == MFX_FOURCC_A2RGB10
                   )));
 
         return mfxU16(


### PR DESCRIPTION
VME doesn't support A2RGB10 input