### PR TITLE
[Decode]Fix hevc decode issue

### DIFF
--- a/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
+++ b/_studio/shared/umc/codec/h265_dec/include/umc_h265_bitstream_headers.h
@@ -549,7 +549,12 @@ inline size_t H265BaseBitstream::BytesLeft() const
 // Throw exception if left bits not enough to decode
 inline void H265BaseBitstream::CheckBitsLeft(const uint32_t nbits)
 {
-    if ((int32_t)m_maxBsSize * 8 - BitsDecoded() < nbits)
+    if((int32_t)m_maxBsSize > 0 && (size_t)m_maxBsSize * 8 > BitsDecoded())
+    {
+        if ((size_t)m_maxBsSize * 8 - (size_t)BitsDecoded() < nbits)
+            throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
+    }
+    else
         throw h265_exception(UMC::UMC_ERR_NOT_ENOUGH_DATA);
 }
 


### PR DESCRIPTION
The “m_maxBsSize” is data of type “int”, and BitsDecoded() returns data of type “unsigned long long”, when the latter is large enough, the former minus the latter may get a positive number, although the former is smaller than the latter, which will causes no exception to be thrown(even if there is not enough data to read).