### PR TITLE
fix AVC bitstream buffer overflow issue

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_mfx_supplier.cpp
@@ -387,6 +387,7 @@ Status MFXTaskSupplier::DecodeSEI(NalUnit *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem, DEFAULT_NU_HEADER_TAIL_VALUE);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NAL_Unit_Type nal_unit_type = NAL_UT_UNSPECIFIED;
         uint32_t nal_ref_idc = 0;

--- a/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
+++ b/_studio/shared/umc/codec/h264_dec/src/umc_h264_task_supplier.cpp
@@ -2387,6 +2387,7 @@ Status TaskSupplier::DecodeSEI(NalUnit *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem, DEFAULT_NU_HEADER_TAIL_VALUE);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NAL_Unit_Type nal_unit_type;
         uint32_t nal_ref_idc;
@@ -2440,6 +2441,7 @@ Status TaskSupplier::DecodeHeaders(NalUnit *nalUnit)
         swapper->SwapMemory(&swappedMem, &mem);
 
         bitStream.Reset((uint8_t*)swappedMem.GetPointer(), (uint32_t)swappedMem.GetDataSize());
+        bitStream.SetTailBsSize(DEFAULT_NU_TAIL_SIZE);
 
         NAL_Unit_Type nal_unit_type;
         uint32_t nal_ref_idc;


### PR DESCRIPTION
AVC has VLC coding which cannot get bitsteram header size.
To avoid get bits operation out of bound ,need to check remaining
bits size before reading.