### PR TITLE
[Decode] Fix av1d issue with small decbufsize

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_decoder.h
@@ -171,6 +171,7 @@ namespace UMC_AV1_DECODER
         AV1DecoderFrame*                Curr_temp; // store current frame insist double updateDPB
         uint32_t                        Repeat_show; // show if current frame is repeated frame
         uint32_t                        PreFrame_id;//id of previous frame
+        uint32_t                        OldPreFrame_id;//old id of previous frame. When decode multi tile-group clip, need this for parsing twice
         DPBType                         refs_temp; // previous updated frameDPB
         mfxU16                          frame_order;
         mfxF64                          in_framerate;

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder_va.cpp
@@ -86,9 +86,12 @@ namespace UMC_AV1_DECODER
 
         const bool lastSubmission = (GetNumMissingTiles(frame) == 0);
         if (lastSubmission)
+        {
             packer->EndFrame();
-
-        sts = va->Execute();
+            // VA Execute after full frame detected to avoid duplicate submission
+            // of the decode buffer when app use small decbufsize.
+            sts = va->Execute();
+        }
         if (sts != UMC::UMC_OK)
             sts = UMC::UMC_ERR_DEVICE_FAILED;
 

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_va_packer_vaapi.cpp
@@ -83,7 +83,7 @@ namespace UMC_AV1_DECODER
         }
 
         UMC::UMCVACompBuffer* compBufBs = nullptr;
-        uint8_t* const bitstreamData = (uint8_t *)m_va->GetCompBuffer(VASliceDataBufferType, &compBufBs, CalcSizeOfTileSets(tileSets));
+        uint8_t* const bitstreamData = (uint8_t *)m_va->GetCompBuffer(VASliceDataBufferType, &compBufBs, CalcSizeOfTileSets(tileSets), tileSets.size());
         if (!bitstreamData || !compBufBs)
             throw av1_exception(MFX_ERR_MEMORY_ALLOC);
 
@@ -110,7 +110,7 @@ namespace UMC_AV1_DECODER
 
         UMCVACompBuffer* compBufTile = nullptr;
         const int32_t tileControlInfoSize = static_cast<int32_t>(sizeof(VASliceParameterBufferAV1) * tileControlParams.size());
-        VASliceParameterBufferAV1 *tileControlParam = (VASliceParameterBufferAV1*)m_va->GetCompBuffer(VASliceParameterBufferType, &compBufTile, tileControlInfoSize);
+        VASliceParameterBufferAV1 *tileControlParam = (VASliceParameterBufferAV1*)m_va->GetCompBuffer(VASliceParameterBufferType, &compBufTile, tileControlInfoSize, tileSets.size());
         if (!tileControlParam || !compBufTile || (compBufTile->GetBufferSize() < tileControlInfoSize))
             throw av1_exception(MFX_ERR_MEMORY_ALLOC);
 


### PR DESCRIPTION
This PR fix two issues caused by samll decbufsize:
1. Frame_id check failed in ReadUncompressedHeader.
2. Duplicate submission of the decode buffer in va Execute.