### PR TITLE
[Decode] Fix VC1d issue when frame_type is NONE_PICTURE.

### DIFF
--- a/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
+++ b/_studio/mfx_lib/decode/vc1/src/mfx_vc1_decode.cpp
@@ -2089,7 +2089,7 @@ mfxStatus MFXVideoDECODEVC1::DecodeFrameCheck(mfxBitstream *bs,
         pEntryPoint->pParam = pAsyncSurface;
         pEntryPoint->pRoutineName = (char *)"DecodeVC1";
 
-        if (MFX_ERR_NONE == mfxSts)
+        if (MFX_ERR_NONE == mfxSts && (m_InternMediaDataOut.GetFrameType() != NONE_PICTURE))
         {
             FillMFXDataOutputSurface(*surface_out);
         }


### PR DESCRIPTION
FFMpeg-qsv splits the bitstream into AVpackets, the small AVpackets may
cause this issue.