### PR TITLE
[Decode] Add flag for HEVCd HDR SEI parsing result

### DIFF
--- a/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/h265/src/mfx_h265_dec_decode.cpp
@@ -1395,12 +1395,23 @@ void VideoDECODEH265::FillOutputSurface(mfxFrameSurface1 **surf_out, mfxFrameSur
         dispaly_colour->WhitePointY = (mfxU16)pFrame->m_mastering_display.SEI_messages.mastering_display.white_point[1];
         dispaly_colour->MaxDisplayMasteringLuminance = (mfxU32)pFrame->m_mastering_display.SEI_messages.mastering_display.max_luminance;
         dispaly_colour->MinDisplayMasteringLuminance = (mfxU32)pFrame->m_mastering_display.SEI_messages.mastering_display.min_luminance;
+        dispaly_colour->InsertPayloadToggle = MFX_PAYLOAD_IDR;
     }
+    else if (dispaly_colour)
+    {
+        dispaly_colour->InsertPayloadToggle = MFX_PAYLOAD_OFF;
+    }
+
     mfxExtContentLightLevelInfo* content_light = (mfxExtContentLightLevelInfo*)GetExtendedBuffer(surface_out->Data.ExtParam, surface_out->Data.NumExtParam, MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO);
     if (content_light && pFrame->m_content_light_level_info.payLoadSize > 0)
     {
         content_light->MaxContentLightLevel = (mfxU16)pFrame->m_content_light_level_info.SEI_messages.content_light_level_info.max_content_light_level;
         content_light->MaxPicAverageLightLevel = (mfxU16)pFrame->m_content_light_level_info.SEI_messages.content_light_level_info.max_pic_average_light_level;
+        content_light->InsertPayloadToggle = MFX_PAYLOAD_IDR;
+    }
+    else if (content_light)
+    {
+        content_light->InsertPayloadToggle = MFX_PAYLOAD_OFF;
     }
 
 }

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -5229,6 +5229,7 @@ typedef struct {
 **Description**
 
 The `mfxExtMasteringDisplayColourVolume` configures the HDR SEI message. If application attaches this structure to the [mfxEncodeCtrl](#mfxEncodeCtrl) at [runtime](#MFXVideoENCODE_EncodeFrameAsync), the encoder inserts the HDR SEI message for current frame and ignores `InsertPayloadToggle`. If application attaches this structure to the [mfxVideoParam](#mfxVideoParam) during [initialization](#MFXVideoENCODE_Init) or [reset](#MFXVideoENCODE_Reset), the encoder inserts HDR SEI message based on `InsertPayloadToggle`. Fields semantic defined in ITU-T* H.265 Annex D.
+If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoENCODE_DecodeFrameAsync) for HDR SEI parsing. The decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame, else the decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
 
 **Members**
 
@@ -5261,6 +5262,7 @@ typedef struct {
 **Description**
 
 The `mfxExtContentLightLevelInfo` structure configures the HDR SEI message. If application attaches this structure to the [mfxEncodeCtrl](#mfxEncodeCtrl) structure at [runtime](#MFXVideoENCODE_EncodeFrameAsync), the encoder inserts the HDR SEI message for current frame and ignores `InsertPayloadToggle`. If application attaches this structure to the [mfxVideoParam](#mfxVideoParam) structure during [initialization](#MFXVideoENCODE_Init) or [reset](#MFXVideoENCODE_Reset), the encoder inserts HDR SEI message based on `InsertPayloadToggle`. Fields semantic defined in ITU-T* H.265 Annex D.
+If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoENCODE_DecodeFrameAsync) for HDR SEI parsing. The decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame, else the decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
 
 **Members**
 

--- a/doc/mediasdk-man.md
+++ b/doc/mediasdk-man.md
@@ -5229,7 +5229,7 @@ typedef struct {
 **Description**
 
 The `mfxExtMasteringDisplayColourVolume` configures the HDR SEI message. If application attaches this structure to the [mfxEncodeCtrl](#mfxEncodeCtrl) at [runtime](#MFXVideoENCODE_EncodeFrameAsync), the encoder inserts the HDR SEI message for current frame and ignores `InsertPayloadToggle`. If application attaches this structure to the [mfxVideoParam](#mfxVideoParam) during [initialization](#MFXVideoENCODE_Init) or [reset](#MFXVideoENCODE_Reset), the encoder inserts HDR SEI message based on `InsertPayloadToggle`. Fields semantic defined in ITU-T* H.265 Annex D.
-If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoENCODE_DecodeFrameAsync) for HDR SEI parsing. The decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame, else the decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
+If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoDECODE_DecodeFrameAsync) for HDR SEI parsing, the decoder sets `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame. Otherwise the decoder sets `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
 
 **Members**
 
@@ -5262,7 +5262,7 @@ typedef struct {
 **Description**
 
 The `mfxExtContentLightLevelInfo` structure configures the HDR SEI message. If application attaches this structure to the [mfxEncodeCtrl](#mfxEncodeCtrl) structure at [runtime](#MFXVideoENCODE_EncodeFrameAsync), the encoder inserts the HDR SEI message for current frame and ignores `InsertPayloadToggle`. If application attaches this structure to the [mfxVideoParam](#mfxVideoParam) structure during [initialization](#MFXVideoENCODE_Init) or [reset](#MFXVideoENCODE_Reset), the encoder inserts HDR SEI message based on `InsertPayloadToggle`. Fields semantic defined in ITU-T* H.265 Annex D.
-If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoENCODE_DecodeFrameAsync) for HDR SEI parsing. The decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame, else the decoder set `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
+If application attaches this structure to the [mfxFrameSurface1](#mfxFrameSurface) at [runtime](#MFXVideoDECODE_DecodeFrameAsync) for HDR SEI parsing, the decoder sets `InsertPayloadToggle` to `MFX_PAYLOAD_IDR` if there exist MasteringDisplayColourVolume in the current frame. Otherwise the decoder sets `InsertPayloadToggle` to `MFX_PAYLOAD_OFF`.
 
 **Members**
 


### PR DESCRIPTION
This PR was used to discuss the HEVCd HDR SEI flag issue which discussed in https://github.com/Intel-Media-SDK/MediaSDK/issues/2597

 *   Option 1: Add a new API.
     *   Concern: 1.x API is frozen, so this would limit usage to oneVPL POR HW (>= Gen12).

  *   Option 2: Overload existing field InsertPayloadToggle. (used in this PR)
      *    Concern: "InsertPayload" doesn't make much sense when decoding. These extBufs were defined with encoding in mind.
