### PR TITLE
Fix build with gcc 12

### DIFF
--- a/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_main.h
+++ b/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_main.h
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 #include <map>
+#include <memory>
 #include <list>
 #include <algorithm>
 

--- a/tests/unit/suites/tracer/linux/mfx_tracer_test_main.h
+++ b/tests/unit/suites/tracer/linux/mfx_tracer_test_main.h
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 #include <map>
+#include <memory>
 #include <list>
 #include <algorithm>
 


### PR DESCRIPTION
gcc 12 changed header dependencies. It now requires to explicitly include the `<memory>` C++ header for using `std::unique_ptr`. 

Otherwise, the following build error will occur: `‘unique_ptr’ in namespace ‘std’ does not name a template type`.

See documentation about [porting to gcc 12](https://gcc.gnu.org/gcc-12/porting_to.html).

Fixes #2940
