### PR TITLE
[PATCH] [HEVCd] disp win offset should be added to crop (#4398)

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_utils.cpp
@@ -361,10 +361,10 @@ UMC::Status FillVideoParam(const H265VideoParamSet * vps, const H265SeqParamSet 
 
     //if (seq->frame_cropping_flag)
     {
-        par->mfx.FrameInfo.CropX = (mfxU16)(seq->conf_win_left_offset);
-        par->mfx.FrameInfo.CropY = (mfxU16)(seq->conf_win_top_offset);
-        par->mfx.FrameInfo.CropH = (mfxU16)(par->mfx.FrameInfo.Height - (seq->conf_win_top_offset + seq->conf_win_bottom_offset));
-        par->mfx.FrameInfo.CropW = (mfxU16)(par->mfx.FrameInfo.Width - (seq->conf_win_left_offset + seq->conf_win_right_offset));
+        par->mfx.FrameInfo.CropX = (mfxU16)(seq->conf_win_left_offset + seq->def_disp_win_left_offset);
+        par->mfx.FrameInfo.CropY = (mfxU16)(seq->conf_win_top_offset + seq->def_disp_win_top_offset);
+        par->mfx.FrameInfo.CropH = (mfxU16)(par->mfx.FrameInfo.Height - (seq->conf_win_top_offset + seq->conf_win_bottom_offset + seq->def_disp_win_top_offset + seq->def_disp_win_bottom_offset));
+        par->mfx.FrameInfo.CropW = (mfxU16)(par->mfx.FrameInfo.Width - (seq->conf_win_left_offset + seq->conf_win_right_offset + seq->def_disp_win_left_offset + seq->def_disp_win_right_offset));
 
         par->mfx.FrameInfo.CropH -= (mfxU16)(par->mfx.FrameInfo.Height - seq->pic_height_in_luma_samples);
         par->mfx.FrameInfo.CropW -= (mfxU16)(par->mfx.FrameInfo.Width - seq->pic_width_in_luma_samples);

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -2409,10 +2409,10 @@ UMC::Status TaskSupplier_H265::InitFreeFrame(H265DecoderFrame * pFrame, const H2
 
     pFrame->m_FrameType   = SliceTypeToFrameType(pSlice->GetSliceHeader()->slice_type);
     pFrame->m_dFrameTime  = pSlice->m_source.GetTime();
-    pFrame->m_crop_left   = pSeqParam->conf_win_left_offset;
-    pFrame->m_crop_right  = pSeqParam->conf_win_right_offset;
-    pFrame->m_crop_top    = pSeqParam->conf_win_top_offset;
-    pFrame->m_crop_bottom = pSeqParam->conf_win_bottom_offset;
+    pFrame->m_crop_left   = pSeqParam->conf_win_left_offset + pSeqParam->def_disp_win_left_offset;
+    pFrame->m_crop_right  = pSeqParam->conf_win_right_offset + pSeqParam->def_disp_win_right_offset;
+    pFrame->m_crop_top    = pSeqParam->conf_win_top_offset + pSeqParam->def_disp_win_top_offset;
+    pFrame->m_crop_bottom = pSeqParam->conf_win_bottom_offset + pSeqParam->def_disp_win_bottom_offset;
     pFrame->m_crop_flag   = pSeqParam->conformance_window_flag;
 
     pFrame->m_aspect_width  = pSeqParam->sar_width;

--- a/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_decoder.cpp
+++ b/_studio/shared/umc/codec/mpeg2_dec/src/umc_mpeg2_decoder.cpp
@@ -946,9 +946,7 @@ namespace UMC_MPEG2_DECODER
         if (sliceCount)
         {
             EliminateSliceErrors(frame, fieldIndex);
-            UMC::Status sts = Submit(frame, fieldIndex);
-            if (UMC::UMC_OK != sts)
-                throw mpeg2_exception(UMC::UMC_ERR_FAILED);
+            Submit(frame, fieldIndex);
         }
         else
         {


### PR DESCRIPTION
Report CropW/CropH using conformance crops, and display crops.

[Internal]
OSPR: Auto
Commit_Type: Bugfix
Platforms: N/A
OS: N/A
Feature impact: N/A
Resolves: MDP-63613
Related-to: MDP-63613
Klocwork: N/A
TP_Passed: N/A
IP Scan: N/A
Open/Embargo Dependency: N/A