### PR TITLE
Fix HEVC bitstream buffer overflow issue

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
@@ -238,6 +238,9 @@ public:
     // Returns number of bytes left in bitstream array
     size_t BytesLeft() const;
 
+    // Throw exception if left bits not enough to decode
+    void CheckBitsLeft(const uint32_t nbits);
+
     // Returns number of bits needed for byte alignment
     unsigned getNumBitsUntilByteAligned() const;
 
@@ -259,6 +262,9 @@ public:
     // Set current decoding position
     void SetDecodedBytes(size_t);
 
+    // Set dummy buffer size in bytes
+    void SetTailBsSize(const uint32_t nBytes);
+
     size_t GetAllBitsCount()
     {
         return m_maxBsSize;
@@ -272,9 +278,10 @@ public:
 protected:
 
     uint32_t *m_pbs;                                              // (uint32_t *) pointer to the current position of the buffer.
-    int32_t m_bitOffset;                                         // (int32_t) the bit position (0 to 31) in the dword pointed by m_pbs.
+    int32_t m_bitOffset;                                          // (int32_t) the bit position (0 to 31) in the dword pointed by m_pbs.
     uint32_t *m_pbsBase;                                          // (uint32_t *) pointer to the first byte of the buffer.
     uint32_t m_maxBsSize;                                         // (uint32_t) maximum buffer size in bytes.
+    uint32_t m_tailBsSize;                                        // (uint32_t) dummy buffer size in bytes at the buffer end.
 };
 
 class H265ScalingList;
@@ -367,6 +374,7 @@ uint32_t H265BaseBitstream::GetBits(const uint32_t nbits)
 {
     uint32_t w, n = nbits;
 
+    CheckBitsLeft(n);
     GetNBits(m_pbs, m_bitOffset, n, w);
     return(w);
 }
@@ -377,6 +385,7 @@ inline uint32_t H265BaseBitstream::GetPredefinedBits()
 {
     uint32_t w, n = nbits;
 
+    CheckBitsLeft(n);
     GetNBits(m_pbs, m_bitOffset, n, w);
     return(w);
 }
