### PR TITLE
add missing <stdint.h> to mfxparser.cpp

### DIFF
--- a/api/mfx_dispatch/linux/mfxparser.cpp
+++ b/api/mfx_dispatch/linux/mfxparser.cpp
@@ -20,6 +20,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Without the change build fails on `gcc-13` as:

    MediaSDK/api/mfx_dispatch/linux/mfxparser.cpp: In function 'std::string MFX::printCodecId(mfxU32)':
    MediaSDK/api/mfx_dispatch/linux/mfxparser.cpp:60:3: error: 'uint8_t' was not declared in this scope
       60 |   uint8_t* data = reinterpret_cast<uint8_t*>(&id);
          |   ^~~~~~~