### PR TITLE
[samples]: Added comparison between m_output_count and MFX_INFINITE

### DIFF
--- a/samples/sample_decode/src/pipeline_decode.cpp
+++ b/samples/sample_decode/src/pipeline_decode.cpp
@@ -1766,7 +1766,7 @@ mfxStatus CDecodingPipeline::RunDecoding()
         deliverThread = std::thread (&CDecodingPipeline::DeliverLoop, this);
     }
 
-    while (((sts == MFX_ERR_NONE) || (MFX_ERR_MORE_DATA == sts) || (MFX_ERR_MORE_SURFACE == sts)) && (m_nFrames > m_output_count))
+    while (((sts == MFX_ERR_NONE) || (MFX_ERR_MORE_DATA == sts) || (MFX_ERR_MORE_SURFACE == sts)) && ((m_nFrames == MFX_INFINITE) || (m_nFrames > m_output_count)))
     {
         if (MFX_ERR_NONE != m_error) {
             msdk_printf(MSDK_STRING("DeliverOutput return error = %d\n"),m_error);


### PR DESCRIPTION
This is a simple issue caused by the number of frames exceeds 0xFFFFFFFFFFFF(over-flow mfxU32)