### PR TITLE
hevce: use Low Power mode for RGB encoding by default

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1455,7 +1455,7 @@ public:
               hw == MFX_HW_JSL) ||
 #endif
              (hw >= MFX_HW_ICL &&
-              (fcc == MFX_FOURCC_AYUV
+              (fcc == MFX_FOURCC_AYUV || fcc == MFX_FOURCC_RGB4
 #if (MFX_VERSION >= 1027)
                || fcc == MFX_FOURCC_Y410
 #endif


### PR DESCRIPTION
According to: https://github.com/intel/media-driver/blob/master/docs/media_features.md, Only VDENC supports RGB encoding, so use lowpower when input RGB data.