@@ -384,6 +393,7 @@ inline uint32_t H265BaseBitstream::GetPredefinedBits()
 inline bool DecodeExpGolombOne_H265_1u32s (uint32_t **ppBitStream,
                                                       int32_t *pBitOffset,
                                                       int32_t *pDst,
+                                                      int32_t remainingBits,
                                                       int32_t isSigned)
 {
     uint32_t code;
@@ -395,21 +405,37 @@ inline bool DecodeExpGolombOne_H265_1u32s (uint32_t **ppBitStream,
     /* check error(s) */
 
     /* Fast check for element = 0 */
-    GetNBits((*ppBitStream), (*pBitOffset), 1, code)
+    if ((remainingBits < 1))
+    {
+        throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
+    }
+    GetNBits((*ppBitStream), (*pBitOffset), 1, code);
+    remainingBits -= 1;
+
     if (code)
     {
         *pDst = 0;
         return true;
     }
 
+    if ((remainingBits < 8))
+    {
+        throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
+    }
     GetNBits((*ppBitStream), (*pBitOffset), 8, code);
     length += 8;
+    remainingBits -= 8;
 
     /* find nonzero byte */
     while (code == 0 && 32 > length)
     {
+        if ((remainingBits < 8))
+        {
+            throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
+        }
         GetNBits((*ppBitStream), (*pBitOffset), 8, code);
         length += 8;
+        remainingBits -= 8;
     }
 
     /* find leading '1' */
@@ -420,7 +446,8 @@ inline bool DecodeExpGolombOne_H265_1u32s (uint32_t **ppBitStream,
     }
     length -= 8 - thisChunksLength;
 
-    UngetNBits((*ppBitStream), (*pBitOffset),8 - (thisChunksLength + 1))
+    UngetNBits((*ppBitStream), (*pBitOffset),8 - (thisChunksLength + 1));
+    remainingBits += 8 - (thisChunksLength + 1);
 
     /* skipping very long codes, let's assume what the code is corrupted */
     if (32 <= length || 32 <= thisChunksLength)
@@ -438,7 +465,12 @@ inline bool DecodeExpGolombOne_H265_1u32s (uint32_t **ppBitStream,
     /* Get info portion of codeword */
     if (length)
     {
-        GetNBits((*ppBitStream), (*pBitOffset),length, info)
+        if ((remainingBits < length))
+        {
+            throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
+        }
+        GetNBits((*ppBitStream), (*pBitOffset),length, info);
+        remainingBits -= length;
     }
 
     sval = ((1 << (length)) + (info) - 1);
@@ -459,8 +491,9 @@ inline bool DecodeExpGolombOne_H265_1u32s (uint32_t **ppBitStream,
 inline uint32_t H265BaseBitstream::GetVLCElementU()
 {
     int32_t sval = 0;
+    int32_t remainingbits = (int32_t)((m_maxBsSize + m_tailBsSize) * 8) - (int32_t)BitsDecoded();
 
-    bool res = DecodeExpGolombOne_H265_1u32s(&m_pbs, &m_bitOffset, &sval, false);
+    bool res = DecodeExpGolombOne_H265_1u32s(&m_pbs, &m_bitOffset, &sval, remainingbits, false);
 
     if (!res)
         throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
@@ -472,8 +505,9 @@ inline uint32_t H265BaseBitstream::GetVLCElementU()
 inline int32_t H265BaseBitstream::GetVLCElementS()
 {
     int32_t sval = 0;
+    int32_t remainingbits = (int32_t)((m_maxBsSize + m_tailBsSize) * 8) - (int32_t)BitsDecoded();
 
-    bool res = DecodeExpGolombOne_H265_1u32s(&m_pbs, &m_bitOffset, &sval, true);
+    bool res = DecodeExpGolombOne_H265_1u32s(&m_pbs, &m_bitOffset, &sval, remainingbits, true);
 
     if (!res)
         throw h265_exception(UMC::UMC_ERR_INVALID_STREAM);
@@ -486,6 +520,7 @@ inline uint8_t H265BaseBitstream::Get1Bit()
 {
     uint32_t w;
 
+    CheckBitsLeft(1);
     GetBits1(m_pbs, m_bitOffset, w);
     return (uint8_t)w;
 
@@ -509,6 +544,13 @@ inline size_t H265BaseBitstream::BitsDecoded() const
 inline size_t H265BaseBitstream::BytesLeft() const
 {
     return (int32_t)m_maxBsSize - (int32_t) BytesDecoded();
+}
+
+// Throw exception if left bits not enough to decode
+inline void H265BaseBitstream::CheckBitsLeft(const uint32_t nbits)
+{
+    if ((int32_t)m_maxBsSize * 8 - BitsDecoded() < nbits)
+        throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
 }
 
 // Returns number of bits needed for byte alignment
@@ -544,6 +586,11 @@ inline void H265BaseBitstream::AlignPointerRight(void)
             m_pbs++;
         } 
     }
+}
+
+inline void H265BaseBitstream::SetTailBsSize(const uint32_t nBytes)
+{
+    m_tailBsSize = nBytes;
 }
 
 } // namespace UMC_HEVC_DECODER

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_bitstream_headers.cpp
@@ -50,7 +50,8 @@ void H265BaseBitstream::Reset(uint8_t * const pb, const uint32_t maxsize)
     m_pbs       = (uint32_t*)pb;
     m_pbsBase   = (uint32_t*)pb;
     m_bitOffset = 31;
-    m_maxBsSize    = maxsize;
+    m_maxBsSize = maxsize;
+    m_tailBsSize = 0;
 
 } // void Reset(uint8_t * const pb, const uint32_t maxsize)
 
@@ -61,6 +62,7 @@ void H265BaseBitstream::Reset(uint8_t * const pb, int32_t offset, const uint32_t
     m_pbsBase   = (uint32_t*)pb;
     m_bitOffset = offset;
     m_maxBsSize = maxsize;
+    m_tailBsSize = 0;
 
 } // void Reset(uint8_t * const pb, int32_t offset, const uint32_t maxsize)
 
@@ -115,6 +117,7 @@ bool H265BaseBitstream::More_RBSP_Data()
         return false;
 
     // get top bit, it can be "rbsp stop" bit
+    CheckBitsLeft(1);
     GetNBits(m_pbs, m_bitOffset, 1, code);
 
     // get remain bits, which is less then byte
@@ -122,6 +125,7 @@ bool H265BaseBitstream::More_RBSP_Data()
 
     if(tmp)
     {
+        CheckBitsLeft(tmp);
         GetNBits(m_pbs, m_bitOffset, tmp, code);
         if ((code << (8 - tmp)) & 0x7f)    // most sig bit could be rbsp stop bit
         {

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_mfx_supplier.cpp
@@ -360,6 +360,7 @@ UMC::Status MFXTaskSupplier_H265::DecodeSEI(UMC::MediaDataEx *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem, 0);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NalUnitType nal_unit_type;
         uint32_t temporal_id;

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_sei.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_sei.cpp
@@ -39,16 +39,20 @@ int32_t H265HeadersBitstream::sei_message(const HeaderSet<H265SeqParamSet> & sps
     uint32_t code;
     int32_t payloadType = 0;
 
+    CheckBitsLeft(8);
     PeakNextBits(m_pbs, m_bitOffset, 8, code);
     while (code  ==  0xFF)
     {
         /* fixed-pattern bit string using 8 bits written equal to 0xFF */
+        CheckBitsLeft(8);
         GetNBits(m_pbs, m_bitOffset, 8, code);
         payloadType += 255;
+        CheckBitsLeft(8);
         PeakNextBits(m_pbs, m_bitOffset, 8, code);
     }
 
     int32_t last_payload_type_byte;    //uint32_t integer using 8 bits
+    CheckBitsLeft(8);
     GetNBits(m_pbs, m_bitOffset, 8, last_payload_type_byte);
 
     payloadType += last_payload_type_byte;
@@ -59,13 +63,16 @@ int32_t H265HeadersBitstream::sei_message(const HeaderSet<H265SeqParamSet> & sps
     while( code  ==  0xFF )
     {
         /* fixed-pattern bit string using 8 bits written equal to 0xFF */
+        CheckBitsLeft(8);
         GetNBits(m_pbs, m_bitOffset, 8, code);
         payloadSize += 255;
+        CheckBitsLeft(8);
         PeakNextBits(m_pbs, m_bitOffset, 8, code);
     }
 
     int32_t last_payload_size_byte;    //uint32_t integer using 8 bits
 
+    CheckBitsLeft(8);
     GetNBits(m_pbs, m_bitOffset, 8, last_payload_size_byte);
     payloadSize += last_payload_size_byte;
     spl->Reset();
@@ -92,6 +99,7 @@ int32_t H265HeadersBitstream::sei_message(const HeaderSet<H265SeqParamSet> & sps
 
     for (uint32_t i = 0; i < spl->payLoadSize; i++)
     {
+        CheckBitsLeft(8);
         SkipNBits(pbs, bitOffset, 8);
     }
 
@@ -224,7 +232,11 @@ int32_t H265HeadersBitstream::content_light_level_info(const HeaderSet<H265SeqPa
 int32_t H265HeadersBitstream::reserved_sei_message(const HeaderSet<H265SeqParamSet> & , int32_t current_sps, H265SEIPayLoad *spl)
 {
     for(uint32_t i = 0; i < spl->payLoadSize; i++)
-        SkipNBits(m_pbs, m_bitOffset, 8)
+    {
+        CheckBitsLeft(8);
+        SkipNBits(m_pbs, m_bitOffset, 8);
+    }
+
     AlignPointerRight();
     return current_sps;
 }

--- a/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h265_dec/src/umc_h265_task_supplier.cpp
@@ -1017,6 +1017,7 @@ UMC::Status TaskSupplier_H265::DecodeSEI(UMC::MediaDataEx *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem, 0);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NalUnitType nal_unit_type;
         uint32_t temporal_id;
@@ -1398,6 +1399,7 @@ UMC::Status TaskSupplier_H265::DecodeHeaders(UMC::MediaDataEx *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem, 0);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NalUnitType nal_unit_type;
         uint32_t temporal_id;


### PR DESCRIPTION
HEVC has VLC coding which cannot get bitsteram header size.
To avoid get bits operation out of bound ,need to check remaining
bits size before reading.